### PR TITLE
Trigger mirror action when tag is created

### DIFF
--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -10,7 +10,8 @@ on:
   push:
     branches: [ main, develop ]
 
-  # When a Git reference (Git branch or tag) is deleted
+  # When a Git reference (Git branch or tag) is created or deleted
+  create:
   delete:
 
   # Allow manual triggering


### PR DESCRIPTION
# Feature Name <!-- replace this with the feature/bug name -->

## Description

<!-- you don't need to write anything here -->

### What was the problem?

<!-- brief description of how things worked before this PR -->
Releases created in the internal repo were being un-published (returned to the `draft` state) when the mirror action ran, which deleted the tag associated with the release.

### How does this fix it?

<!-- brief description of how things will work after this PR -->

Trigger mirror action when tag is created.
Updated instructions at [Secure Release process](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process):
> Create a [tag in the public repo](https://github.com/department-of-veterans-affairs/abd-vro/tags) -- this will trigger the Mirror action. Wait for the [tag to appear in the internal repo](https://github.com/department-of-veterans-affairs/abd-vro-internal/tags). Then create a [GitHub Release associated with that tag in this internal repo](https://github.com/department-of-veterans-affairs/abd-vro-internal/releases) to trigger the SecRel pipeline along with signing the docker images and setting up continuous monitoring of that release.
