### PR TITLE
Ignore files copied from abd-vro-dev-secrets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,10 @@
 #Ignoring the password file
 all-secrets.txt
 
+# Files copied from repo abd-vro-dev-secrets
+private.pem
+setenv.sh
+
 #Ignoring cache folders
 .cache
 

--- a/service-data-access/.gitignore
+++ b/service-data-access/.gitignore
@@ -28,10 +28,6 @@ target/
 !**/src/main/**/target/
 !**/src/test/**/target/
 
-### Gradle ###
-
-!gradle/wrapper/gradle-wrapper.jar
-
 ### STS ###
 .apt_generated
 .classpath
@@ -62,12 +58,3 @@ build/
 
 ### Mac artifacts ###
 .DS_Store
-
-### Gradle
-.gradle
-
-### Build result
-
-src/main/resources/private.pem
-bin/
-!bin/entryppoint.sh


### PR DESCRIPTION
# Feature Name <!-- replace this with the feature/bug name -->

## Description

<!-- you don't need to write anything here -->

### What was the problem?

<!-- brief description of how things worked before this PR -->
Instructions at https://github.com/department-of-veterans-affairs/abd-vro-dev-secrets state "copy the files in this repo to abd-vro project" but these files should be ignored for this repo

### How does this fix it?

<!-- brief description of how things will work after this PR -->
Ignore these files copied from abd-vro-dev-secrets

