### PR TITLE
Fix SecRel's pushing images

### DIFF
--- a/.github/secrel/config.yml
+++ b/.github/secrel/config.yml
@@ -32,7 +32,7 @@ images:
 - name: vro-service-data-access
   context: "./service-data-access/src/main/resources"
   path: "./service-data-access/src/docker/Dockerfile"
-- name: vro-pdfgenerator
+- name: vro-service-pdfgenerator
   context: "./service-python/pdfgenerator/src"
   path: "./service-python/pdfgenerator/src/docker/Dockerfile"
 - name: vro-service-assessclaimdc7101

--- a/.github/secrel/config.yml
+++ b/.github/secrel/config.yml
@@ -16,29 +16,29 @@ snyk:
 
 # Remove image block if you're not building Docker images
 images:
-- name: abd_vro
+- name: vro
   path: "./Dockerfile"
   args:
     -  GITHUB_ACCESS_TOKEN=${{ secrets.ACCESS_TOKEN }}
-- name: abd_vro-db-init
+- name: vro-db-init
   context: "./db-init/src/main/resources"
   path: "./db-init/src/docker/Dockerfile"
-- name: container-init
+- name: vro-container-init
   context: "./container-init/src/main/resources"
   path: "./container-init/src/docker/Dockerfile"
-- name: opa-init
+- name: vro-opa-init
   context: "./opa-init/src/main/resources"
   path: "./opa-init/src/docker/Dockerfile"
-- name: service-data-access
+- name: vro-service-data-access
   context: "./service-data-access/src/main/resources"
   path: "./service-data-access/src/docker/Dockerfile"
-- name: abd_vro-pdfgenerator
+- name: vro-pdfgenerator
   context: "./service-python/pdfgenerator/src"
   path: "./service-python/pdfgenerator/src/docker/Dockerfile"
-- name: abd_vro-service-assessclaimdc7101
+- name: vro-service-assessclaimdc7101
   context: "./service-python/assessclaimdc7101/src"
   path: "./service-python/assessclaimdc7101/src/docker/Dockerfile"
-- name: abd_vro-service-assessclaimdc6602
+- name: vro-service-assessclaimdc6602
   context: "./service-python/assessclaimdc6602/src"
   path: "./service-python/assessclaimdc6602/src/docker/Dockerfile"
 

--- a/.github/secrel/config.yml
+++ b/.github/secrel/config.yml
@@ -20,13 +20,13 @@ images:
   path: "./Dockerfile"
   args:
     -  GITHUB_ACCESS_TOKEN=${{ secrets.ACCESS_TOKEN }}
-- name: vro-db-init
+- name: vro-init-db
   context: "./db-init/src/main/resources"
   path: "./db-init/src/docker/Dockerfile"
-- name: vro-container-init
+- name: vro-init-container
   context: "./container-init/src/main/resources"
   path: "./container-init/src/docker/Dockerfile"
-- name: vro-opa-init
+- name: vro-init-opa
   context: "./opa-init/src/main/resources"
   path: "./opa-init/src/docker/Dockerfile"
 - name: vro-service-data-access

--- a/.github/workflows/aqua-checker.yml
+++ b/.github/workflows/aqua-checker.yml
@@ -11,7 +11,7 @@ jobs:
     # only run for the internal repo
     if: github.repository == 'department-of-veterans-affairs/abd-vro-internal'
     name: Aqua Check
-    uses: department-of-veterans-affairs/lighthouse-tornado-secrel-pipeline/.github/workflows/aqua-checker.yml@v2.1.1
+    uses: department-of-veterans-affairs/lighthouse-tornado-secrel-pipeline/.github/workflows/aqua-checker.yml@v2.2.0
     with:
       config-file: .github/secrel/config.yml
     secrets: inherit

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -56,14 +56,14 @@ jobs:
             "ghcr.io/${{ github.repository }}/dev_vro-app:${COMMIT_SHA:0:7}"
           docker tag va/dev_vro-init-db \
             "ghcr.io/${{ github.repository }}/dev_vro-init-db:${COMMIT_SHA:0:7}"
