### PR TITLE
Add medication flag

### DIFF
--- a/api/src/main/java/gov/va/vro/api/model/AbdMedication.java
+++ b/api/src/main/java/gov/va/vro/api/model/AbdMedication.java
@@ -21,6 +21,7 @@ public class AbdMedication implements Comparable<AbdMedication> {
   private String authoredOn;
   private List<String> dosageInstructions;
   private String route;
+  private int asthma_relevant;
 
   @Override
   public int compareTo(AbdMedication otherMedication) {

--- a/api/src/main/java/gov/va/vro/api/model/AbdMedication.java
+++ b/api/src/main/java/gov/va/vro/api/model/AbdMedication.java
@@ -21,7 +21,7 @@ public class AbdMedication implements Comparable<AbdMedication> {
   private String authoredOn;
   private List<String> dosageInstructions;
   private String route;
-  private int asthma_relevant;
+  private String asthma_relevant;
 
   @Override
   public int compareTo(AbdMedication otherMedication) {

--- a/service-data-access/src/main/java/gov/va/vro/abd_data_access/model/AbdMedication.java
+++ b/service-data-access/src/main/java/gov/va/vro/abd_data_access/model/AbdMedication.java
@@ -20,7 +20,7 @@ public class AbdMedication implements Comparable<AbdMedication> {
   private String authoredOn;
   private List<String> dosageInstructions;
   private String route;
-  private int asthma_relevant;
+  private String asthma_relevant;
 
   @Override
   public int compareTo(AbdMedication otherMedication) {

--- a/service-data-access/src/main/java/gov/va/vro/abd_data_access/model/AbdMedication.java
+++ b/service-data-access/src/main/java/gov/va/vro/abd_data_access/model/AbdMedication.java
@@ -20,6 +20,7 @@ public class AbdMedication implements Comparable<AbdMedication> {
   private String authoredOn;
   private List<String> dosageInstructions;
   private String route;
+  private int asthma_relevant;
 
   @Override
   public int compareTo(AbdMedication otherMedication) {

--- a/service-python/assessclaimdc6602/src/lib/medication.py
+++ b/service-python/assessclaimdc6602/src/lib/medication.py
@@ -46,11 +46,11 @@ def medication_required(request_body):
       medication_display = medication["description"]
       for keyword in [x.lower() for x in asthma_medications]:
         if (keyword in medication_display.lower()):
-          medication["flagged"] = 1
+          medication["asthma_relevant"] = 1
           relevant_medications.append(medication)
           flagged = True
       if flagged == False:
-        medication["flagged"] = 0
+        medication["asthma_relevant"] = 0
         other_medications.append(medication)
   
   relevant_medications = sorted(relevant_medications, key=lambda i: datetime.strptime(i["authoredOn"], "%Y-%m-%dT%H:%M:%SZ").date(), reverse=True)

--- a/service-python/assessclaimdc6602/src/lib/medication.py
+++ b/service-python/assessclaimdc6602/src/lib/medication.py
@@ -46,11 +46,11 @@ def medication_required(request_body):
       medication_display = medication["description"]
       for keyword in [x.lower() for x in asthma_medications]:
         if (keyword in medication_display.lower()):
-          medication["asthma_relevant"] = 1
+          medication["asthma_relevant"] = "True"
           relevant_medications.append(medication)
           flagged = True
       if flagged == False:
-        medication["asthma_relevant"] = 0
+        medication["asthma_relevant"] = "False"
         other_medications.append(medication)
   
   relevant_medications = sorted(relevant_medications, key=lambda i: datetime.strptime(i["authoredOn"], "%Y-%m-%dT%H:%M:%SZ").date(), reverse=True)

--- a/service-python/assessclaimdc6602/src/lib/queues.py
+++ b/service-python/assessclaimdc6602/src/lib/queues.py
@@ -4,7 +4,6 @@ from . import main
 import pika
 import json
 import logging
-import base64
 
 EXCHANGE = queue_config["exchange_name"]
 SERVICE_QUEUE = queue_config["service_queue_name"]
@@ -24,6 +23,7 @@ def on_request_callback(channel, method, properties, body):
 
 	channel.basic_publish(exchange=EXCHANGE, routing_key=properties.reply_to, properties=pika.BasicProperties(correlation_id=properties.correlation_id), body=json.dumps(response))
 	logging.info(f" [x] {binding_key}: Message sent to: {properties.reply_to}")
+	logging.info(f"Message data: {response}")
 
 def queue_setup(channel):
 

--- a/service-python/pdfgenerator/src/lib/templates/shared/medications.html
+++ b/service-python/pdfgenerator/src/lib/templates/shared/medications.html
@@ -20,7 +20,7 @@
   {% for medicine in evidence.medications %}
     <br />
     <p>
-      {% if medicine.flagged %}
+      {% if medicine.asthma_relevant == "True" %}
         <span class="dejavu">&#9654;</span>
         <b>{{medicine.description}}</b>
         <span class="dejavu">&#9664;</span>

--- a/service-python/tests/assessclaim/dc6602/test_continuous_medication.py
+++ b/service-python/tests/assessclaim/dc6602/test_continuous_medication.py
@@ -19,7 +19,7 @@ from assessclaimdc6602.src.lib import medication
                 {
                     "description": "Albuterol",
                     "status": "active",
-                    'asthma_relevant': 1,
+                    'asthma_relevant': "True",
                     "authoredOn": "1950-04-06T04:00:00Z"
                 }
             ]
@@ -38,7 +38,7 @@ from assessclaimdc6602.src.lib import medication
                 {
                     "description": "Albuterol",
                     "status": "active",
-                    'asthma_relevant': 1,
+                    'asthma_relevant': "True",
                     "authoredOn": "1950-04-06T04:00:00Z"
                 }
             ]
@@ -55,7 +55,7 @@ from assessclaimdc6602.src.lib import medication
             },
             [{"description": "Advil",
                     "status": "active",
-                    'asthma_relevant': 0,
+                    'asthma_relevant': "False",
                     "authoredOn": "1950-04-06T04:00:00Z"}],
         ),
         # multiple medications, some to treat and others not to treat asthma
@@ -74,13 +74,13 @@ from assessclaimdc6602.src.lib import medication
                 {
                     "description": "Albuterol",
                     "status": "active",
-                    'asthma_relevant': 1,
+                    'asthma_relevant': "True",
                     "authoredOn": "1950-04-06T04:00:00Z"
                 },
                 {
                     "description": "Advil",
                     "status": "active",
-                    'asthma_relevant': 0,
+                    'asthma_relevant': "False",
                     "authoredOn": "1952-04-06T04:00:00Z"
                 }
             ]

--- a/service-python/tests/assessclaim/dc6602/test_continuous_medication.py
+++ b/service-python/tests/assessclaim/dc6602/test_continuous_medication.py
@@ -19,7 +19,7 @@ from assessclaimdc6602.src.lib import medication
                 {
                     "description": "Albuterol",
                     "status": "active",
-                    'flagged': 1,
+                    'asthma_relevant': 1,
                     "authoredOn": "1950-04-06T04:00:00Z"
                 }
             ]
@@ -38,7 +38,7 @@ from assessclaimdc6602.src.lib import medication
                 {
                     "description": "Albuterol",
                     "status": "active",
-                    'flagged': 1,
+                    'asthma_relevant': 1,
                     "authoredOn": "1950-04-06T04:00:00Z"
                 }
             ]
@@ -55,7 +55,7 @@ from assessclaimdc6602.src.lib import medication
             },
             [{"description": "Advil",
                     "status": "active",
-                    'flagged': 0,
+                    'asthma_relevant': 0,
                     "authoredOn": "1950-04-06T04:00:00Z"}],
         ),
         # multiple medications, some to treat and others not to treat asthma
