### PR TITLE
add Packages section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,15 @@ The overall goal for this project is to build automation to enrich Veteran claim
 
 [LHDI's Java Starter Kit](#lhdis-java-starter-kit) was used to populate this codebase (see PR #8) using Java (AdoptOpenJDK) 17 and Gradle 7.4.
 
+## Packages (in Github Container Registry)
+
+Initially, there are 2 packages (container images):
+- abd-vro/abd_vro-db-init
+- abd-vro/abd_vro-app
+
+If more are created, go to the [VA Organization's Packages page](https://github.com/orgs/department-of-veterans-affairs/packages?tab=packages&q=abd-vro), search for the package, and  manually connect them to the repo.
+[LHDI info](https://animated-carnival-57b3e7f5.pages.github.io/starterkits/java/development-guide/#changing-published-package-visibility)
+
 # LHDI's Java Starter Kit
 
 <div align="center">


### PR DESCRIPTION
[Slack](https://dsva.slack.com/archives/C01U98SGHFS/p1652824286784459?thread_ts=1652729749.105279&cid=C01U98SGHFS)
Ran into problems going through [this "Changing published package visibility" section](https://animated-carnival-57b3e7f5.pages.github.io/starterkits/java/development-guide/#changing-published-package-visibility). The GH Action [pushed the image](https://github.com/department-of-veterans-affairs/abd-vro/runs/6479140229?check_suite_focus=true) to the Container Registry, but I didn't see any packages listed.

I had to go to the VA org's Packages page: https://github.com/orgs/department-of-veterans-affairs/packages?tab=packages&q=vro, search for the packages (2 of them), and  manually connect them to the repo. Now I can see the packages in my repo.

Adding this info to the README for future reference.
