### PR TITLE
Error message for missing evidence

### DIFF
--- a/service-python/assessclaimdc6602/src/lib/main.py
+++ b/service-python/assessclaimdc6602/src/lib/main.py
@@ -19,17 +19,17 @@ def assess_asthma(event: Dict):
 
     if validation_results["is_valid"]:
         active_medications = medication.medication_required(event)
+
+        response_body.update(
+            {
+                "evidence": {
+                    "medications": active_medications,
+                }
+            }
+        )
+
     else:
-        active_medications = []
         logging.info(validation_results["errors"])
         response_body["errorMessage"] = "error validating request message data"
-
-    response_body.update(
-        {
-            "evidence": {
-                "medications": active_medications,
-            }
-        }
-    )
 
     return response_body

--- a/service-python/assessclaimdc7101/src/lib/main.py
+++ b/service-python/assessclaimdc7101/src/lib/main.py
@@ -24,20 +24,17 @@ def assess_hypertension(event: Dict):
             event
         )
         valid_bp_readings = bp_filter.bp_recency(event)
+        response_body.update(
+            {
+                "evidence": {
+                    "medications": relevant_medication,
+                    "bp_readings": valid_bp_readings,
+                }
+            }
+        )
 
     else:
-        relevant_medication = []
-        valid_bp_readings = []
         logging.info(validation_results["errors"])
         response_body["errorMessage"] = "error validating request message data"
-
-    response_body.update(
-        {
-            "evidence": {
-                "medications": relevant_medication,
-                "bp_readings": valid_bp_readings,
-            }
-        }
-    )
 
     return response_body

--- a/service-python/tests/assessclaim/dc7101/main_test.py
+++ b/service-python/tests/assessclaim/dc7101/main_test.py
@@ -199,7 +199,6 @@ from assessclaimdc7101.src.lib import main
                 }
             },
             {
-                "evidence": {"medications": [], "bp_readings": []},
                 "errorMessage": "error validating request message data",
             },
         ),
@@ -251,7 +250,6 @@ from assessclaimdc7101.src.lib import main
                 "date_of_claim": "2021-11-09",
             },
             {
-                "evidence": {"medications": [], "bp_readings": []},
                 "errorMessage": "error validating request message data",
             },
         ),


### PR DESCRIPTION
# Feature Name <!-- replace this with the feature/bug name -->

## Description

<!-- you don't need to write anything here -->

### What was the problem?
Before the python services returned empty `evidence` fields so that the exception handling in VroController never took affect. 
<!-- brief description of how things worked before this PR -->

### How does this fix it?
Now the python services return only the error message so that the exception will catch that there is no evidence in the response. 
<!-- brief description of how things will work after this PR -->

### Jira Tickets

<!-- replace "000" with ticket number in both places -->

- [MCP-1868](https://amida.atlassian.net/browse/MCP-1868)

## How to test this PR

- Step 1
- Try a non existent ICN (ex:99) for the full-health-assessment endpoint
- Step 2 

## Reminders

- Review [Pull-Requests](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests) guidelines
- [ ] If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) and
[Roadmap](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Roadmap) wiki pages
- [ ] If changing software behavior, post a link to the PR in Slack channel #benefits-virtual-regional-office
