### PR TITLE
PDF Generator Template Fixes

### DIFF
--- a/api/src/main/java/gov/va/vro/api/model/AbdMedication.java
+++ b/api/src/main/java/gov/va/vro/api/model/AbdMedication.java
@@ -17,6 +17,7 @@ public class AbdMedication implements Comparable<AbdMedication> {
   private List<String> notes;
   private String description;
   private int refills;
+  private Boolean asthma_relevant;
   private String duration;
   private String authoredOn;
   private List<String> dosageInstructions;

--- a/service-data-access/src/main/java/gov/va/vro/abd_data_access/model/AbdMedication.java
+++ b/service-data-access/src/main/java/gov/va/vro/abd_data_access/model/AbdMedication.java
@@ -16,6 +16,7 @@ public class AbdMedication implements Comparable<AbdMedication> {
   private List<String> notes;
   private String description;
   private int refills;
+  private Boolean asthma_relevant;
   private String duration;
   private String authoredOn;
   private List<String> dosageInstructions;

--- a/service-python/pdfgenerator/src/lib/queues.py
+++ b/service-python/pdfgenerator/src/lib/queues.py
@@ -31,10 +31,10 @@ def on_generate_callback(channel, method, properties, body):
 			pdf = pdf_generator.generate_pdf_from_string(template)
 			redis_client.save_data(claim_id, base64.b64encode(pdf).decode("ascii"))
 			logging.info("Saved PDF")
-			response = {"claimSubmissionId": claim_id, "status": "IN_PROGRESS", "pdf": None}
+			response = {"claimSubmissionId": claim_id, "status": "IN_PROGRESS"}
 	except Exception as e:
 			logging.error(e, exc_info=True)
-			response = {"claimSubmissionId": claim_id, "status": "ERROR", "pdf": None}
+			response = {"claimSubmissionId": claim_id, "status": "ERROR"}
 	channel.basic_publish(exchange=EXCHANGE, routing_key=properties.reply_to, properties=pika.BasicProperties(correlation_id=properties.correlation_id), body=json.dumps(response))
 
 

--- a/service-python/pdfgenerator/src/lib/queues.py
+++ b/service-python/pdfgenerator/src/lib/queues.py
@@ -32,7 +32,8 @@ def on_generate_callback(channel, method, properties, body):
 			redis_client.save_data(claim_id, base64.b64encode(pdf).decode("ascii"))
 			logging.info("Saved PDF")
 			response = {"claimSubmissionId": claim_id, "status": "IN_PROGRESS", "pdf": None}
-	except:
+	except Exception as e:
+			logging.error(e, exc_info=True)
 			response = {"claimSubmissionId": claim_id, "status": "ERROR", "pdf": None}
 	channel.basic_publish(exchange=EXCHANGE, routing_key=properties.reply_to, properties=pika.BasicProperties(correlation_id=properties.correlation_id), body=json.dumps(response))
 

--- a/service-python/pdfgenerator/src/lib/templates/hypertension/blood_pressure_readings.html
+++ b/service-python/pdfgenerator/src/lib/templates/hypertension/blood_pressure_readings.html
@@ -1,5 +1,5 @@
 <p>
-  {% if evidence.bp_readings|length > 0 %}
+  {% if evidence.bp_readings and evidence.bp_readings|length > 0 %}
     <h3>One Year of Blood Pressure History</h3>
   {% else %}
     <h3>No blood pressure records found</h3>
@@ -9,14 +9,16 @@
 <i>VHA records searched from {{start_date.strftime('%m/%d/%Y')}} to {{timestamp.strftime('%m/%d/%Y')}}</i> <br/>
 <i>All VAMC locations using VistA/CAPRI were checked</i>
 
-{% if evidence.bp_readings|length > 0 %}
+{% if evidence.bp_readings and evidence.bp_readings|length > 0 %}
   <p>Blood pressure is shown as systolic/diastolic.</p>
 {% endif %}
 
-{% for measurement in evidence.bp_readings %}
-  <p>
-    <b>Blood pressure: {{measurement.systolic.value|round}}/{{measurement.diastolic.value|round}} </b> <br />
-    Taken on: {{measurement.date}} <br />
-    Location: {{measurement.organization or "Unknown"}}
-  </p>
-{% endfor %}
+{% if evidence.bp_readings %}
+  {% for measurement in evidence.bp_readings %}
+    <p>
+      <b>Blood pressure: {{measurement.systolic.value|round}}/{{measurement.diastolic.value|round}} </b> <br />
+      Taken on: {{measurement.date}} <br />
+      Location: {{measurement.organization or "Unknown"}}
+    </p>
+  {% endfor %}
+{% endif %}

--- a/service-python/pdfgenerator/src/lib/templates/shared/medications.html
+++ b/service-python/pdfgenerator/src/lib/templates/shared/medications.html
@@ -20,7 +20,7 @@
   {% for medicine in evidence.medications %}
     <br />
     <p>
-      {% if medicine.flagged %}
+      {% if medicine.asthma_relevant %}
         <span class="dejavu">&#9654;</span>
         <b>{{medicine.description}}</b>
         <span class="dejavu">&#9664;</span>

--- a/service/spi/src/main/java/gov/va/vro/service/spi/model/AbdMedication.java
+++ b/service/spi/src/main/java/gov/va/vro/service/spi/model/AbdMedication.java
@@ -13,6 +13,7 @@ public class AbdMedication implements Comparable<AbdMedication> {
   private List<String> notes;
   private String description;
   private int refills;
+  private Boolean asthma_relevant;
   private String duration;
   private String authoredOn;
   private List<String> dosageInstructions;


### PR DESCRIPTION
# PDF Generator Template Fixes <!-- replace this with the feature/bug name -->

## Description

<!-- you don't need to write anything here -->

### What was the problem?

<!-- brief description of how things worked before this PR -->

- `bp_readings` was being passed as `None`
- `pdf` field is not needed in Generate response
- Asthma arrows needs to be added using `asthma_relevant` field in `medications`

## How to test this PR

- Send a request with `bp_readings` set to `None`
