### PR TITLE
Add health check to depends on for Python services 

### DIFF
--- a/app/src/docker/docker-compose.yml
+++ b/app/src/docker/docker-compose.yml
@@ -118,7 +118,8 @@ services:
       RABBITMQ_PLACEHOLDERS_USERNAME: guest
       RABBITMQ_PLACEHOLDERS_USERPASSWORD: guest
     depends_on:
-      - rabbitmq1
+      rabbitmq1:
+        condition: service_healthy
     networks:
       - internal
 
@@ -129,7 +130,8 @@ services:
       RABBITMQ_PLACEHOLDERS_USERNAME: guest
       RABBITMQ_PLACEHOLDERS_USERPASSWORD: guest
     depends_on:
-      - rabbitmq1
+      rabbitmq1:
+        condition: service_healthy
     networks:
       - internal
 
@@ -141,8 +143,10 @@ services:
       RABBITMQ_PLACEHOLDERS_USERPASSWORD: guest
       REDIS_PLACEHOLDERS_HOST: redis1
     depends_on:
-      - rabbitmq1
-      - redis1
+      rabbitmq1:
+        condition: service_healthy
+      redis1:
+        condition: service_healthy
     networks:
       - internal
 

--- a/app/src/docker/docker-compose.yml
+++ b/app/src/docker/docker-compose.yml
@@ -143,6 +143,7 @@ services:
       RABBITMQ_PLACEHOLDERS_USERPASSWORD: guest
       REDIS_PLACEHOLDERS_HOST: redis1
     depends_on:
+      redis:
       rabbitmq1:
         condition: service_healthy
     networks:

--- a/app/src/docker/docker-compose.yml
+++ b/app/src/docker/docker-compose.yml
@@ -144,6 +144,7 @@ services:
       REDIS_PLACEHOLDERS_HOST: redis1
     depends_on:
       redis1:
+        condition: service_started
       rabbitmq1:
         condition: service_healthy
     networks:

--- a/app/src/docker/docker-compose.yml
+++ b/app/src/docker/docker-compose.yml
@@ -145,8 +145,7 @@ services:
     depends_on:
       rabbitmq1:
         condition: service_healthy
-      redis1:
-        condition: service_healthy
+
     networks:
       - internal
 

--- a/app/src/docker/docker-compose.yml
+++ b/app/src/docker/docker-compose.yml
@@ -143,7 +143,7 @@ services:
       RABBITMQ_PLACEHOLDERS_USERPASSWORD: guest
       REDIS_PLACEHOLDERS_HOST: redis1
     depends_on:
-      redis:
+      redis1:
       rabbitmq1:
         condition: service_healthy
     networks:

--- a/app/src/docker/docker-compose.yml
+++ b/app/src/docker/docker-compose.yml
@@ -145,7 +145,6 @@ services:
     depends_on:
       rabbitmq1:
         condition: service_healthy
-
     networks:
       - internal
 


### PR DESCRIPTION
# Feature Name <!-- replace this with the feature/bug name -->

## Description

<!-- you don't need to write anything here -->

### What was the problem?
Python services failed to wait for Rabbit MQ before trying to connect. 

<!-- brief description of how things worked before this PR -->

### How does this fix it?
Docker compose has been updated for the Python services to properly wait for Rabbit MQ to be healthy.  
<!-- brief description of how things will work after this PR -->

### Jira Tickets

<!-- replace "000" with ticket number in both places -->

- [MCP-1810](https://amida.atlassian.net/browse/MCP-1810)

## How to test this PR

- Step 1
- Run the gradle commands to start up the project. See in the logs that python services are successful on the first attempt at connection. 
- Step 2 

## Reminders

- Review [Pull-Requests](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests) guidelines
- [ ] If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) and
[Roadmap](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Roadmap) wiki pages
- [ ] If changing software behavior, post a link to the PR in Slack channel #benefits-virtual-regional-office
