### PR TITLE
Remove starter endpoint from Swagger documentation

### DIFF
--- a/app/src/main/resources/application.yml
+++ b/app/src/main/resources/application.yml
@@ -138,8 +138,11 @@ opentracing:
 springdoc:
   writer-with-default-pretty-printer: true
   show-actuator: true
+  packages-to-exclude: gov.va.starter
+
   swagger-ui:
     operations-sorter: method
+    tagsSorter: alpha
     path: swagger
 
 starter:

--- a/app/src/test/resources/application.yml
+++ b/app/src/test/resources/application.yml
@@ -136,8 +136,12 @@ opentracing:
 springdoc:
   writer-with-default-pretty-printer: true
   show-actuator: true
+  packages-to-exclude: gov.va.starter
+
   swagger-ui:
     operations-sorter: method
+    tagsSorter: alpha
+    path: swagger
 
 starter:
   openapi:


### PR DESCRIPTION
# Remove  starter end point from Swagger documentation

## Description

<!-- you don't need to write anything here -->

### What was the problem?

Swagger UI showed starter end points that came with the starter project. That does not look good for a demo.

Actual code is left for now since we are missing tests for api and controller directories and existing starter tests might help.

### How does this fix it?

The starter end point will not show in the swagger ui.

### Jira Tickets

- [MCP-1596](https://amida.atlassian.net/browse/MCP-1596)

## How to test this PR

- Open http://localhost:8080/swagger-ui/index.html?configUrl=/v3/api-docs/swagger-config#
- Check starter end points are not shown. Only VRO end points should be there

## Reminders

- Review [Pull-Requests](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests) guidelines
- [ ] If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) and
[Roadmap](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Roadmap) wiki pages
- [ ] If changing software behavior, post a link to the PR in Slack channel #benefits-virtual-regional-office