-          docker tag va/dev_vro-assessclaimdc7101 \
-            "ghcr.io/${{ github.repository }}/dev_vro-assessclaimdc7101:${COMMIT_SHA:0:7}"
-          docker tag va/dev_vro-assessclaimdc6602 \
-            "ghcr.io/${{ github.repository }}/dev_vro-assessclaimdc6602:${COMMIT_SHA:0:7}"
-          docker tag va/dev_vro-pdfgenerator \
-            "ghcr.io/${{ github.repository }}/dev_vro-pdfgenerator:${COMMIT_SHA:0:7}"
+          docker tag va/dev_vro-service-assessclaimdc7101 \
+            "ghcr.io/${{ github.repository }}/dev_vro-service-assessclaimdc7101:${COMMIT_SHA:0:7}"
+          docker tag va/dev_vro-service-assessclaimdc6602 \
+            "ghcr.io/${{ github.repository }}/dev_vro-service-assessclaimdc6602:${COMMIT_SHA:0:7}"
+          docker tag va/dev_vro-service-pdfgenerator \
+            "ghcr.io/${{ github.repository }}/dev_vro-service-pdfgenerator:${COMMIT_SHA:0:7}"
           docker tag va/dev_vro-service-data-access \
-            "ghcr.io/${{ github.repository }}/dev_vro-data-access:${COMMIT_SHA:0:7}"
+            "ghcr.io/${{ github.repository }}/dev_vro-service-data-access:${COMMIT_SHA:0:7}"
 
       - name: Push images
         run: |
@@ -74,6 +74,7 @@ jobs:
           # Remove the following section once SecRel works 
           docker push "ghcr.io/${{ github.repository }}/dev_vro-app:${COMMIT_SHA:0:7}"
           docker push "ghcr.io/${{ github.repository }}/dev_vro-init-db:${COMMIT_SHA:0:7}"
-          docker push "ghcr.io/${{ github.repository }}/dev_vro-pdfgenerator:${COMMIT_SHA:0:7}"
-          docker push "ghcr.io/${{ github.repository }}/dev_vro-assessclaimdc7101:${COMMIT_SHA:0:7}"
-          docker push "ghcr.io/${{ github.repository }}/dev_vro-assessclaimdc6602:${COMMIT_SHA:0:7}"
+          docker push "ghcr.io/${{ github.repository }}/dev_vro-service-pdfgenerator:${COMMIT_SHA:0:7}"
+          docker push "ghcr.io/${{ github.repository }}/dev_vro-service-assessclaimdc7101:${COMMIT_SHA:0:7}"
+          docker push "ghcr.io/${{ github.repository }}/dev_vro-service-assessclaimdc6602:${COMMIT_SHA:0:7}"
+          docker push "ghcr.io/${{ github.repository }}/dev_vro-service-data-access:${COMMIT_SHA:0:7}"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,34 +46,34 @@ jobs:
           # Pull and tag these images to work around https://www.docker.com/increase-rate-limits/
           docker pull postgres:latest
           docker tag postgres:latest \
-            "ghcr.io/${{ github.repository }}/abd_vro-postgres:latest"
+            "ghcr.io/${{ github.repository }}/vro-postgres:latest"
           docker pull rabbitmq:3
           docker tag rabbitmq:3 \
-            "ghcr.io/${{ github.repository }}/abd_vro-rabbitmq:3"
+            "ghcr.io/${{ github.repository }}/vro-rabbitmq:3"
 
           # Remove the following section once SecRel works
