### PR TITLE
Add controller test for Full-Health-Assessment endpoint

### DIFF
--- a/app/src/test/java/gov/va/vro/VroControllerTest.java
+++ b/app/src/test/java/gov/va/vro/VroControllerTest.java
@@ -136,36 +136,35 @@ class VroControllerTest extends BaseIntegrationTest {
     assertEquals("1234", claimProcessingError.getClaimSubmissionId());
   }
 
-
   @Test
   @DirtiesContext
   void postFullHealthAssessment() throws Exception {
 
     // intercept the original endpoint, skip it and replace it with the mock endpoint
     adviceWith(
-            camelContext,
-            "claim-submit",
-            route ->
-                    route
-                            .interceptSendToEndpoint(
-                                    "rabbitmq:claim-submit-exchange"
-                                            + "?queue=claim-submit"
-                                            + "&routingKey=code.7101&requestTimeout=60000")
-                            .skipSendToOriginalEndpoint()
-                            .to("mock:claim-submit"));
+        camelContext,
+        "claim-submit",
+        route ->
+            route
+                .interceptSendToEndpoint(
+                    "rabbitmq:claim-submit-exchange"
+                        + "?queue=claim-submit"
+                        + "&routingKey=code.7101&requestTimeout=60000")
+                .skipSendToOriginalEndpoint()
+                .to("mock:claim-submit"));
     // Mock secondary process endpoint
     adviceWith(
-            camelContext,
-            "claim-submit-full",
-            route ->
-                    route
-                            .interceptSendToEndpoint(
-                                    "rabbitmq:health-assess-exchange?routingKey=7101&requestTimeout=60000")
-                            .skipSendToOriginalEndpoint()
-                            .to("mock:claim-submit-full"));
+        camelContext,
+        "claim-submit-full",
+        route ->
+            route
+                .interceptSendToEndpoint(
+                    "rabbitmq:health-assess-exchange?routingKey=7101&requestTimeout=60000")
+                .skipSendToOriginalEndpoint()
+                .to("mock:claim-submit-full"));
     // The mock endpoint returns a valid response
     mockFullHealthEndpoint.whenAnyExchangeReceived(
-            FunctionProcessor.<Claim, String>fromFunction(claim -> claimToResponse(claim, true)));
+        FunctionProcessor.<Claim, String>fromFunction(claim -> claimToResponse(claim, true)));
 
     HealthDataAssessmentRequest request = new HealthDataAssessmentRequest();
     request.setClaimSubmissionId("1234");
