### PR TITLE
Use unshaded ObjectMapper

### DIFF
--- a/app/src/test/java/gov/va/vro/MasControllerTest.java
+++ b/app/src/test/java/gov/va/vro/MasControllerTest.java
@@ -2,6 +2,7 @@ package gov.va.vro;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import gov.va.vro.api.model.mas.ClaimDetail;
 import gov.va.vro.api.model.mas.ClaimDetailConditions;
 import gov.va.vro.api.model.mas.VeteranIdentifiers;
@@ -13,7 +14,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.context.ActiveProfiles;
-import org.testcontainers.shaded.com.fasterxml.jackson.databind.ObjectMapper;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ActiveProfiles("test")


### PR DESCRIPTION
# Feature Name <!-- replace this with the feature/bug name -->

## Description

<!-- you don't need to write anything here -->

### What was the problem?

<!-- brief description of how things worked before this PR -->

Using a `shaded` class.

### How does this fix it?

<!-- brief description of how things will work after this PR -->

Use the `ObjectMapper` class directly