### PR TITLE
have Helm pull images from GHCR

### DIFF
--- a/helmchart/Chart.yaml
+++ b/helmchart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-name: starterkit-api
-description: A Helm chart for Kubernetes
+name: vro-api
+description: VRO API and backend
 
 # A chart can be either an 'application' or a 'library' chart.
 #

--- a/helmchart/templates/api/deployment.yaml
+++ b/helmchart/templates/api/deployment.yaml
@@ -96,10 +96,12 @@ spec:
             - name: STARTER_OPENAPI_SERVERURL
               value: /{{ .Values.name }}
           resources: {{- toYaml .Values.resources.api | nindent 12 }}
-        - name: {{ .Values.name }}-serviceRuby
+        - name: {{ .Values.name }}-service-ruby
           image: {{ .Values.images.registry }}/{{ .Values.images.org }}/{{ .Values.images.repo }}/{{ .Values.images.serviceRuby.imageName }}:{{ .Values.images.serviceRuby.tag }}
           imagePullPolicy: {{ .Values.images.serviceRuby.imagePullPolicy }}
           env:
+            - name: RABBITMQ_PLACEHOLDERS_HOST
+              value: {{ .Chart.Name }}-rabbitmq
             - name: RABBITMQ_PLACEHOLDERS_USERNAME
               valueFrom:
                 secretKeyRef:

--- a/helmchart/templates/db/deployment.yaml
+++ b/helmchart/templates/db/deployment.yaml
@@ -11,9 +11,11 @@ spec:
     metadata:
       labels: {{- toYaml .Values.labels.db.pod | nindent 8 }}
     spec:
+      imagePullSecrets:
+        - name: {{ .Values.name }}-ghcr
       containers:
         - name: postgres-db
-          image: {{ .Values.images.db.imageName }}:{{ .Values.images.db.tag }}
+          image: {{ .Values.images.registry }}/{{ .Values.images.org }}/{{ .Values.images.repo }}/{{ .Values.images.db.imageName }}:{{ .Values.images.db.tag }}
           env:
             - name: POSTGRES_USER
               valueFrom:

--- a/helmchart/templates/mq/deployment.yaml
+++ b/helmchart/templates/mq/deployment.yaml
@@ -11,9 +11,11 @@ spec:
     metadata:
       labels: {{- toYaml .Values.labels.mq.pod | nindent 8 }}
     spec:
+      imagePullSecrets:
+        - name: {{ .Values.name }}-ghcr
       containers:
         - name: rabbit-mq
-          image: {{ .Values.images.mq.imageName }}:{{ .Values.images.mq.tag }}
+          image: {{ .Values.images.registry }}/{{ .Values.images.org }}/{{ .Values.images.repo }}/{{ .Values.images.mq.imageName }}:{{ .Values.images.mq.tag }}
           env:
             - name: RABBITMQ_DEFAULT_USER
               valueFrom:

--- a/scripts/cicd-deploy.sh
+++ b/scripts/cicd-deploy.sh
@@ -21,7 +21,7 @@ fi
 
 : "${TEAMNAME:=va-abd-rrd}"
 
-# Name must match `{{ .Values.name }}-ghcr` used in api/deployment.yaml
+# Name must match `{{ .Values.name }}-ghcr` used for imagePullSecrets in */deployment.yaml
 kubectl create secret docker-registry abd-vro-ghcr -n ${TEAMNAME}-"${ENV}" \
     --docker-username="${GITHUB_USERNAME}" \
     --docker-password="${GITHUB_ACCESS_TOKEN}" \


### PR DESCRIPTION
Followup from #68 
Successfully deployed to dev:
```
❯ kc get pods
NAME                                READY   STATUS    RESTARTS   AGE
vro-api-75d87dbddc-wwt65            3/3     Running   0          17m
vro-api-postgres-b866c6966-vm24g    1/1     Running   0          34m
vro-api-rabbitmq-7767bd687d-l5r42   1/1     Running   0          34m
```
<img width="867" alt="image" src="https://user-images.githubusercontent.com/55255674/171486538-0ab7ffa1-eadc-4069-9c02-c59a6505c48c.png">

Next up: create API endpoint to trigger (Ruby) PDF generation and health-data assessment via RabbitMQ