@@ -173,7 +172,7 @@ class VroControllerTest extends BaseIntegrationTest {
     request.setDiagnosticCode("7101");
 
     var responseEntity1 =
-            post("/v1/full-health-data-assessment", request, FullHealthDataAssessmentResponse.class);
+        post("/v1/full-health-data-assessment", request, FullHealthDataAssessmentResponse.class);
 
     assertEquals(HttpStatus.CREATED, responseEntity1.getStatusCode());
     FullHealthDataAssessmentResponse response1 = responseEntity1.getBody();
@@ -182,14 +181,14 @@ class VroControllerTest extends BaseIntegrationTest {
 
     // Now submit an existing claim:
     var responseEntity2 =
-            post("/v1/full-health-data-assessment", request, HealthDataAssessmentResponse.class);
+        post("/v1/full-health-data-assessment", request, HealthDataAssessmentResponse.class);
     assertEquals(HttpStatus.CREATED, responseEntity2.getStatusCode());
     HealthDataAssessmentResponse response2 = responseEntity2.getBody();
     assertEquals(request.getDiagnosticCode(), response2.getDiagnosticCode());
     assertEquals(request.getVeteranIcn(), response2.getVeteranIcn());
 
     Optional<ClaimEntity> claimEntityOptional =
-            claimRepository.findByClaimSubmissionIdAndIdType("1234", "va.gov-Form526Submission");
+        claimRepository.findByClaimSubmissionIdAndIdType("1234", "va.gov-Form526Submission");
     assertTrue(claimEntityOptional.isPresent());
   }
 
@@ -197,36 +196,37 @@ class VroControllerTest extends BaseIntegrationTest {
   @DirtiesContext
   void fullClaimSubmit_missing_evidence() throws Exception {
     adviceWith(
-            camelContext,
-            "claim-submit",
-            route ->
-                    route
-                            .interceptSendToEndpoint(
-                                    "rabbitmq:claim-submit-exchange"
-                                            + "?queue=claim-submit"
-                                            + "&routingKey=code.7101&requestTimeout=60000")
-                            .skipSendToOriginalEndpoint()
-                            .to("mock:claim-submit"));
+        camelContext,
+        "claim-submit",
+        route ->
+            route
+                .interceptSendToEndpoint(
+                    "rabbitmq:claim-submit-exchange"
+                        + "?queue=claim-submit"
+                        + "&routingKey=code.7101&requestTimeout=60000")
+                .skipSendToOriginalEndpoint()
+                .to("mock:claim-submit"));
     // Mock secondary process endpoint
     adviceWith(
-            camelContext,
-            "claim-submit-full",
-            route ->
-                    route
-                            .interceptSendToEndpoint(
-                                    "rabbitmq:health-assess-exchange?routingKey=7101&requestTimeout=60000")
-                            .skipSendToOriginalEndpoint()
-                            .to("mock:claim-submit-full"));
+        camelContext,
+        "claim-submit-full",
+        route ->
+            route
+                .interceptSendToEndpoint(
+                    "rabbitmq:health-assess-exchange?routingKey=7101&requestTimeout=60000")
+                .skipSendToOriginalEndpoint()
+                .to("mock:claim-submit-full"));
 
     mockFullHealthEndpoint.whenAnyExchangeReceived(
-            FunctionProcessor.<Claim, String>fromFunction(claim -> claimToResponse(claim, false)));
+        FunctionProcessor.<Claim, String>fromFunction(claim -> claimToResponse(claim, false)));
 
     HealthDataAssessmentRequest request = new HealthDataAssessmentRequest();
     request.setClaimSubmissionId("1234");
     request.setVeteranIcn("icn");
     request.setDiagnosticCode("7101");
 
-    var responseEntity = post("/v1/full-health-data-assessment", request, ClaimProcessingError.class);
+    var responseEntity =
+        post("/v1/full-health-data-assessment", request, ClaimProcessingError.class);
     assertEquals(HttpStatus.NOT_FOUND, responseEntity.getStatusCode());
     var claimProcessingError = responseEntity.getBody();
     assertEquals("No evidence found.", claimProcessingError.getMessage());

