### PR TITLE
Update to flyway version 9.2.3 to use updated H2 and Postgres drivers

### DIFF
--- a/db-init/src/docker/Dockerfile
+++ b/db-init/src/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM flyway/flyway:9.2.0
+FROM flyway/flyway:9.2.3
 LABEL org.opencontainers.image.source=https://github.com/department-of-veterans-affairs/abd-vro
 COPY database /flyway/sql
 COPY flyway.conf /flyway/conf

--- a/db-init/src/main/resources/flyway.conf
+++ b/db-init/src/main/resources/flyway.conf
@@ -33,9 +33,13 @@ flyway.validateOnMigrate=true
 flyway.cleanOnValidationError=true
 flyway.mixed=true
 flyway.group=false
-flyway.ignoreMissingMigrations=false
-flyway.ignoreIgnoredMigrations=false
-flyway.ignoreFutureMigrations=false
+
+# No longer supported.
+# Instead, use https://flywaydb.org/documentation/configuration/parameters/ignoreMigrationPatterns
+# flyway.ignoreMissingMigrations=false
+# flyway.ignoreIgnoredMigrations=false
+# flyway.ignoreFutureMigrations=false
+
 flyway.cleanDisabled=false
 flyway.baselineOnMigrate=false
 flyway.installedBy=my-user


### PR DESCRIPTION
# Feature Name <!-- replace this with the feature/bug name -->

## Description

<!-- you don't need to write anything here -->

### What was the problem?

<!-- brief description of how things worked before this PR -->

Aqua alerts about vulnerabilities with older H2 and Postgres drivers

### How does this fix it?

<!-- brief description of how things will work after this PR -->
Flyway version 9.2.3 uses h2-2.1.214.jar and postgresql-42.4.1.jar (located in the `/flyway/drivers` folder of the image)

### How to test

* Manually mirror this repo to the internal repo - https://github.com/department-of-veterans-affairs/abd-vro/wiki/Github-Actions#mirror
* In the internal repo, manually run the SecRel workflow action on this branch - https://github.com/department-of-veterans-affairs/abd-vro-internal/actions/workflows/secrel.yml
* Check the results in Aqua - https://aqua.lighthouse.va.gov/#/images/CiCdScans
