### PR TITLE
Remove unnecessary build-docker-app job from the build GH Action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -102,4 +102,4 @@ jobs:
           docker build -f ./service-python/assessclaimdc7101/src/docker/Dockerfile ./service-python/assessclaimdc7101/src
           docker build -f ./service-python/assessclaimdc6602/src/docker/Dockerfile ./service-python/assessclaimdc6602/src
 
-          # Reminder: also add path to Dockerfile to .github/secrel/config.yml
+          # Reminder to also add new images to .github/secrel/config.yml

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,16 +90,21 @@ jobs:
         with:
           install: true
 
-      - name: Build all Dockerfiles
+      - name: Build Dockerfiles - base application
         run: |
           docker build -f ./app/src/docker/Dockerfile ./app/src/main/resources
           docker build -f ./db-init/src/docker/Dockerfile ./db-init/src/main/resources
           docker build -f ./container-init/src/docker/Dockerfile ./container-init/src/main/resources
           docker build -f ./opa-init/src/docker/Dockerfile ./opa-init/src/main/resources
+
+      - name: Build Dockerfiles - Java microservice
+        run: |
           docker build -f ./service-data-access/src/docker/Dockerfile ./service-data-access/src/main/resources
 
+      - name: Build Dockerfiles - Python microservice
+        run: |
           docker build -f ./service-python/pdfgenerator/src/docker/Dockerfile ./service-python/pdfgenerator/src
           docker build -f ./service-python/assessclaimdc7101/src/docker/Dockerfile ./service-python/assessclaimdc7101/src
           docker build -f ./service-python/assessclaimdc6602/src/docker/Dockerfile ./service-python/assessclaimdc6602/src
 
-          # Reminder to also add new images to .github/secrel/config.yml
+      # Reminder to also add new images to .github/secrel/config.yml

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,22 +58,26 @@ jobs:
       - name: "Build and test Python code with test coverage report"
         run: cd service-python && python -m pytest --cov-report term-missing --cov
 
-  build-docker-app:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout source code
-        uses: actions/checkout@v3
-
-      - uses: docker/setup-buildx-action@v2
-        id: buildx
-        with:
-          install: true
-
-      - name: Build docker-app
-        run: |
-          echo 'GITHUB_ACCESS_TOKEN=${{ secrets.ACCESS_TOKEN }}' > all-secrets.txt
-          docker build . --no-cache --progress=plain --secret id=all-secrets,src=all-secrets.txt
-          rm all-secrets.txt
+# This job doesn't seem relevant since VRO is runs entirely from images.
+# We don't use the generated "fat jar" file at all.
+# Leaving this job here until VRO completes SecRel pipeline.
+#  build-docker-app:
+#    runs-on: ubuntu-latest
+#    steps:
+#      - name: Checkout source code
+#        uses: actions/checkout@v3
+#
+#      - uses: docker/setup-buildx-action@v2
+#        id: buildx
+#        with:
+#          install: true
+#
+#      - name: Build docker-app
+#        run: |
+#          echo 'GITHUB_ACCESS_TOKEN=${{ secrets.ACCESS_TOKEN }}' > all-secrets.txt
+# Builds using `./Dockerfile`, which runs `./gradlew assemble`, which creates an image that runs the generated "fat jar"
+#          docker build . --no-cache --progress=plain --secret id=all-secrets,src=all-secrets.txt
+#          rm all-secrets.txt
 
   build-docker-images:
     runs-on: ubuntu-latest
@@ -88,6 +92,7 @@ jobs:
 
       - name: Build all Dockerfiles
         run: |
+          docker build -f ./app/src/docker/Dockerfile ./app/src/main/resources
           docker build -f ./db-init/src/docker/Dockerfile ./db-init/src/main/resources
           docker build -f ./container-init/src/docker/Dockerfile ./container-init/src/main/resources
           docker build -f ./opa-init/src/docker/Dockerfile ./opa-init/src/main/resources


### PR DESCRIPTION
# Feature Name <!-- replace this with the feature/bug name -->

## Description

<!-- you don't need to write anything here -->

### What was the problem?

<!-- brief description of how things worked before this PR -->

The `build-docker-app` job runs as part of the `build.yml` GitHub Action for every PR.
This job doesn't seem relevant since VRO is runs entirely from images.
We don't use the generated "fat jar" file at all, so we don't need to run this job.

I also question the need for the `./Dockerfile`.

### How does this fix it?

<!-- brief description of how things will work after this PR -->

Remove unnecessary `build-docker-app` job
