### PR TITLE
revert jackson - fixes swagger ui

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -36,10 +36,6 @@ dependencies {
     implementation 'gov.va.starter:exceptions'
     implementation 'gov.va.starter:open-api'
 
-    // override vulnerable jackson version
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.14.0-rc1'
-    implementation 'com.fasterxml.jackson.core:jackson-core:2.14.0-rc1'
-
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-security'

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,6 +14,7 @@ buildtimetracker_version=0.11.0
 # 3.13 through 3.15 are not compatible with va.starter's spring_boot version
 camel_version=3.19.0
 
+jackson_version=2.13.4
 checkstyle_tool_version=8.36
 flyway_plugin_version=9.2.0
 gatling_plugin_version=3.8.4

--- a/service-data-access/build.gradle
+++ b/service-data-access/build.gradle
@@ -35,8 +35,8 @@ dependencies {
     annotationBom platform("gov.va.starter:starter-bom:${starter_boot_version}")
     checkstyleRules platform("gov.va.starter:checkstyle-bom:${starter_boot_version}")
 
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.14.0-rc1'
-    implementation 'com.fasterxml.jackson.core:jackson-core:2.14.0-rc1'
+    implementation "com.fasterxml.jackson.core:jackson-databind:${jackson_version}"
+    implementation "com.fasterxml.jackson.core:jackson-core:${jackson_version}"
     implementation 'org.springframework.boot:spring-boot-starter-amqp:2.7.4'
     implementation 'org.springframework:spring-web:5.3.23'
     implementation 'ca.uhn.hapi.fhir:hapi-fhir-base:6.1.1'


### PR DESCRIPTION
# Feature Name <!-- replace this with the feature/bug name -->

## Description

<!-- you don't need to write anything here -->

### What was the problem?

Upgrading to the latest jackson libraries breaks swagger ui

### How does this fix it?

Revert jackson libraries

### Jira Tickets

<!-- replace "000" with ticket number in both places -->

- [MCP-000](https://amida.atlassian.net/browse/MCP-000)

## How to test this PR

- Step 1
- Step 2 

## Reminders

- Review [Pull-Requests](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests) guidelines
- [ ] If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) and
[Roadmap](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Roadmap) wiki pages
- [ ] If changing software behavior, post a link to the PR in Slack channel #benefits-virtual-regional-office
