### PR TITLE
deploy and access skeleton application at dev.lighthouse.va.gov/abd-vro/

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,10 +42,24 @@ Remember to specify the namespace (e.g., `--namespace va-abd-rrd-dev`) for all `
 `kubectl get pods --namespace va-abd-rrd-dev` and `helm list --namespace va-abd-rrd-dev`
 
 ## EKS/Kubernetes clusters
-From [LHDI kubernetes docs](https://animated-carnival-57b3e7f5.pages.github.io/kubernetes/), clusters:
-- ldx-nonprod-1
-- ldx-prod-1
-- ldx-preview-1
+From [LHDI kubernetes docs](https://animated-carnival-57b3e7f5.pages.github.io/kubernetes/), clusters are:
+- ldx-nonprod-1 (DEV, SANDBOX, QA)
+- ldx-prod-1 (PROD)
+- ldx-preview-1 (PREVIEW)
+
+[Associated gateways](https://animated-carnival-57b3e7f5.pages.github.io/service-mesh/routing-traffic/#environment-gateways)
+- ldx-nonprod (NONPROD)
+- ldx-nonprod-1 (NONPROD1)
+- ldx-dev (DEV)
+- ldx-prod-1 (PROD1)
+- ldx-preview-1 (PREVIEW1) (no gateway)
+- ldx-mapi-1 (MAPI-1)
+
+DNS:
+- dev.lighthouse.va.gov
+- sandbox.lighthouse.va.gov
+- qa.lighthouse.va.gov
+- (PROD) api.lighthouse.va.gov
 
 Output from `lightkeeper list team va-abd-rrd`:
 
@@ -236,7 +250,7 @@ curl localhost:8081/health
 ```
 
 ```bash
-curl localhost:8081/info
+curl localhost:8081/actuator/info
 
 {
     "app": {

--- a/helmchart/dev.yaml
+++ b/helmchart/dev.yaml
@@ -1,0 +1,9 @@
+environment: dev
+  # stage: dev
+  # name: dev
+  # host: dev.lighthouse.va.gov
+
+rbac:
+  create: true
+  serviceAccountAnnotations:
+    eks.amazonaws.com/role-arn: ""

--- a/helmchart/templates/api/virtual-service.yaml
+++ b/helmchart/templates/api/virtual-service.yaml
@@ -6,8 +6,8 @@ metadata:
   namespace: {{ .Values.namespace }}
   labels: {{- toYaml .Values.labels.api | nindent 4 }}
 spec:
-  hosts: [{{ .Values.environment }}.devportal.name]
-  gateways: [istio-system/{{ .Values.environment }}-devportal-name-gateway]
+  hosts: [{{ .Values.environment }}.lighthouse.va.gov]
+  gateways: [istio-system/ldx-nonprod-1-{{ .Values.environment }}-gateway]
   http:
   - match:
     - uri:

--- a/helmchart/values.yaml
+++ b/helmchart/values.yaml
@@ -91,7 +91,7 @@ readinessProbe:
 #   targetCPUUtilizationPercentage: 80
 
 postgres:
-  dbName: abd_vro
+  dbName: example
   secretName: postgres
   usernameKey: username
   passwordKey: password

--- a/scripts/cicd-deploy.sh
+++ b/scripts/cicd-deploy.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+ENV="$(tr '[A-Z]' '[a-z]' <<< $1)"
+
+if [ "${ENV}" != "sandbox" ] && [ "${ENV}" != "dev" ] && [ "${ENV}" != "qa" ] && [ "${ENV}" != "prod" ]
+then
+  echo "Please enter valid environment (dev, sandbox, qa, prod)" && exit 1
+fi
+
+GIT_SHA=$(git rev-parse HEAD)
+if [ -n "$2" ]
+then
+  IMAGE_TAG=$2
+  VERSION=$2
+else
+  IMAGE_TAG=$GIT_SHA
+fi
+
+: ${TEAMNAME:=va-abd-rrd}
+
+# Name must match `{{ .Values.name }}-ghcr` used in api/deployment.yaml
+kubectl create secret docker-registry abd-vro-ghcr -n ${TEAMNAME}-"${ENV}" \
+    --docker-username="${GITHUB_USERNAME}" \
+    --docker-password="${GITHUB_ACCESS_TOKEN}" \
+    --docker-server='https://ghcr.io' \
+    --dry-run=client -o yaml | kubectl apply -f -
+
+# Why is this needed?
+kubectl create secret generic github-access-token \
+              --from-literal=GITHUB_ACCESS_TOKEN="${GITHUB_ACCESS_TOKEN}" \
+              -n ${TEAMNAME}-"${ENV}" \
+              --save-config --dry-run=client -o yaml | kubectl apply -f -
+
+: ${HELM_APP_NAME:=abd-vro}
+: ${VERSION:=0.0.1}
+# --set-string overrides settings in helmchart/values.yaml
+helm upgrade --install $HELM_APP_NAME helmchart \
+              --set-string environment="${ENV}"\
+              --set-string images.app.tag="${IMAGE_TAG}"\
+              --set-string images.dbInit.tag="${IMAGE_TAG}"\
+              --set-string info.version="${VERSION}"\
+              --set-string info.git_hash="${GIT_SHA}" \
+              --set-string info.deploy_env="${ENV}" \
+              --set-string info.github_token="${GITHUB_ACCESS_TOKEN}" \
+              --debug \
+              -f helmchart/"${ENV}".yaml -n ${TEAMNAME}-"${ENV}" --wait


### PR DESCRIPTION
Skeleton-code ABD-VRO is deployed on LHDI's dev environment. It can be accessed on the VA network (GFE) at https://dev.lighthouse.va.gov/abd-vro/v1/example/claimsubmissions
or https://dev.lighthouse.va.gov/abd-vro/swagger.
For other env, see https://animated-carnival-57b3e7f5.pages.github.io/container-platform/routing-traffic/

Used https://github.com/department-of-veterans-affairs/medication-visualizer/tree/main/ci as a reference.

Documented deployment procedure in `scripts/cicd-deploy.sh`, adapted from https://github.com/department-of-veterans-affairs/medication-visualizer/blob/main/ci/scripts/deploy.sh. Some open questions:
- Who and when should this script be run? Maybe as a GH Action to deploy to dev every time a PR is merged into `main`?
- Who's `GITHUB_USERNAME` and `GITHUB_ACCESS_TOKEN` should be used?
- Should the `abd-vro-ghcr` secret need to be written every time? `kubectl create secret docker-registry abd-vro-ghcr ...`
- Why is `kubectl create secret generic github-access-token` needed?

Had to merge PR #44 to fix blocking failure.

Tips:
* used [Lens app](https://k8slens.dev/) to easily view k8s' state
* Created [our DataDog dashboard](https://app.datadoghq.com/dashboard/t76-6vq-g67) (I copied from Lasershark's dashboard).
* `helm del abd-vro -n va-abd-rrd-dev` to reset to empty cluster