@@ -64,10 +64,8 @@ from assessclaimdc6602.src.lib import medication
                 {
                     "medications": [{"description": "Albuterol",
                     "status": "active",
-                    'flagged': 1,
                     "authoredOn": "1950-04-06T04:00:00Z"}, {"description": "Advil",
                     "status": "active",
-                    'flagged': 0,
                     "authoredOn": "1952-04-06T04:00:00Z"}],
                     'date_of_claim': '2021-11-09',
                 }
@@ -76,13 +74,13 @@ from assessclaimdc6602.src.lib import medication
                 {
                     "description": "Albuterol",
                     "status": "active",
-                    'flagged': 1,
+                    'asthma_relevant': 1,
                     "authoredOn": "1950-04-06T04:00:00Z"
                 },
                 {
                     "description": "Advil",
                     "status": "active",
-                    'flagged': 0,
+                    'asthma_relevant': 0,
                     "authoredOn": "1952-04-06T04:00:00Z"
                 }
             ]

--- a/service-python/tests/assessclaim/dc6602/test_main.py
+++ b/service-python/tests/assessclaim/dc6602/test_main.py
@@ -17,7 +17,7 @@ from assessclaimdc6602.src.lib import main
             },
             {"evidence": {"medications": [{"description": "Prednisone",
             "status": "active",
-            'asthma_relevant': 1,
+            'asthma_relevant': "True",
                     "authoredOn": "1952-04-06T04:00:00Z"}]}}
         ),
 
