### PR TITLE
Use Alpine-based Docker images

### DIFF
--- a/app/src/docker/Dockerfile
+++ b/app/src/docker/Dockerfile
@@ -10,7 +10,7 @@ RUN mkdir -p /project/build/tomcat && chmod 777 /project/build/tomcat && chmod +
 COPY ${JAR_FILE} vro-app.jar
 EXPOSE 8081
 
-RUN apk --no-cache add curl
+RUN apk --no-cache add curl=7.83.1-r3
 HEALTHCHECK CMD curl --fail http://localhost:8081/health || exit 1
 
 RUN adduser --no-create-home --disabled-password docker

--- a/app/src/docker/Dockerfile
+++ b/app/src/docker/Dockerfile
@@ -1,13 +1,17 @@
 FROM eclipse-temurin:17-jre-alpine
+LABEL org.opencontainers.image.source=https://github.com/department-of-veterans-affairs/abd-vro
+
 ARG JAR_FILE
 ARG ENTRYPOINT_FILE
+
 WORKDIR /project
 COPY ${ENTRYPOINT_FILE} entrypoint.sh
 RUN mkdir -p /project/build/tomcat && chmod 777 /project/build/tomcat && chmod +x entrypoint.sh
 COPY ${JAR_FILE} vro-app.jar
 EXPOSE 8081
+
+RUN apk --no-cache add curl
 HEALTHCHECK CMD curl --fail http://localhost:8081/health || exit 1
-LABEL org.opencontainers.image.source=https://github.com/department-of-veterans-affairs/abd-vro
 
 RUN adduser --no-create-home --disabled-password docker
 USER docker

--- a/app/src/docker/Dockerfile
+++ b/app/src/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17-jre
+FROM eclipse-temurin:17-jre-alpine
 ARG JAR_FILE
 ARG ENTRYPOINT_FILE
 WORKDIR /project
@@ -9,6 +9,6 @@ EXPOSE 8081
 HEALTHCHECK CMD curl --fail http://localhost:8081/health || exit 1
 LABEL org.opencontainers.image.source=https://github.com/department-of-veterans-affairs/abd-vro
 
-RUN useradd --no-create-home someuser
-USER someuser
+RUN adduser --no-create-home --disabled-password docker
+USER docker
 CMD ["sh", "entrypoint.sh"]

--- a/db-init/src/docker/Dockerfile
+++ b/db-init/src/docker/Dockerfile
@@ -1,10 +1,10 @@
-FROM flyway/flyway:9.3.1
+FROM flyway/flyway:9.3.1-alpine
 LABEL org.opencontainers.image.source=https://github.com/department-of-veterans-affairs/abd-vro
 COPY database /flyway/sql
 COPY flyway.conf /flyway/conf
 HEALTHCHECK NONE
 
-RUN useradd --no-create-home docker
+RUN adduser --no-create-home --disabled-password docker
 USER docker
 
 CMD [ "migrate", "-X" ]

--- a/db-init/src/docker/Dockerfile
+++ b/db-init/src/docker/Dockerfile
@@ -1,10 +1,11 @@
 FROM flyway/flyway:9.3.1-alpine
 LABEL org.opencontainers.image.source=https://github.com/department-of-veterans-affairs/abd-vro
+
 COPY database /flyway/sql
 COPY flyway.conf /flyway/conf
+
 HEALTHCHECK NONE
 
 RUN adduser --no-create-home --disabled-password docker
 USER docker
-
 CMD [ "migrate", "-X" ]

--- a/service-data-access/src/docker/Dockerfile
+++ b/service-data-access/src/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17-jre
+FROM eclipse-temurin:17-jre-alpine
 LABEL org.opencontainers.image.source=https://github.com/department-of-veterans-affairs/abd-vro
 ARG JAR_FILE
 ARG ENTRYPOINT_FILE
@@ -6,6 +6,6 @@ WORKDIR /project
 COPY ${ENTRYPOINT_FILE} entrypoint.sh
 RUN chmod +x entrypoint.sh
 COPY ${JAR_FILE} service-data-access.jar
-RUN adduser --home /home/docker docker
+RUN adduser --no-create-home --disabled-password docker
 USER docker
 CMD ["sh", "entrypoint.sh"]

--- a/service-data-access/src/docker/Dockerfile
+++ b/service-data-access/src/docker/Dockerfile
@@ -1,11 +1,14 @@
 FROM eclipse-temurin:17-jre-alpine
 LABEL org.opencontainers.image.source=https://github.com/department-of-veterans-affairs/abd-vro
+
 ARG JAR_FILE
 ARG ENTRYPOINT_FILE
+
 WORKDIR /project
 COPY ${ENTRYPOINT_FILE} entrypoint.sh
 RUN chmod +x entrypoint.sh
 COPY ${JAR_FILE} service-data-access.jar
+
 RUN adduser --no-create-home --disabled-password docker
 USER docker
 CMD ["sh", "entrypoint.sh"]


### PR DESCRIPTION
# Feature Name <!-- replace this with the feature/bug name -->

## Description

<!-- you don't need to write anything here -->

### What was the problem?

<!-- brief description of how things worked before this PR -->

Some Dockerfiles use Alpine as the base image and others don't. Let's be consistent.
https://www.techtarget.com/searchitoperations/tutorial/Use-Docker-and-Alpine-Linux-to-build-lightweight-containers

### How does this fix it?

<!-- brief description of how things will work after this PR -->

Make Dockerfiles consistent and use Alpine-based images.