-          docker tag va/abd_vro-app \
-            "ghcr.io/${{ github.repository }}/abd_vro-app:${COMMIT_SHA:0:7}"
-          docker tag va/abd_vro-db-init \
-            "ghcr.io/${{ github.repository }}/abd_vro-db-init:${COMMIT_SHA:0:7}"
-          docker tag va/abd_vro-assessclaimdc7101 \
-            "ghcr.io/${{ github.repository }}/abd_vro-assessclaimdc7101:${COMMIT_SHA:0:7}"
-          docker tag va/abd_vro-assessclaimdc6602 \
-            "ghcr.io/${{ github.repository }}/abd_vro-assessclaimdc6602:${COMMIT_SHA:0:7}"
-          docker tag va/abd_vro-pdfgenerator \
-            "ghcr.io/${{ github.repository }}/abd_vro-pdfgenerator:${COMMIT_SHA:0:7}"
-          docker tag va/abd_vro-service-data-access \
-            "ghcr.io/${{ github.repository }}/abd_vro-data-access:${COMMIT_SHA:0:7}"
+          docker tag va/dev_vro-app \
+            "ghcr.io/${{ github.repository }}/dev_vro-app:${COMMIT_SHA:0:7}"
+          docker tag va/dev_vro-init-db \
+            "ghcr.io/${{ github.repository }}/dev_vro-init-db:${COMMIT_SHA:0:7}"
+          docker tag va/dev_vro-assessclaimdc7101 \
+            "ghcr.io/${{ github.repository }}/dev_vro-assessclaimdc7101:${COMMIT_SHA:0:7}"
+          docker tag va/dev_vro-assessclaimdc6602 \
+            "ghcr.io/${{ github.repository }}/dev_vro-assessclaimdc6602:${COMMIT_SHA:0:7}"
+          docker tag va/dev_vro-pdfgenerator \
+            "ghcr.io/${{ github.repository }}/dev_vro-pdfgenerator:${COMMIT_SHA:0:7}"
+          docker tag va/dev_vro-service-data-access \
+            "ghcr.io/${{ github.repository }}/dev_vro-data-access:${COMMIT_SHA:0:7}"
 
       - name: Push images
         run: |
           # Push the following images to work around https://www.docker.com/increase-rate-limits/
-          docker push "ghcr.io/${{ github.repository }}/abd_vro-postgres:latest"
-          docker push "ghcr.io/${{ github.repository }}/abd_vro-rabbitmq:3"
+          docker push "ghcr.io/${{ github.repository }}/dev_vro-postgres:latest"
+          docker push "ghcr.io/${{ github.repository }}/dev_vro-rabbitmq:3"
 
           # Remove the following section once SecRel works 
-          docker push "ghcr.io/${{ github.repository }}/abd_vro-app:${COMMIT_SHA:0:7}"
-          docker push "ghcr.io/${{ github.repository }}/abd_vro-db-init:${COMMIT_SHA:0:7}"
-          docker push "ghcr.io/${{ github.repository }}/abd_vro-pdfgenerator:${COMMIT_SHA:0:7}"
-          docker push "ghcr.io/${{ github.repository }}/abd_vro-assessclaimdc7101:${COMMIT_SHA:0:7}"
-          docker push "ghcr.io/${{ github.repository }}/abd_vro-assessclaimdc6602:${COMMIT_SHA:0:7}"
+          docker push "ghcr.io/${{ github.repository }}/dev_vro-app:${COMMIT_SHA:0:7}"
+          docker push "ghcr.io/${{ github.repository }}/dev_vro-init-db:${COMMIT_SHA:0:7}"
+          docker push "ghcr.io/${{ github.repository }}/dev_vro-pdfgenerator:${COMMIT_SHA:0:7}"
+          docker push "ghcr.io/${{ github.repository }}/dev_vro-assessclaimdc7101:${COMMIT_SHA:0:7}"
+          docker push "ghcr.io/${{ github.repository }}/dev_vro-assessclaimdc6602:${COMMIT_SHA:0:7}"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -68,8 +68,8 @@ jobs:
       - name: Push images
         run: |
           # Push the following images to work around https://www.docker.com/increase-rate-limits/
-          docker push "ghcr.io/${{ github.repository }}/dev_vro-postgres:latest"
-          docker push "ghcr.io/${{ github.repository }}/dev_vro-rabbitmq:3"
+          docker push "ghcr.io/${{ github.repository }}/vro-postgres:latest"
+          docker push "ghcr.io/${{ github.repository }}/vro-rabbitmq:3"
 
           # Remove the following section once SecRel works 
           docker push "ghcr.io/${{ github.repository }}/dev_vro-app:${COMMIT_SHA:0:7}"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -51,18 +51,18 @@ jobs:
           docker tag rabbitmq:3 \
             "ghcr.io/${{ github.repository }}/vro-rabbitmq:3"
 
-          # Remove the following section once SecRel works
-          docker tag va/dev_vro-app \
+          # Tag dev images for non-prod testing
+          docker tag va/abd_vro-app \
             "ghcr.io/${{ github.repository }}/dev_vro-app:${COMMIT_SHA:0:7}"
-          docker tag va/dev_vro-init-db \
+          docker tag va/abd_vro-db-init \
             "ghcr.io/${{ github.repository }}/dev_vro-init-db:${COMMIT_SHA:0:7}"
