### PR TITLE
Update Commit Message Requirements

### DIFF
--- a/scripts/commit-message.sh
+++ b/scripts/commit-message.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
 # regex to validate in commit msg
-commit_regex='(^\[API-[0-9]+\])'
-error_msg="Aborting commit. Your commit message is formatted incorrectly ex. [API-1234] message"
+commit_regex='(^\[MCP-[0-9]+\])'
+error_msg="Aborting commit. Your commit message is formatted incorrectly ex. [MCP-1234] message"
 
 if ! grep -iqE "$commit_regex" "$1"; then
     echo "$error_msg" >&2


### PR DESCRIPTION
Amida works with a `MCP` prefix for our JIRA tickets. Updating this to match that rather than using `API`