### PR TITLE
Filter out "null" in dosageInstruction as well as other fields

### DIFF
--- a/service-data-access/src/main/java/gov/va/vro/abd_data_access/service/FieldExtractor.java
+++ b/service-data-access/src/main/java/gov/va/vro/abd_data_access/service/FieldExtractor.java
@@ -104,11 +104,11 @@ public class FieldExtractor {
     }
     if (medication.hasNote()) {
       result.setNotes(medication.getNote().stream()
-          .map(n -> n.getText()).collect(Collectors.toList()));
+          .filter(n -> n.hasText()).map(n -> n.getText()).collect(Collectors.toList()));
     }
     if (medication.hasDosageInstruction()) {
       List<String> dosages = medication.getDosageInstruction()
-          .parallelStream().map(d -> d.getText()).collect(Collectors.toList());
+          .parallelStream().filter(d -> d.hasText()).map(d -> d.getText()).collect(Collectors.toList());
       List<String> codeText = medication.getDosageInstruction()
           .stream().filter(d -> d.hasTiming()).filter(t -> t.getTiming().hasCode())
           .filter(c -> c.getTiming().getCode().hasText()).map(c -> c.getTiming().getCode().getText())
@@ -121,10 +121,14 @@ public class FieldExtractor {
       result.setRoute(routes);
     }
     if (medication.hasDispenseRequest()) {
-      result.setDuration(medication.getDispenseRequest()
-          .getExpectedSupplyDuration().getDisplay());
-      result.setRefills(medication.getDispenseRequest()
-          .getNumberOfRepeatsAllowed());
+      if (medication.getDispenseRequest().hasExpectedSupplyDuration()) {
+        result.setDuration(medication.getDispenseRequest()
+                .getExpectedSupplyDuration().getDisplay());
+      }
+      if (medication.getDispenseRequest().hasNumberOfRepeatsAllowed()) {
+        result.setRefills(medication.getDispenseRequest()
+                .getNumberOfRepeatsAllowed());
+      }
     }
 
     return result;
@@ -176,12 +180,14 @@ public class FieldExtractor {
     result.setCode(coding.getCode());
     result.setDisplay(coding.getDisplay());
 
-    Quantity quantity = component.getValueQuantity();
+    if (component.hasValueQuantity()) {
+      Quantity quantity = component.getValueQuantity();
 
-    result.setUnit(quantity.getUnit());
+      result.setUnit(quantity.getUnit());
 
-    BigDecimal value = quantity.getValue().setScale(1, RoundingMode.HALF_UP);
-    result.setValue(value);
+      BigDecimal value = quantity.getValue().setScale(1, RoundingMode.HALF_UP);
+      result.setValue(value);
+    }
 
     return result;
   }


### PR DESCRIPTION
MCP-1769 Removing null in dosageInstruction of returned medication request data.

## Description

The current dosageInstruction field in the returned medication request data model is based on what Ruby code does to support existing front end application to call the endpoint in abd-vro. 

The Ruby code returns an array that contains the values of a few fields in dosageInstruction FHIR object. Since some fields are optional by FHIR and will return null values, it will make the endpoint returned data object for dosageInstruction array contains "null". See MCP-1769.

This fix will avoid to put null into the dosageInstruction array.

### What was the problem?

null in dosageIntrction array. See MCP-1769.

### How does this fix it?

Filter out null value.

### Jira Tickets

MCP-1769

- [MCP-000](https://amida.atlassian.net/browse/MCP-000)

## How to test this PR

- Step 1. Build and launch the abd-vro.
- Step 2. Bring up swagger ui, and try POST /v1/health-data-assessment.
- Step 3. Check the returned data. In medication section, check dosageInstructions. No "null" should be seen in them.

## Reminders

- Review [Pull-Requests](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests) guidelines
- [ ] If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) and
[Roadmap](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Roadmap) wiki pages
- [ ] If changing software behavior, post a link to the PR in Slack channel #benefits-virtual-regional-office