-          docker tag va/dev_vro-service-assessclaimdc7101 \
+          docker tag va/abd_vro-assessclaimdc7101 \
             "ghcr.io/${{ github.repository }}/dev_vro-service-assessclaimdc7101:${COMMIT_SHA:0:7}"
-          docker tag va/dev_vro-service-assessclaimdc6602 \
+          docker tag va/abd_vro-assessclaimdc6602 \
             "ghcr.io/${{ github.repository }}/dev_vro-service-assessclaimdc6602:${COMMIT_SHA:0:7}"
-          docker tag va/dev_vro-service-pdfgenerator \
+          docker tag va/abd_vro-pdfgenerator \
             "ghcr.io/${{ github.repository }}/dev_vro-service-pdfgenerator:${COMMIT_SHA:0:7}"
-          docker tag va/dev_vro-service-data-access \
+          docker tag va/abd_vro-service-data-access \
             "ghcr.io/${{ github.repository }}/dev_vro-service-data-access:${COMMIT_SHA:0:7}"
 
       - name: Push images
@@ -71,7 +71,7 @@ jobs:
           docker push "ghcr.io/${{ github.repository }}/vro-postgres:latest"
           docker push "ghcr.io/${{ github.repository }}/vro-rabbitmq:3"
 
-          # Remove the following section once SecRel works 
+          # Pushes dev images for non-prod testing
           docker push "ghcr.io/${{ github.repository }}/dev_vro-app:${COMMIT_SHA:0:7}"
           docker push "ghcr.io/${{ github.repository }}/dev_vro-init-db:${COMMIT_SHA:0:7}"
           docker push "ghcr.io/${{ github.repository }}/dev_vro-service-pdfgenerator:${COMMIT_SHA:0:7}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN --mount=type=secret,id=all-secrets GITHUB_ACCESS_TOKEN=$(cat /run/secrets/al
 ./gradlew assemble -PGITHUB_ACCESS_TOKEN=$GITHUB_ACCESS_TOKEN
 
 # Stage 2 - Run Stage
-FROM openjdk:17-alpine as run
+FROM eclipse-temurin:17-alpine as run
 RUN mkdir /app
 
 # Move jars over from build stage

--- a/container-init/src/docker/Dockerfile
+++ b/container-init/src/docker/Dockerfile
@@ -1,4 +1,5 @@
 FROM alpine:3.7
+LABEL org.opencontainers.image.source=https://github.com/department-of-veterans-affairs/abd-vro
 RUN apk --no-cache add postgresql-client=10.10-r0
 COPY init_pg.sql /usr/local/share
 CMD [ "sleep 10 && echo \"attempting to create new db with username:$POSTGRES_USER\" && psql \"postgres://$POSTGRES_ROOT_USER:$POSTGRES_ROOT_PASSWORD@$POSTGRES_HOST:5432/postgres\" -v username=\"$POSTGRES_USER\" -v dbname=\"$POSTGRES_DBNAME\" -v password=\"$POSTGRES_PASSWORD\" -f /usr/local/share/init_pg.sql" ]

--- a/db-init/src/docker/Dockerfile
+++ b/db-init/src/docker/Dockerfile
@@ -1,7 +1,7 @@
 FROM flyway/flyway:7.5.4
+LABEL org.opencontainers.image.source=https://github.com/department-of-veterans-affairs/abd-vro
 COPY database /flyway/sql
 COPY flyway.conf /flyway/conf
 HEALTHCHECK NONE
-LABEL org.opencontainers.image.source=https://github.com/department-of-veterans-affairs/abd-vro
 
 CMD [ "migrate", "-X" ]

--- a/helmchart/values.yaml
+++ b/helmchart/values.yaml
@@ -27,30 +27,30 @@ images:
   org: department-of-veterans-affairs
   # Note the repo name uses a hypen, not underscore
   repo: abd-vro
-  app:
-    imageName: abd_vro-app
+  db:
+    imageName: vro-postgres
     tag: latest
-    imagePullPolicy: Always
-  pdfGenerator:
-    imageName: abd_vro-pdfgenerator
+  mq:
+    imageName: vro-rabbitmq
+    tag: 3
+  app:
+    imageName: dev_vro-app
     tag: latest
     imagePullPolicy: Always
   dbInit:
-    imageName: abd_vro-db-init
+    imageName: dev_vro-init-db
     tag: latest
     imagePullPolicy: Always
