### PR TITLE
explicitly set shellcheck path

### DIFF
--- a/scripts/build.gradle
+++ b/scripts/build.gradle
@@ -2,3 +2,6 @@ plugins {
     id 'starter.std.java.shell-conventions'
 }
 
+shellcheck {
+    shellcheckBinary = '/usr/bin/shellcheck'
+}


### PR DESCRIPTION
To get past GH Actions failure. [Slack](https://dsva.slack.com/archives/C01U98SGHFS/p1652820666608419?thread_ts=1652729749.105279&cid=C01U98SGHFS)

## Attempts to resolve:
The provided [Github Action failed](https://github.com/department-of-veterans-affairs/abd-vro/runs/6473778419?check_suite_focus=true) with:  

```
* What went wrong:
Execution failed for task ':scripts:shellcheck'.
> Error while executing shellcheck: xargs: /usr/local/bin/shellcheck: No such file or directory
```

In the prior action step, it is installed at `/usr/bin/shellcheck` -- [details here](https://github.com/department-of-veterans-affairs/abd-vro/pull/8#issuecomment-1129022910)
