### PR TITLE
add Dependabot secrets.ACCESS_TOKEN

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,10 @@
 version: 2
 updates:
   - package-ecosystem: "github-actions"
+    # Needed for Dependabot-created PRs to retrieve jars from the VA's repo in order to build
+    # See https://github.com/department-of-veterans-affairs/abd-vro/wiki/Dependabot
+    # Set in https://github.com/department-of-veterans-affairs/abd-vro/settings/secrets/dependabot
+    password: ${{secrets.ACCESS_TOKEN}}
     # Workflow files are expected in the relative location `.github/workflows`
     directory: "/"
     # Raise pull requests for updates against this branch
@@ -14,12 +18,14 @@ updates:
       interval: "weekly"
 
   - package-ecosystem: "gradle"
+    password: ${{secrets.ACCESS_TOKEN}}
     directory: "/"
     target-branch: "develop"
     schedule:
       interval: "weekly"
 
   - package-ecosystem: "pip"
+    password: ${{secrets.ACCESS_TOKEN}}
     directory: "/"
     target-branch: "develop"
     schedule:
@@ -27,42 +33,49 @@ updates:
 
   # For Docker ecosystem, we must specify each file because Dependabot doesn't recursive search
   - package-ecosystem: "docker"
+    password: ${{secrets.ACCESS_TOKEN}}
     directory: "/app/src/docker"
     target-branch: "develop"
     schedule:
       interval: "weekly"
 
   - package-ecosystem: "docker"
+    password: ${{secrets.ACCESS_TOKEN}}
     directory: "/postgres/src/docker"
     target-branch: "develop"
     schedule:
       interval: "weekly"
 
   - package-ecosystem: "docker"
+    password: ${{secrets.ACCESS_TOKEN}}
     directory: "/db-init/src/docker"
     target-branch: "develop"
     schedule:
       interval: "weekly"
 
   - package-ecosystem: "docker"
+    password: ${{secrets.ACCESS_TOKEN}}
     directory: "/service-data-access/src/docker"
     target-branch: "develop"
     schedule:
       interval: "weekly"
 
   - package-ecosystem: "docker"
+    password: ${{secrets.ACCESS_TOKEN}}
     directory: "/service-python/pdfgenerator/src/docker"
     target-branch: "develop"
     schedule:
       interval: "weekly"
 
   - package-ecosystem: "docker"
+    password: ${{secrets.ACCESS_TOKEN}}
     directory: "/service-python/assessclaimdc6602/src/docker"
     target-branch: "develop"
     schedule:
       interval: "weekly"
 
   - package-ecosystem: "docker"
+    password: ${{secrets.ACCESS_TOKEN}}
     directory: "/service-python/assessclaimdc7101/src/docker"
     target-branch: "develop"
     schedule:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,14 +3,8 @@ name: Build
 on:
   # Trigger on all pull requests
   pull_request:
-    branches-ignore:
-      - "dependabot/**"
-
-  # Workaround for Dependabot PRs
-  # See https://github.com/dependabot/dependabot-core/issues/3253
-  pull_request_target:
     branches:
-      - "dependabot/**"
+      - "*"
 
   # Trigger when called by another GitHub Action
   workflow_call:


### PR DESCRIPTION
# Feature Name <!-- replace this with the feature/bug name -->

## Description

<!-- you don't need to write anything here -->

### What was the problem?

<!-- brief description of how things worked before this PR -->

Checks (GitHub Actions) fail on Dependabot-generated PR

Checks fail because Dependabot doesn't have access to the GitHub Actions secrets -- see https://github.com/dependabot/dependabot-core/issues/3253#issuecomment-795101596. 
A workaround is to merging the `develop` branch into the PR or manually committing to the PR branch. See example resolution in [PR #386](https://github.com/department-of-veterans-affairs/abd-vro/pull/386).

### How does this fix it?

<!-- brief description of how things will work after this PR -->

Added secret to Dependabot's secrets in https://github.com/department-of-veterans-affairs/abd-vro/settings/secrets/dependabot

Updated Dependabot config to use secret to retrieve jars from the VA's repo in order to build
See https://github.com/department-of-veterans-affairs/abd-vro/wiki/Dependabot

Revert PR #415

## How to test this PR

Watch next PR created by Dependabot for build failure
Ensure no problems for all other PRs
