### PR TITLE
Reduce triggers of mirroring GH action

### DIFF
--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -1,10 +1,10 @@
 name: Mirroring
 
 on:
-  # Trigger on all pull requests
   pull_request:
-    branches:
-      - "*"
+    branches: [ main, develop ]
+    # Limit to certain PR event types since this action triggers checks to run on the mirror
+    types: [ready_for_review, review_requested]
 
   # When changes are pushed to special branches
   push:
@@ -12,6 +12,9 @@ on:
 
   # When a Git reference (Git branch or tag) is deleted
   delete:
+
+  # Allow manual triggering
+  workflow_dispatch:
 
 # Ensures that only one mirror task will run at a time.
 concurrency:


### PR DESCRIPTION
# Feature Name <!-- replace this with the feature/bug name -->

## Description

<!-- you don't need to write anything here -->

https://github.com/department-of-veterans-affairs/abd-vro/wiki/Github-Actions#mirror

### What was the problem?

<!-- brief description of how things worked before this PR -->
Mirroring to the internal repo triggers CircleCI and other checks to run on the internal repo. This isn't necessary for every PR change.

### How does this fix it?

<!-- brief description of how things will work after this PR -->
Limit to certain PR event types (e.g., `ready_for_review`, `review_requested`) and for pushes to special branches `main` and `develop`.

### Tested

When this PR is created or marked as a draft, only the mirror action does not run. When the PR is marked "ready for review", the mirror action runs.
