### PR TITLE
Create someuser to run db-init container commands

### DIFF
--- a/.github/secrel/config.yml
+++ b/.github/secrel/config.yml
@@ -23,12 +23,12 @@ images:
 - name: vro-init-db
   context: "./db-init/src/main/resources"
   path: "./db-init/src/docker/Dockerfile"
-#- name: vro-init-container
-#  context: "./container-init/src/main/resources"
-#  path: "./container-init/src/docker/Dockerfile"
-#- name: vro-init-opa
-#  context: "./opa-init/src/main/resources"
-#  path: "./opa-init/src/docker/Dockerfile"
+- name: vro-init-container
+  context: "./container-init/src/main/resources"
+  path: "./container-init/src/docker/Dockerfile"
+- name: vro-init-opa
+  context: "./opa-init/src/main/resources"
+  path: "./opa-init/src/docker/Dockerfile"
 - name: vro-service-data-access
   context: "./service-data-access/src/main/resources"
   path: "./service-data-access/src/docker/Dockerfile"

--- a/.github/secrel/config.yml
+++ b/.github/secrel/config.yml
@@ -23,12 +23,12 @@ images:
 - name: vro-init-db
   context: "./db-init/src/main/resources"
   path: "./db-init/src/docker/Dockerfile"
-- name: vro-init-container
-  context: "./container-init/src/main/resources"
-  path: "./container-init/src/docker/Dockerfile"
-- name: vro-init-opa
-  context: "./opa-init/src/main/resources"
-  path: "./opa-init/src/docker/Dockerfile"
+#- name: vro-init-container
+#  context: "./container-init/src/main/resources"
+#  path: "./container-init/src/docker/Dockerfile"
+#- name: vro-init-opa
+#  context: "./opa-init/src/main/resources"
+#  path: "./opa-init/src/docker/Dockerfile"
 - name: vro-service-data-access
   context: "./service-data-access/src/main/resources"
   path: "./service-data-access/src/docker/Dockerfile"

--- a/db-init/src/docker/Dockerfile
+++ b/db-init/src/docker/Dockerfile
@@ -4,4 +4,7 @@ COPY database /flyway/sql
 COPY flyway.conf /flyway/conf
 HEALTHCHECK NONE
 
+RUN useradd --no-create-home someuser
+USER someuser
+
 CMD [ "migrate", "-X" ]


### PR DESCRIPTION
## Description

<!-- you don't need to write anything here -->

Follow-on to PR #263 

### What was the problem?

<!-- brief description of how things worked before this PR -->

Aqua alert says to "Modify the image to run with a user other than root" for the db-init image

### How does this fix it?

<!-- brief description of how things will work after this PR -->

Create someuser to run db-init container commands instead of the default root user

## How to test this PR

* Manually mirror this repo to the internal repo - https://github.com/department-of-veterans-affairs/abd-vro/wiki/Github-Actions#mirror
* In the internal repo, manually run the SecRel workflow action on this branch - https://github.com/department-of-veterans-affairs/abd-vro-internal/actions/workflows/secrel.yml
* Check the results in Aqua - https://aqua.lighthouse.va.gov/#/images/CiCdScans