--- a/app/src/test/java/gov/va/vro/VroControllerTest.java
+++ b/app/src/test/java/gov/va/vro/VroControllerTest.java
@@ -108,53 +108,6 @@ class VroControllerTest extends BaseIntegrationTest {
 
   @Test
   @DirtiesContext
-  void postFullHealthAssessment() throws Exception {
-
-    // intercept the original endpoint, skip it and replace it with the mock endpoint
-    adviceWith(
-            camelContext,
-            "claim-submit",
-            route ->
-                    route
-                            .interceptSendToEndpoint(
-                                    "rabbitmq:claim-submit-exchange"
-                                            + "?queue=claim-submit"
-                                            + "&routingKey=code.1701&requestTimeout=60000")
-                            .skipSendToOriginalEndpoint()
-                            .to("mock:claim-submit"));
-    // Mock secondary process endpoint
-    adviceWith(
-            camelContext,
-            "claim-submit-full",
-            route ->
-                    route
-                            .interceptSendToEndpoint(
-                                    "rabbitmq:health-assess-exchange"
-                                            + "?queue=1701"
-                                            + "&routingKey=1701&requestTimeout=60000")
-                            .skipSendToOriginalEndpoint()
-                            .to("mock:claim-submit-full"));
-    // The mock endpoint returns a valid response
-    mockFullHealthEndpoint.whenAnyExchangeReceived(
-            FunctionProcessor.<Claim, String>fromFunction(claim -> claimToResponse(claim, true)));
-
-    HealthDataAssessmentRequest request = new HealthDataAssessmentRequest();
-    request.setClaimSubmissionId("1234");
-    request.setVeteranIcn("icn");
-    request.setDiagnosticCode("1701");
-
-    var responseEntity1 =
-            post("/v1/full-health-data-assessment", request, FullHealthDataAssessmentResponse.class);
-
-    assertEquals(HttpStatus.CREATED, responseEntity1.getStatusCode());
-    FullHealthDataAssessmentResponse response1 = responseEntity1.getBody();
-    assertEquals(request.getDiagnosticCode(), response1.getDiagnosticCode());
-    assertEquals(request.getVeteranIcn(), response1.getVeteranIcn());
-
-  }
-
-  @Test
-  @DirtiesContext
   void claimSubmit_missing_evidence() throws Exception {
     adviceWith(
         camelContext,
@@ -177,6 +130,103 @@ class VroControllerTest extends BaseIntegrationTest {
     request.setDiagnosticCode("1701");
 
     var responseEntity = post("/v1/health-data-assessment", request, ClaimProcessingError.class);
+    assertEquals(HttpStatus.NOT_FOUND, responseEntity.getStatusCode());
+    var claimProcessingError = responseEntity.getBody();
+    assertEquals("No evidence found.", claimProcessingError.getMessage());
+    assertEquals("1234", claimProcessingError.getClaimSubmissionId());
+  }
+
+
+  @Test
+  @DirtiesContext
+  void postFullHealthAssessment() throws Exception {
+
+    // intercept the original endpoint, skip it and replace it with the mock endpoint
+    adviceWith(
+            camelContext,
+            "claim-submit",
+            route ->
+                    route
+                            .interceptSendToEndpoint(
+                                    "rabbitmq:claim-submit-exchange"
+                                            + "?queue=claim-submit"
+                                            + "&routingKey=code.7101&requestTimeout=60000")
+                            .skipSendToOriginalEndpoint()
+                            .to("mock:claim-submit"));
+    // Mock secondary process endpoint
+    adviceWith(
+            camelContext,
+            "claim-submit-full",
+            route ->
+                    route
+                            .interceptSendToEndpoint(
+                                    "rabbitmq:health-assess-exchange?routingKey=7101&requestTimeout=60000")
+                            .skipSendToOriginalEndpoint()
+                            .to("mock:claim-submit-full"));
+    // The mock endpoint returns a valid response
+    mockFullHealthEndpoint.whenAnyExchangeReceived(
+            FunctionProcessor.<Claim, String>fromFunction(claim -> claimToResponse(claim, true)));
+
+    HealthDataAssessmentRequest request = new HealthDataAssessmentRequest();
+    request.setClaimSubmissionId("1234");
+    request.setVeteranIcn("icn");
+    request.setDiagnosticCode("7101");
+
+    var responseEntity1 =
+            post("/v1/full-health-data-assessment", request, FullHealthDataAssessmentResponse.class);
+
+    assertEquals(HttpStatus.CREATED, responseEntity1.getStatusCode());
+    FullHealthDataAssessmentResponse response1 = responseEntity1.getBody();
+    assertEquals(request.getDiagnosticCode(), response1.getDiagnosticCode());
+    assertEquals(request.getVeteranIcn(), response1.getVeteranIcn());
+
+    // Now submit an existing claim:
+    var responseEntity2 =
+            post("/v1/full-health-data-assessment", request, HealthDataAssessmentResponse.class);
+    assertEquals(HttpStatus.CREATED, responseEntity2.getStatusCode());
+    HealthDataAssessmentResponse response2 = responseEntity2.getBody();
+    assertEquals(request.getDiagnosticCode(), response2.getDiagnosticCode());
+    assertEquals(request.getVeteranIcn(), response2.getVeteranIcn());
+
+    Optional<ClaimEntity> claimEntityOptional =
+            claimRepository.findByClaimSubmissionIdAndIdType("1234", "va.gov-Form526Submission");
+    assertTrue(claimEntityOptional.isPresent());
+  }
+
+  @Test
+  @DirtiesContext
+  void fullClaimSubmit_missing_evidence() throws Exception {
+    adviceWith(
+            camelContext,
+            "claim-submit",
+            route ->
+                    route
+                            .interceptSendToEndpoint(
+                                    "rabbitmq:claim-submit-exchange"
+                                            + "?queue=claim-submit"
+                                            + "&routingKey=code.7101&requestTimeout=60000")
+                            .skipSendToOriginalEndpoint()
+                            .to("mock:claim-submit"));
+    // Mock secondary process endpoint
+    adviceWith(
+            camelContext,
+            "claim-submit-full",
+            route ->
+                    route
+                            .interceptSendToEndpoint(
+                                    "rabbitmq:health-assess-exchange?routingKey=7101&requestTimeout=60000")
+                            .skipSendToOriginalEndpoint()
+                            .to("mock:claim-submit-full"));
+
+    mockFullHealthEndpoint.whenAnyExchangeReceived(
+            FunctionProcessor.<Claim, String>fromFunction(claim -> claimToResponse(claim, false)));
+
+    HealthDataAssessmentRequest request = new HealthDataAssessmentRequest();
+    request.setClaimSubmissionId("1234");
+    request.setVeteranIcn("icn");
+    request.setDiagnosticCode("7101");
+
+    var responseEntity = post("/v1/full-health-data-assessment", request, ClaimProcessingError.class);
     assertEquals(HttpStatus.NOT_FOUND, responseEntity.getStatusCode());
     var claimProcessingError = responseEntity.getBody();
     assertEquals("No evidence found.", claimProcessingError.getMessage());

--- a/controller/src/main/java/gov/va/vro/controller/VroController.java
+++ b/controller/src/main/java/gov/va/vro/controller/VroController.java
@@ -135,7 +135,7 @@ public class VroController implements VroResource {
           objectMapper.readValue(responseAsString, FullHealthDataAssessmentResponse.class);
       if (response.getEvidence() == null) {
         throw new ClaimProcessingException(
-                claim.getClaimSubmissionId(), HttpStatus.NOT_FOUND, "No evidence found.");
+            claim.getClaimSubmissionId(), HttpStatus.NOT_FOUND, "No evidence found.");
       }
       log.info("Returning health assessment for: {}", claim.getVeteranIcn());
       response.setVeteranIcn(claim.getVeteranIcn());

--- a/service/provider/src/main/java/gov/va/vro/service/provider/camel/SlipClaimSubmitRouter.java
+++ b/service/provider/src/main/java/gov/va/vro/service/provider/camel/SlipClaimSubmitRouter.java
@@ -54,7 +54,7 @@ public class SlipClaimSubmitRouter {
     String diagnosticCode = diagnosticCodeObj.toString();
     String route =
         String.format(
-            "rabbitmq:claim-submit-exchange?routingKey=code.%s&requestTimeout=%d",
+            "rabbitmq:health-assess-exchange?routingKey=%s&requestTimeout=%d",
             diagnosticCode, DEFAULT_REQUEST_TIMEOUT);
     log.info("Routing to {}.", route);
     return route;


### PR DESCRIPTION
# Full-Health-Assessment testing <!-- replace this with the feature/bug name -->

## Description

<!-- you don't need to write anything here -->

### What was the problem?
There were no tests for the full-process endpoint in the controller
<!-- brief description of how things worked before this PR -->

### How does this fix it?
Adds positive and negative test cases to the controller tests
<!-- brief description of how things will work after this PR -->

### Jira Tickets

<!-- replace "000" with ticket number in both places -->

- [MCP-1806](https://amida.atlassian.net/browse/MCP-1806)

## How to test this PR

- Step 1
- Run tests in controller and see that they pass
- Step 2 
- Manually test the Full-Health-Assessment endpoint on Swagger

## Reminders

- Review [Pull-Requests](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests) guidelines
- [ ] If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) and
[Roadmap](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Roadmap) wiki pages
- [ ] If changing software behavior, post a link to the PR in Slack channel #benefits-virtual-regional-office