@@ -34,7 +34,7 @@ from assessclaimdc6602.src.lib import main
             {"evidence": {
                 "medications": [{"description": "predniSONE 1 MG Oral Tablet",
                 "status": "active",
-                'asthma_relevant': 1,
+                'asthma_relevant': "True",
                     "authoredOn": "1952-04-06T04:00:00Z"}]
                 }}
         ),
@@ -50,7 +50,7 @@ from assessclaimdc6602.src.lib import main
             },
             {"evidence": {"medications": [{"description" : "Advil",
                     "status": "active",
-                    'asthma_relevant': 0,
+                    'asthma_relevant': "False",
                     "authoredOn": "1952-04-06T04:00:00Z"}]}}
         ),
     ],

--- a/service-python/tests/assessclaim/dc6602/test_main.py
+++ b/service-python/tests/assessclaim/dc6602/test_main.py
@@ -17,7 +17,7 @@ from assessclaimdc6602.src.lib import main
             },
             {"evidence": {"medications": [{"description": "Prednisone",
             "status": "active",
-            'flagged': 1,
+            'asthma_relevant': 1,
                     "authoredOn": "1952-04-06T04:00:00Z"}]}}
         ),
 
@@ -34,7 +34,7 @@ from assessclaimdc6602.src.lib import main
             {"evidence": {
                 "medications": [{"description": "predniSONE 1 MG Oral Tablet",
                 "status": "active",
-                'flagged': 1,
+                'asthma_relevant': 1,
                     "authoredOn": "1952-04-06T04:00:00Z"}]
                 }}
         ),
@@ -50,7 +50,7 @@ from assessclaimdc6602.src.lib import main
             },
             {"evidence": {"medications": [{"description" : "Advil",
                     "status": "active",
-                    'flagged': 0,
+                    'asthma_relevant': 0,
                     "authoredOn": "1952-04-06T04:00:00Z"}]}}
         ),
     ],

--- a/service/spi/src/main/java/gov/va/vro/service/spi/model/AbdMedication.java
+++ b/service/spi/src/main/java/gov/va/vro/service/spi/model/AbdMedication.java
@@ -1,5 +1,6 @@
 package gov.va.vro.service.spi.model;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Getter;
 import lombok.Setter;
 import org.apache.commons.lang3.StringUtils;
@@ -8,6 +9,7 @@ import java.util.List;
 
 @Getter
 @Setter
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class AbdMedication implements Comparable<AbdMedication> {
   private String status;
   private List<String> notes;
@@ -17,6 +19,7 @@ public class AbdMedication implements Comparable<AbdMedication> {
   private String authoredOn;
   private List<String> dosageInstructions;
   private String route;
+  private int asthma_relevant;
 
   @Override
   public int compareTo(AbdMedication otherMedication) {

--- a/service/spi/src/main/java/gov/va/vro/service/spi/model/AbdMedication.java
+++ b/service/spi/src/main/java/gov/va/vro/service/spi/model/AbdMedication.java
@@ -19,7 +19,7 @@ public class AbdMedication implements Comparable<AbdMedication> {
   private String authoredOn;
   private List<String> dosageInstructions;
   private String route;
-  private int asthma_relevant;
+  private String asthma_relevant;
 
   @Override
   public int compareTo(AbdMedication otherMedication) {


### PR DESCRIPTION
# Enable PDF medication <!-- replace this with the feature/bug name -->

## Description

<!-- you don't need to write anything here -->

### What was the problem?
There was no field to indicate medication used to treat Asthma
<!-- brief description of how things worked before this PR -->

### How does this fix it?
Adds a field to the medication object returned by the full-process endpoint
<!-- brief description of how things will work after this PR -->

### Jira Tickets

<!-- replace "000" with ticket number in both places -->

- [MCP-1806](https://amida.atlassian.net/browse/MCP-1806)

## How to test this PR

- Step 1
- Try full process endpoint, with ICN 38, Diagnostic Code 6602 
- Step 2 
- Feed the returned data into the pdf generator endpoint
## Reminders

- Review [Pull-Requests](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests) guidelines
- [ ] If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) and
[Roadmap](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Roadmap) wiki pages
- [ ] If changing software behavior, post a link to the PR in Slack channel #benefits-virtual-regional-office
