### PR TITLE
Remove init-container image from SecRel

### DIFF
--- a/.github/secrel/config.yml
+++ b/.github/secrel/config.yml
@@ -21,9 +21,6 @@ images:
 - name: vro-init-db
   context: "./db-init/src/main/resources"
   path: "./db-init/src/docker/Dockerfile"
-- name: vro-init-container
-  context: "./container-init/src/main/resources"
-  path: "./container-init/src/docker/Dockerfile"
 - name: vro-service-data-access
   context: "./service-data-access/src/main/resources"
   path: "./service-data-access/src/docker/Dockerfile"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,7 +94,6 @@ jobs:
         run: |
           docker build -f ./app/src/docker/Dockerfile ./app/src/main/resources
           docker build -f ./db-init/src/docker/Dockerfile ./db-init/src/main/resources
-          docker build -f ./container-init/src/docker/Dockerfile ./container-init/src/main/resources
 
       - name: Build Dockerfiles - Java microservice
         run: |

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -42,7 +42,6 @@ dependencies {
     //This version is compatible with current spring version: 5.3.8
     testImplementation 'org.apache.camel:camel-test-spring-junit5:3.11.0'
 
-    docker project(':container-init')
     docker project(':db-init')
 }
 
@@ -97,6 +96,5 @@ tasks.named('lintDockerfile').configure {
 }
 
 tasks.named('dockerComposeUp').configure {
-    dependsOn ':container-init:docker'
     dependsOn ':db-init:docker'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -64,7 +64,6 @@ ext {
                      ':service-python:assessclaimdc6602',
                      ':service-python:pdfgenerator',
                      ':service-data-access',
-                     ':container-init',
                      ':db-init']
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -73,7 +73,6 @@ dependencyResolutionManagement {
 rootProject.name = 'abd_vro'
 include ':api'
 include ':app'
-include ':container-init'
 include ':controller'
 include ':docs'
 include ':db-init'


### PR DESCRIPTION
# Feature Name <!-- replace this with the feature/bug name -->

## Description

<!-- you don't need to write anything here -->

### What was the problem?

<!-- brief description of how things worked before this PR -->

init-container image has `critical` SecRel alerts.

The image is [not needed](https://dsva.slack.com/archives/C01Q7979Z7D/p1662589199987369).

### How does this fix it?

<!-- brief description of how things will work after this PR -->
Removes init-container image from SecRel processing
