### PR TITLE
don't specify shellcheck path

### DIFF
--- a/scripts/build.gradle
+++ b/scripts/build.gradle
@@ -3,5 +3,6 @@ plugins {
 }
 
 shellcheck {
-    shellcheckBinary = '/usr/bin/shellcheck'
+    // don't specify the absolute path so that it can work in GH Actions and locally
+    shellcheckBinary = 'shellcheck'
 }


### PR DESCRIPTION
Followup to #9. [Slack](https://dsva.slack.com/archives/C01U98SGHFS/p1652822032301949?thread_ts=1652729749.105279&cid=C01U98SGHFS)
> make the default behavior picking up whatever shellcheck is on the system path and then documenting how to specify an exact binary if you wish for security purposes.