### PR TITLE
fix container labels to associate with repo

### DIFF
--- a/app/src/docker/Dockerfile
+++ b/app/src/docker/Dockerfile
@@ -7,5 +7,5 @@ RUN chmod +x entrypoint.sh
 COPY ${JAR_FILE} starter-java.jar
 EXPOSE 8081
 HEALTHCHECK CMD curl --fail http://localhost:8081/health || exit 1
-LABEL org.opencontainers.image.source=https://github.com/department-of-veterans-affairs/abd_vro
+LABEL org.opencontainers.image.source=https://github.com/department-of-veterans-affairs/abd-vro
 CMD ["sh", "entrypoint.sh"]

--- a/db-init/src/docker/Dockerfile
+++ b/db-init/src/docker/Dockerfile
@@ -2,6 +2,6 @@ FROM flyway/flyway:7.5.4
 COPY database /flyway/sql
 COPY flyway.conf /flyway/conf
 HEALTHCHECK NONE
-LABEL org.opencontainers.image.source=https://github.com/department-of-veterans-affairs/abd_vro
+LABEL org.opencontainers.image.source=https://github.com/department-of-veterans-affairs/abd-vro
 
 CMD [ "migrate", "-X" ]

--- a/service-ruby/src/docker/Dockerfile
+++ b/service-ruby/src/docker/Dockerfile
@@ -8,7 +8,7 @@ ARG RUBY_VERSION=2.7.6
 ARG DISTRO_NAME=buster
 
 FROM ruby:$RUBY_VERSION-slim-$DISTRO_NAME
-LABEL org.opencontainers.image.source=https://github.com/department-of-veterans-affairs/abd_vro
+LABEL org.opencontainers.image.source=https://github.com/department-of-veterans-affairs/abd-vro
 
 ARG DISTRO_NAME
 


### PR DESCRIPTION
This fix should avoid having to manually associate packages to this repo.

From the https://github.com/department-of-veterans-affairs/abd-vro/wiki/CircleCI wiki page:
> If more are created, go to the [VA Organization's Packages page](https://github.com/orgs/department-of-veterans-affairs/packages?tab=packages&q=abd-vro), search for the package, and  manually connect them to the repo -- see
[LHDI Development Guide](https://animated-carnival-57b3e7f5.pages.github.io/starterkits/java/development-guide/#changing-published-package-visibility).

Our packages: https://github.com/orgs/department-of-veterans-affairs/packages/container/package/abd-vro