-  db:
-    imageName: abd_vro-postgres
+  pdfGenerator:
+    imageName: dev_vro-service-pdfgenerator
     tag: latest
-  mq:
-    imageName: abd_vro-rabbitmq
-    tag: 3
+    imagePullPolicy: Always
   serviceAssessClaimDC7101:
-    imageName: abd_vro-service-assessclaimdc7101
+    imageName: dev_vro-service-assessclaimdc7101
     tag: latest
     imagePullPolicy: Always
   serviceAssessClaimDC6602:
-    imageName: abd_vro-service-assessclaimdc6602
+    imageName: dev_vro-service-assessclaimdc6602
     tag: latest
     imagePullPolicy: Always
     

--- a/opa-init/src/docker/Dockerfile
+++ b/opa-init/src/docker/Dockerfile
@@ -1,4 +1,5 @@
 FROM alpine:3.7
+LABEL org.opencontainers.image.source=https://github.com/department-of-veterans-affairs/abd-vro
 
 RUN apk --no-cache add curl==7.61.1-r3
 HEALTHCHECK NONE

--- a/service-data-access/src/docker/Dockerfile
+++ b/service-data-access/src/docker/Dockerfile
@@ -1,4 +1,5 @@
 FROM openjdk:17
+LABEL org.opencontainers.image.source=https://github.com/department-of-veterans-affairs/abd-vro
 ARG JAR_FILE
 ARG ENTRYPOINT_FILE
 WORKDIR /project

--- a/service-python/assessclaimdc6602/src/docker/Dockerfile
+++ b/service-python/assessclaimdc6602/src/docker/Dockerfile
@@ -1,6 +1,7 @@
 ARG PYTHON_VERSION=3.8
 
 FROM python:${PYTHON_VERSION}
+LABEL org.opencontainers.image.source=https://github.com/department-of-veterans-affairs/abd-vro
 
 ENV PYTHONDONTWRITEBYTECODE 1
 ENV PYTHONUNBUFFERED 1

--- a/service-python/assessclaimdc7101/src/docker/Dockerfile
+++ b/service-python/assessclaimdc7101/src/docker/Dockerfile
@@ -1,6 +1,7 @@
 ARG PYTHON_VERSION=3.8
 
 FROM python:${PYTHON_VERSION}
+LABEL org.opencontainers.image.source=https://github.com/department-of-veterans-affairs/abd-vro
 
 ENV PYTHONDONTWRITEBYTECODE 1
 ENV PYTHONUNBUFFERED 1

--- a/service-python/pdfgenerator/src/docker/Dockerfile
+++ b/service-python/pdfgenerator/src/docker/Dockerfile
@@ -1,6 +1,7 @@
 ARG WKHTML_VERSION=3.9.9-0.12.6-small
 
 FROM surnet/alpine-python-wkhtmltopdf:${WKHTML_VERSION}
+LABEL org.opencontainers.image.source=https://github.com/department-of-veterans-affairs/abd-vro
 
 ENV PYTHONDONTWRITEBYTECODE 1
 ENV PYTHONUNBUFFERED 1


### PR DESCRIPTION
# Feature Name <!-- replace this with the feature/bug name -->

## Description

<!-- you don't need to write anything here -->

### What was the problem?

<!-- brief description of how things worked before this PR -->

SecRel pipeline consistently [failing to push 2 out of 8 Docker images](https://github.com/department-of-veterans-affairs/abd-vro-internal/actions/runs/2975468236): [db-init](https://github.com/department-of-veterans-affairs/abd-vro-internal/runs/8146473039?check_suite_focus=true#step:14:26) and [pdfgenerator](https://github.com/department-of-veterans-affairs/abd-vro-internal/runs/8146473351?check_suite_focus=true#step:14:32).

[Slack thread](https://lighthouseva.slack.com/archives/C02PTSZKM8W/p1662135807727909)

### How does this fix it?

<!-- brief description of how things will work after this PR -->
Clean up https://github.com/orgs/department-of-veterans-affairs/packages?q=abd-vro-internal and https://github.com/orgs/department-of-veterans-affairs/packages?tab=packages&q=abd-vro.

Define new package naming convention to make them easily distinguishable and easier to search in https://github.com/orgs/department-of-veterans-affairs/packages:
* `vro-*` for prod
* `dev_vro-*` for non-prod
