### PR TITLE
improve CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,6 +58,14 @@ jobs:
       - store_artifacts:
           path: build
       - run:
+          name: Save test results
+          command: |
+            mkdir -p ~/test-results/
+            find . -type f -regex ".*/build/test-results/.*xml" -exec cp {} ~/test-results/ \;
+          when: always
+      - store_test_results:
+          path: ~/test-results
+      - run:
           name: Run cis-benchmark tests
           command: |
             cd ..


### PR DESCRIPTION
Improve CircleCI by using [caching](https://circleci.com/docs/2.0/language-java/), parallelism example, and `store_test_results`.

Note the TODO to parallelize `./gradlew check`