### PR TITLE
Feature/mcp 1929 remove gradle warnings

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -10,7 +10,6 @@ plugins {
 repositories {
     // Use the plugin portal to apply community plugins in convention plugins.
     gradlePluginPortal()
-    jcenter()
     mavenCentral()
 }
 

--- a/service-data-access/src/main/java/gov/va/vro/abddataaccess/service/AbdDomain.java
+++ b/service-data-access/src/main/java/gov/va/vro/abddataaccess/service/AbdDomain.java
@@ -5,8 +5,18 @@ package gov.va.vro.abddataaccess.service;
  * assessment.
  */
 public enum AbdDomain {
-  MEDICATION,
-  BLOOD_PRESSURE,
-  PROCEDURE,
-  CONDITION;
+  MEDICATION("launch patient/MedicationRequest.read"),
+  BLOOD_PRESSURE("launch patient/Observation.read"),
+  PROCEDURE("launch patient/Procedure.read"),
+  CONDITION("launch patient/Condition.read");
+
+  private final String scope;
+
+  AbdDomain(String scope) {
+    this.scope = scope;
+  }
+
+  public String getScope() {
+    return scope;
+  }
 }

--- a/service-data-access/src/main/java/gov/va/vro/abddataaccess/service/LighthouseApiService.java
+++ b/service-data-access/src/main/java/gov/va/vro/abddataaccess/service/LighthouseApiService.java
@@ -55,46 +55,6 @@ public class LighthouseApiService {
     }
   }
 
-  public enum Scope {
-    OBSERVATION("launch patient/Observation.read"),
-    MEDICATION_REQUEST("launch patient/MedicationRequest.read"),
-    CONDITION("launch patient/Condition.read"),
-    PROCEDURE("launch patient/Procedure.read"),
-    UNKNOWN("");
-
-    private final String scope;
-
-    Scope(String scope) {
-      this.scope = scope;
-    }
-
-    public String getScope() {
-      return scope;
-    }
-
-    /**
-     * Gets the Scope for a given AbdDomain.
-     *
-     * @param domain an {@link AbdDomain}.
-     * @return a Scope.
-     */
-    public static Scope getScope(AbdDomain domain) {
-      log.info("Getting scope for domain {}", domain.name());
-      return switch (domain) {
-        case MEDICATION:
-          yield MEDICATION_REQUEST;
-        case BLOOD_PRESSURE:
-          yield OBSERVATION;
-        case CONDITION:
-          yield CONDITION;
-        case PROCEDURE:
-          yield PROCEDURE;
-        default:
-          yield null;
-      };
-    }
-  }
-
   private static final String PATIENT_CODING = "{\"patient\":\"%s\"}";
 
   @Autowired private LighthouseProperties lhProps;
@@ -110,7 +70,7 @@ public class LighthouseApiService {
    * @throws AbdException when error occurs.
    */
   public String getLighthouseToken(AbdDomain domain, String patientIcn) throws AbdException {
-    String scope = getLighthouseScope(domain);
+    String scope = domain.getScope();
     LighthouseTokenMessage tokenMessage = getToken(patientIcn, scope);
     return "Bearer " + tokenMessage.getAccessToken();
   }
@@ -209,9 +169,5 @@ public class LighthouseApiService {
     requestBody.add("launch", launchCode);
     requestBody.add("scope", scope);
     return new HttpEntity<>(requestBody, headers);
-  }
-
-  private String getLighthouseScope(AbdDomain domain) {
-    return Scope.getScope(domain).getScope();
   }
 }

--- a/service-data-access/src/test/java/gov/va/vro/abddataaccess/service/LighthouseApiServiceTest.java
+++ b/service-data-access/src/test/java/gov/va/vro/abddataaccess/service/LighthouseApiServiceTest.java
@@ -101,10 +101,8 @@ class LighthouseApiServiceTest {
   @Test
   public void testScope() {
     for (AbdDomain domain : AbdDomain.values()) {
-      LighthouseApiService.Scope scope = LighthouseApiService.Scope.getScope(domain);
-      log.info(scope.getScope());
-      assertTrue(scope.getScope().startsWith("launch patient"));
+      log.info(domain.getScope());
+      assertTrue(domain.getScope().startsWith("launch patient"));
     }
-    assertTrue(LighthouseApiService.Scope.UNKNOWN.getScope().isEmpty());
   }
 }


### PR DESCRIPTION
# Feature Name <!-- replace this with the feature/bug name -->

## Gradle Warning Refactor

<!-- you don't need to write anything here -->

### What was the problem?

There was erroneous Gradle warning. But the object that was causing the warning was not really needed.

### How does this fix it?

AbdDomain and Scope enums are merged. There was really no reason for the intermediate Enum Scope.

### Jira Tickets

<!-- replace "000" with ticket number in both places -->

- [MCP-1929](https://amida.atlassian.net/browse/MCP-000)

## How to test this PR

- Use curl or swagger to make sure health-data-assess end point is functional.

## Reminders

- Review [Pull-Requests](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests) guidelines
- [ ] If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) and
[Roadmap](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Roadmap) wiki pages
- [ ] If changing software behavior, post a link to the PR in Slack channel #benefits-virtual-regional-office
