### PR TITLE
PDF Generator - Redis Client

### DIFF
--- a/service-python/src/config/settings.py
+++ b/service-python/src/config/settings.py
@@ -10,6 +10,12 @@ pdf_options = {
     "zoom": "1.1",
 }
 
+redis_config = {
+    "host": os.environ.get("REDIS_PLACEHOLDERS_HOST", "localhost"),
+    "port": 5672,
+    "retry_limit": 3,
+}
+
 consumer_config = {
     "host": os.environ.get("RABBITMQ_PLACEHOLDERS_HOST", "localhost"),
     "port": 5672,

--- a/service-python/src/lib/redis_client.py
+++ b/service-python/src/lib/redis_client.py
@@ -1,0 +1,30 @@
+from time import sleep
+
+import logging
+import redis
+
+logging.basicConfig(level=logging.INFO)
+
+class RedisClient:
+
+	def __init__(self, config):
+		self.config = config
+		self.client = self._create_client()
+
+
+	def _create_client(self):
+		for i in range(self.config["retry_limit"]):
+			try:
+				client = redis.Redis(host=self.config["host"], port = self.config["port"])
+				return client
+			except:
+				logging.warn(f"Redis Connection Failed. Retrying in 15s")
+				sleep(15)
+
+	
+	def save_data(self, key, value):
+		self.client.set(key, value)
+
+
+	def get_data(self, key):
+		return self.client.get(key)

--- a/service-python/src/requirements.txt
+++ b/service-python/src/requirements.txt
@@ -11,6 +11,7 @@ pika==1.2.1
 pdfkit==1.0.0
 pytest==7.1.2
 python-dateutil==2.8.2
+redis==4.3.4
 requests==2.27.1
 Werkzeug==2.1.1
 zipp==3.8.0


### PR DESCRIPTION
#PDF Generator - Redis Client <!-- replace this with the feature/bug name -->

## Description

<!-- you don't need to write anything here -->

### What was the problem?

We can no longer use S3 for PDF upload due to PII

### How does this fix it?

Redis will store the PDFs based on a `key`. The `key` will be the `claimSubmissionId` while the value will be the base64 encoded PDF

## How to test this PR

- Step 1
- Step 2 
