### PR TITLE
Update Gatling's scala-library version

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -17,6 +17,8 @@ dependencies {
     implementation "org.springframework:spring-beans:${spring_framework_version}"
     implementation "io.github.classgraph:classgraph:${class_graph_version}"
     implementation 'org.scala-lang:scala-library:2.13.9'
+    // force gatling to use updated scala-library without vulnerability
+    gatling 'org.scala-lang:scala-library:2.13.9'
 
     implementation project(':api')
     implementation project(':controller')

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,7 +16,7 @@ camel_version=3.19.0
 
 checkstyle_tool_version=8.36
 flyway_plugin_version=9.2.0
-gatling_plugin_version=3.8.2
+gatling_plugin_version=3.8.4
 grgit_version=4.1.0
 h2_version=2.1.214
 jacoco_tool_version=0.8.7


### PR DESCRIPTION
# Feature Name <!-- replace this with the feature/bug name -->

## Description

<!-- you don't need to write anything here -->

### What was the problem?

<!-- brief description of how things worked before this PR -->

https://github.com/department-of-veterans-affairs/abd-vro-internal/security/code-scanning/333
> Critical severity - Remote Code Execution (RCE) vulnerability in org.scala-lang:scala-library
> Remediation
> Upgrade org.scala-lang:scala-library to version 2.13.9 or higher.

### How does this fix it?

<!-- brief description of how things will work after this PR -->

Forcec gatling to use updated scala-library without the vulnerability

