### PR TITLE
Workaround for Dependabot failing on build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,8 @@ name: Build
 on:
   # Trigger on all pull requests
   pull_request:
+    branches-ignore:
+      - "dependabot/**"
     branches:
       - "*"
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,8 +5,6 @@ on:
   pull_request:
     branches-ignore:
       - "dependabot/**"
-    branches:
-      - "*"
 
   # Workaround for Dependabot PRs
   # See https://github.com/dependabot/dependabot-core/issues/3253

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,12 @@ on:
     branches:
       - "*"
 
+  # Workaround for Dependabot PRs
+  # See https://github.com/dependabot/dependabot-core/issues/3253
+  pull_request_target:
+    branches:
+      - "dependabot/**"
+
   # Trigger when called by another GitHub Action
   workflow_call:
     secrets:


### PR DESCRIPTION
# Feature Name <!-- replace this with the feature/bug name -->

## Description

<!-- you don't need to write anything here -->

### What was the problem?

<!-- brief description of how things worked before this PR -->

Checks (GitHub Actions) fail on Dependabot-generated PR

Checks fail because Dependabot doesn't have access to the GitHub Actions secrets -- see https://github.com/dependabot/dependabot-core/issues/3253#issuecomment-795101596. 
A workaround is to merging the `develop` branch into the PR or manually committing to the PR branch. See example resolution in [PR #386](https://github.com/department-of-veterans-affairs/abd-vro/pull/386).

### How does this fix it?

<!-- brief description of how things will work after this PR -->

Add `pull_request_target` GH Action trigger for only Dependabot PRs
as suggested by See https://github.com/dependabot/dependabot-core/issues/3253

## How to test this PR

Watch next PR created by Dependabot for build failure
Ensure no problems for all other PRs
