### PR TITLE
Undo Helmchart Service Delete

### DIFF
--- a/helmchart/templates/api/deployment.yaml
+++ b/helmchart/templates/api/deployment.yaml
@@ -96,6 +96,9 @@ spec:
             - name: STARTER_OPENAPI_SERVERURL
               value: /{{ .Values.name }}
           resources: {{- toYaml .Values.resources.api | nindent 12 }}
+        - name: {{ .Values.name }}-service-assess-claim-dc7101
+          image: {{ .Values.images.registry }}/{{ .Values.images.org }}/{{ .Values.images.repo }}/{{ .Values.images.serviceAssessClaimDC7101.imageName }}:{{ .Values.images.serviceAssessClaimDC7101.tag }}
+          imagePullPolicy: {{ .Values.images.serviceAssessClaimDC7101.imagePullPolicy }}
         - name: {{ .Values.name }}-service-python
           image: {{ .Values.images.registry }}/{{ .Values.images.org }}/{{ .Values.images.repo }}/{{ .Values.images.servicePython.imageName }}:{{ .Values.images.servicePython.tag }}
           imagePullPolicy: {{ .Values.images.servicePython.imagePullPolicy }}


### PR DESCRIPTION
#Undo Helmchart Service Delete <!-- replace this with the feature/bug name -->

## Description

<!-- you don't need to write anything here -->

### What was the problem?

Accidentally deleted the `service-assess-claim` from Helmchart in #133 

### How does this fix it?

Adding it back