### PR TITLE
Clean up build.gradle files with dependency constraints

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -6,13 +6,13 @@ dependencies {
     annotationBom platform("gov.va.starter:starter-bom:${starter_boot_version}")
     checkstyleRules platform("gov.va.starter:checkstyle-bom:${starter_boot_version}")
 
-    // override starter-bom
+    implementation project(':domain')
+
+    // override starter-bom to use versions without vulnerabilities
     implementation "org.springframework.boot:spring-boot-dependencies:${spring_boot_version}"
     implementation "org.springframework:spring-webmvc:${spring_framework_version}"
 
     implementation 'io.micrometer:micrometer-core'
     implementation 'gov.va.starter:exceptions'
-
-    implementation project(':domain')
 }
 

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -3,9 +3,6 @@ plugins {
 }
 
 dependencies {
-    annotationBom platform("gov.va.starter:starter-bom:${starter_boot_version}")
-    checkstyleRules platform("gov.va.starter:checkstyle-bom:${starter_boot_version}")
-
     implementation project(':domain')
 
     implementation 'io.micrometer:micrometer-core'

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -8,10 +8,6 @@ dependencies {
 
     implementation project(':domain')
 
-    // override starter-bom to use versions without vulnerabilities
-    implementation "org.springframework.boot:spring-boot-dependencies:${spring_boot_version}"
-    implementation "org.springframework:spring-webmvc:${spring_framework_version}"
-
     implementation 'io.micrometer:micrometer-core'
     implementation 'gov.va.starter:exceptions'
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,16 +11,13 @@ dependencies {
     annotationBom platform("gov.va.starter:starter-bom:${starter_boot_version}")
     checkstyleRules platform("gov.va.starter:checkstyle-bom:${starter_boot_version}")
 
-    // override starter-bom
-    implementation "org.springframework.boot:spring-boot-dependencies:${spring_boot_version}"
-    implementation "org.springframework:spring-webmvc:${spring_framework_version}"
-    implementation "org.springframework:spring-beans:${spring_framework_version}"
-    implementation "io.github.classgraph:classgraph:${class_graph_version}"
-    implementation "org.scala-lang:scala-library:${scala_version}"
-    // force gatling and zinc to use updated scala-library without vulnerability
-    gatling "org.scala-lang:scala-library:${scala_version}"
-    gatlingImplementation "org.scala-lang:scala-library:${scala_version}"
-    zinc "org.scala-lang:scala-library:${scala_version}"
+    // constrain gatling and zinc to use updated scala-library without vulnerability
+    constraints {
+        implementation "org.scala-lang:scala-library:${scala_version}"
+        gatling "org.scala-lang:scala-library:${scala_version}"
+        gatlingImplementation "org.scala-lang:scala-library:${scala_version}"
+        zinc "org.scala-lang:scala-library:${scala_version}"
+    }
 
     implementation project(':domain')
     implementation project(':api')
@@ -58,12 +55,6 @@ project.gradle.startParameter.excludedTaskNames.add('compileGatlingJava')
 project.gradle.startParameter.excludedTaskNames.add('compileGatlingScala')
 project.gradle.startParameter.excludedTaskNames.add('processGatlingResources')
 project.gradle.startParameter.excludedTaskNames.add('checkstyleGatling')
-
-configurations.all {
-    resolutionStrategy.dependencySubstitution {
-        substitute module("org.yaml:snakeyaml") using module("org.yaml:snakeyaml:1.33")
-    }
-}
 
 application {
     // Define the main class for the application.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -27,11 +27,12 @@ dependencies {
     implementation project(':service:spi')
     implementation project(':service:db')
 
-    implementation 'gov.va.starter:health'
-    implementation 'gov.va.starter:tracing'
-    implementation 'gov.va.starter:error-handling'
-    implementation 'gov.va.starter:exceptions'
     implementation 'gov.va.starter:open-api'
+    // Needed?
+    // implementation 'gov.va.starter:health'
+    // implementation 'gov.va.starter:tracing'
+    // implementation 'gov.va.starter:error-handling'
+    // implementation 'gov.va.starter:exceptions'
 
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
@@ -39,12 +40,16 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 
-    testRuntimeOnly "com.h2database:h2:${h2_version}"
-    implementation "org.postgresql:postgresql:${postgresql_version}"
+    // Needed?
+    // implementation "org.postgresql:postgresql:${postgresql_version}"
     runtimeOnly "org.postgresql:postgresql:${postgresql_version}"
-    testImplementation "org.testcontainers:junit-jupiter:${testcontainers_version}"
-    testImplementation "org.testcontainers:postgresql:${testcontainers_version}"
-    //This version is compatible with current spring version: 5.3.8
+
+    testRuntimeOnly "com.h2database:h2:${h2_version}"
+    // Needed?
+    // testImplementation "org.testcontainers:junit-jupiter:${testcontainers_version}"
+    // testImplementation "org.testcontainers:postgresql:${testcontainers_version}"
+
+    // This version is compatible with current spring version: 5.3.8
     testImplementation "org.apache.camel:camel-test-spring-junit5:${camel_version}"
 
     docker project(':db-init')
@@ -116,5 +121,3 @@ tasks.named('lintDockerfile').configure {
 tasks.named('dockerComposeUp').configure {
     dependsOn ':db-init:docker'
 }
-
-

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,9 +8,6 @@ plugins {
 }
 
 dependencies {
-    annotationBom platform("gov.va.starter:starter-bom:${starter_boot_version}")
-    checkstyleRules platform("gov.va.starter:checkstyle-bom:${starter_boot_version}")
-
     // constrain gatling and zinc to use updated scala-library without vulnerability
     constraints {
         implementation "org.scala-lang:scala-library:${scala_version}"

--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ allprojects {
     gradleLint {
         alwaysRun = false
         reportFormat = 'text'
-        rules  = [
+        rules = [
                 'unused-dependency',
                 'dependency-parentheses',
                 'archaic-wrapper',
@@ -66,6 +66,18 @@ allprojects {
             if (name.startsWith("incrementalScalaAnalysis")) {
                 extendsFrom = []
             }
+        }
+    }
+}
+
+subprojects {
+    apply plugin:  "java"
+    dependencies {
+        // override starter-bom to use versions without vulnerabilities
+        constraints {
+            implementation "org.springframework.boot:spring-boot-dependencies:${spring_boot_version}"
+            implementation "org.springframework:spring-webmvc:${spring_framework_version}"
+            implementation "org.yaml:snakeyaml:1.33"
         }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,7 @@ plugins {
     id("org.springdoc.openapi-gradle-plugin") version "${openapi_gradle_plugin_version}" apply false
     id("org.flywaydb.flyway") version "${flyway_plugin_version}" apply false
     id("com.felipefzdz.gradle.shellcheck") version "${shellcheck_plugin_version}" apply false
+    id 'nebula.lint' version '17.7.0' apply false
     id("org.barfuin.gradle.jacocolog") version "${jacocolog_plugin_version}" apply false
     id("org.barfuin.gradle.taskinfo") version "${taskinfo_plugin_version}"
     id("starter.java.build-utils-property-conventions") version "${starter_boot_version}"
@@ -40,6 +41,33 @@ plugins {
     id("starter.java.test-jacoco-aggregation-conventions") version "${starter_boot_version}"
     id('starter.java.doc-mkdocs-conventions') version "${starter_boot_version}"
     id("pl.allegro.tech.build.axion-release") version "${axion_release_plugin_version}"
+}
+
+allprojects {
+    apply plugin: 'nebula.lint'
+    gradleLint {
+        alwaysRun = false
+        reportFormat = 'text'
+        rules  = [
+                'unused-dependency',
+                'dependency-parentheses',
+                'archaic-wrapper',
+                'all-nebula-renames'
+                ]
+        // criticalRules will fail the build in the event of a violation
+        criticalRules = []
+    }
+
+    afterEvaluate {
+        // Workaround for gradleLint failure
+        // https://github.com/nebula-plugins/gradle-lint-plugin/issues/336#issuecomment-844989277
+        // https://github.com/gradle/gradle/issues/6854
+        configurations.all {
+            if (name.startsWith("incrementalScalaAnalysis")) {
+                extendsFrom = []
+            }
+        }
+    }
 }
 
 ext {

--- a/build.gradle
+++ b/build.gradle
@@ -79,6 +79,7 @@ subprojects {
             implementation "org.springframework:spring-webmvc:${spring_framework_version}"
             implementation "org.springframework:spring-beans:${spring_framework_version}"
             implementation "io.github.classgraph:classgraph:${class_graph_version}"
+            implementation "com.squareup.okhttp3:okhttp:4.10.0"
             implementation "org.yaml:snakeyaml:1.33"
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -73,7 +73,7 @@ allprojects {
 subprojects {
     apply plugin: "java"
     dependencies {
-        // constrain starter-bom to use versions without vulnerabilities
+        // constrain starter-bom transitive dependencies to use versions without vulnerabilities
         constraints {
             implementation "org.springframework.boot:spring-boot-dependencies:${spring_boot_version}"
             implementation "org.springframework:spring-webmvc:${spring_framework_version}"

--- a/build.gradle
+++ b/build.gradle
@@ -72,7 +72,11 @@ allprojects {
 
 subprojects {
     apply plugin: "java"
+    apply plugin: 'starter.java.config-conventions'
     dependencies {
+        annotationBom platform("gov.va.starter:starter-bom:${starter_boot_version}")
+        checkstyleRules platform("gov.va.starter:checkstyle-bom:${starter_boot_version}")
+
         // constrain starter-bom transitive dependencies to use versions without vulnerabilities
         constraints {
             implementation "org.springframework.boot:spring-boot-dependencies:${spring_boot_version}"

--- a/build.gradle
+++ b/build.gradle
@@ -71,7 +71,7 @@ allprojects {
 }
 
 subprojects {
-    apply plugin:  "java"
+    apply plugin: "java"
     dependencies {
         // constrain starter-bom to use versions without vulnerabilities
         constraints {

--- a/build.gradle
+++ b/build.gradle
@@ -73,10 +73,12 @@ allprojects {
 subprojects {
     apply plugin:  "java"
     dependencies {
-        // override starter-bom to use versions without vulnerabilities
+        // constrain starter-bom to use versions without vulnerabilities
         constraints {
             implementation "org.springframework.boot:spring-boot-dependencies:${spring_boot_version}"
             implementation "org.springframework:spring-webmvc:${spring_framework_version}"
+            implementation "org.springframework:spring-beans:${spring_framework_version}"
+            implementation "io.github.classgraph:classgraph:${class_graph_version}"
             implementation "org.yaml:snakeyaml:1.33"
         }
     }

--- a/controller/build.gradle
+++ b/controller/build.gradle
@@ -13,10 +13,10 @@ dependencies {
     implementation project(':service:spi')
 
     implementation "gov.va.starter:exceptions"
-    implementation "gov.va.starter:entity-lifecycle-notifier"
-    implementation 'org.springframework.boot:spring-boot-starter-web'
-    implementation 'org.springframework.boot:spring-boot-starter-actuator'
-
-    implementation "io.opentracing.contrib:opentracing-spring-web-starter"
-    implementation 'gov.va.starter:test-data'
+    // Needed?
+    // implementation 'gov.va.starter:test-data'
+    // implementation "gov.va.starter:entity-lifecycle-notifier"
+    // implementation 'org.springframework.boot:spring-boot-starter-web'
+    // implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    // implementation "io.opentracing.contrib:opentracing-spring-web-starter"
 }

--- a/controller/build.gradle
+++ b/controller/build.gradle
@@ -4,9 +4,6 @@ plugins {
 }
 
 dependencies {
-    annotationBom platform("gov.va.starter:starter-bom:${starter_boot_version}")
-    checkstyleRules platform("gov.va.starter:checkstyle-bom:${starter_boot_version}")
-
     implementation project(':domain')
     implementation project(':api')
     implementation project(':service:provider')

--- a/controller/build.gradle
+++ b/controller/build.gradle
@@ -7,10 +7,6 @@ dependencies {
     annotationBom platform("gov.va.starter:starter-bom:${starter_boot_version}")
     checkstyleRules platform("gov.va.starter:checkstyle-bom:${starter_boot_version}")
 
-    // override starter-bom
-    implementation "org.springframework.boot:spring-boot-dependencies:${spring_boot_version}"
-    implementation "org.springframework:spring-webmvc:${spring_framework_version}"
-
     implementation project(':domain')
     implementation project(':api')
     implementation project(':service:provider')
@@ -23,5 +19,4 @@ dependencies {
 
     implementation "io.opentracing.contrib:opentracing-spring-web-starter"
     implementation 'gov.va.starter:test-data'
-
 }

--- a/domain/build.gradle
+++ b/domain/build.gradle
@@ -2,17 +2,8 @@ plugins {
     id 'starter.std.java.library-spring-conventions'
 }
 
-configurations.all {
-    resolutionStrategy.dependencySubstitution {
-        substitute module("org.yaml:snakeyaml") using module("org.yaml:snakeyaml:1.33")
-    }
-}
-
 dependencies {
     annotationBom platform("gov.va.starter:starter-bom:${starter_boot_version}")
     checkstyleRules platform("gov.va.starter:checkstyle-bom:${starter_boot_version}")
-
-    // override starter-bom to use versions without vulnerabilities
-    implementation "com.squareup.okhttp3:okhttp:4.10.0"
 }
 

--- a/domain/build.gradle
+++ b/domain/build.gradle
@@ -3,7 +3,5 @@ plugins {
 }
 
 dependencies {
-    annotationBom platform("gov.va.starter:starter-bom:${starter_boot_version}")
-    checkstyleRules platform("gov.va.starter:checkstyle-bom:${starter_boot_version}")
 }
 

--- a/persistence/model/build.gradle
+++ b/persistence/model/build.gradle
@@ -7,10 +7,6 @@ dependencies {
     annotationBom platform("gov.va.starter:starter-bom:${starter_boot_version}")
     checkstyleRules platform("gov.va.starter:checkstyle-bom:${starter_boot_version}")
 
-    // override starter-bom
-    implementation "org.springframework.boot:spring-boot-dependencies:${spring_boot_version}"
-    implementation "org.springframework:spring-webmvc:${spring_framework_version}"
-    implementation "org.springframework:spring-beans:${spring_framework_version}"
     implementation "org.apache.camel.springboot:camel-spring-boot-starter:${camel_version}"
 
     // include jdbc tracing here since we are assuming for this version we are using JDBC SQL

--- a/persistence/model/build.gradle
+++ b/persistence/model/build.gradle
@@ -4,9 +4,6 @@ plugins {
 
 
 dependencies {
-    annotationBom platform("gov.va.starter:starter-bom:${starter_boot_version}")
-    checkstyleRules platform("gov.va.starter:checkstyle-bom:${starter_boot_version}")
-
     // Needed?
     // implementation "org.apache.camel.springboot:camel-spring-boot-starter:${camel_version}"
     // implementation 'gov.va.starter:test-data'

--- a/persistence/model/build.gradle
+++ b/persistence/model/build.gradle
@@ -7,11 +7,13 @@ dependencies {
     annotationBom platform("gov.va.starter:starter-bom:${starter_boot_version}")
     checkstyleRules platform("gov.va.starter:checkstyle-bom:${starter_boot_version}")
 
-    implementation "org.apache.camel.springboot:camel-spring-boot-starter:${camel_version}"
+    // Needed?
+    // implementation "org.apache.camel.springboot:camel-spring-boot-starter:${camel_version}"
+    // implementation 'gov.va.starter:test-data'
 
     // include jdbc tracing here since we are assuming for this version we are using JDBC SQL
-    implementation "io.opentracing.contrib:opentracing-spring-cloud-jdbc-starter"
+    // implementation "io.opentracing.contrib:opentracing-spring-cloud-jdbc-starter"
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+
     testImplementation "com.h2database:h2:${h2_version}"
-    implementation 'gov.va.starter:test-data'
 }

--- a/service-data-access/build.gradle
+++ b/service-data-access/build.gradle
@@ -31,9 +31,6 @@ sourceSets {
 }
 
 dependencies {
-    annotationBom platform("gov.va.starter:starter-bom:${starter_boot_version}")
-    checkstyleRules platform("gov.va.starter:checkstyle-bom:${starter_boot_version}")
-
     implementation "com.fasterxml.jackson.core:jackson-databind:${jackson_version}"
     implementation "com.fasterxml.jackson.core:jackson-core:${jackson_version}"
     implementation 'org.springframework.boot:spring-boot-starter-amqp:2.7.4'

--- a/service-data-access/build.gradle
+++ b/service-data-access/build.gradle
@@ -44,20 +44,23 @@ dependencies {
     }
     implementation 'org.bouncycastle:bcprov-jdk15on:1.70'
     implementation 'org.projectlombok:lombok:1.18.24'
-    implementation 'org.springframework.boot:spring-boot-configuration-processor:2.7.4'
     implementation 'org.apache.commons:commons-lang3:3.12.0'
     implementation 'io.jsonwebtoken:jjwt:0.9.1'
-    implementation 'com.auth0:java-jwt:4.0.0'
+    // Needed?
+    // implementation 'org.springframework.boot:spring-boot-configuration-processor:2.7.4'
+    // implementation 'com.auth0:java-jwt:4.0.0'
 
-    testImplementation 'org.springframework.boot:spring-boot-starter-test:2.7.4'
-    testImplementation "org.apache.camel.springboot:camel-spring-boot-starter:${camel_version}"
     testImplementation "org.apache.camel.springboot:camel-rabbitmq-starter:${camel_version}"
-    testImplementation "org.apache.camel.springboot:camel-jackson-starter:${camel_version}"
-    testImplementation 'org.skyscreamer:jsonassert:1.5.1'
-    testImplementation 'org.mockito:mockito-junit-jupiter:4.8.0'
+    // Needed?
+    // testImplementation 'org.springframework.boot:spring-boot-starter-test:2.7.4'
+    // testImplementation "org.apache.camel.springboot:camel-spring-boot-starter:${camel_version}"
+    // testImplementation "org.apache.camel.springboot:camel-jackson-starter:${camel_version}"
 
-    testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.9.1'
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.1'
+    // Needed?
+    // testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.9.1'
+    // testImplementation 'org.skyscreamer:jsonassert:1.5.1'
+    // testImplementation 'org.mockito:mockito-junit-jupiter:4.8.0'
 
     integrationTestImplementation "org.testcontainers:testcontainers:${testcontainers_version}"
     integrationTestImplementation "org.testcontainers:junit-jupiter:${testcontainers_version}"

--- a/service/db/build.gradle
+++ b/service/db/build.gradle
@@ -6,12 +6,12 @@ dependencies {
     annotationBom platform("gov.va.starter:starter-bom:${starter_boot_version}")
     checkstyleRules platform("gov.va.starter:checkstyle-bom:${starter_boot_version}")
 
+    implementation project(':persistence:model')
+    implementation project(':service:spi')
 
     implementation "gov.va.starter:exceptions"
 
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-    implementation project(':persistence:model')
-    implementation project(':service:spi')
 
     testRuntimeOnly "com.h2database:h2:${h2_version}"
 }

--- a/service/db/build.gradle
+++ b/service/db/build.gradle
@@ -9,7 +9,8 @@ dependencies {
     implementation project(':persistence:model')
     implementation project(':service:spi')
 
-    implementation "gov.va.starter:exceptions"
+    // Needed?
+    // implementation "gov.va.starter:exceptions"
 
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 

--- a/service/db/build.gradle
+++ b/service/db/build.gradle
@@ -3,9 +3,6 @@ plugins {
 }
 
 dependencies {
-    annotationBom platform("gov.va.starter:starter-bom:${starter_boot_version}")
-    checkstyleRules platform("gov.va.starter:checkstyle-bom:${starter_boot_version}")
-
     implementation project(':persistence:model')
     implementation project(':service:spi')
 

--- a/service/db/build.gradle
+++ b/service/db/build.gradle
@@ -6,9 +6,6 @@ dependencies {
     annotationBom platform("gov.va.starter:starter-bom:${starter_boot_version}")
     checkstyleRules platform("gov.va.starter:checkstyle-bom:${starter_boot_version}")
 
-    // override starter-bom
-    implementation "org.springframework.boot:spring-boot-dependencies:${spring_boot_version}"
-    implementation "org.springframework:spring-webmvc:${spring_framework_version}"
 
     implementation "gov.va.starter:exceptions"
 

--- a/service/provider/build.gradle
+++ b/service/provider/build.gradle
@@ -7,9 +7,6 @@ plugins {
 }
 
 dependencies {
-    annotationBom platform("gov.va.starter:starter-bom:${starter_boot_version}")
-    checkstyleRules platform("gov.va.starter:checkstyle-bom:${starter_boot_version}")
-
     implementation project(':persistence:model')
     implementation project(':service:spi')
 

--- a/service/provider/build.gradle
+++ b/service/provider/build.gradle
@@ -13,17 +13,22 @@ dependencies {
     implementation project(':persistence:model')
     implementation project(':service:spi')
 
-    implementation "gov.va.starter:exceptions"
-    implementation 'gov.va.starter:test-data'
+    // Needed?
+    // implementation "gov.va.starter:exceptions"
+    // implementation 'gov.va.starter:test-data'
+
+    implementation 'com.google.guava:guava:31.1-jre'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 
     // Apache Camel
     implementation "org.apache.camel.springboot:camel-spring-boot-starter:${camel_version}"
     implementation "org.apache.camel.springboot:camel-jms-starter:${camel_version}"
     implementation "org.apache.camel.springboot:camel-rabbitmq-starter:${camel_version}"
-    implementation "org.apache.camel.springboot:camel-servlet-starter:${camel_version}"
-    implementation "org.apache.camel.springboot:camel-jackson-starter:${camel_version}"
-    implementation "org.apache.camel.springboot:camel-swagger-java-starter:${camel_version}"
+    // Needed?
+    // implementation "org.apache.camel.springboot:camel-jackson-starter:${camel_version}"
+    // implementation "org.apache.camel.springboot:camel-servlet-starter:${camel_version}"
+    // implementation "org.apache.camel.springboot:camel-swagger-java-starter:${camel_version}"
+
     // Needed to send POST to external API
     implementation "org.apache.camel.springboot:camel-http-starter:${camel_version}"
 

--- a/service/provider/build.gradle
+++ b/service/provider/build.gradle
@@ -10,10 +10,6 @@ dependencies {
     annotationBom platform("gov.va.starter:starter-bom:${starter_boot_version}")
     checkstyleRules platform("gov.va.starter:checkstyle-bom:${starter_boot_version}")
 
-    // override starter-bom
-    implementation "org.springframework.boot:spring-boot-dependencies:${spring_boot_version}"
-    implementation "org.springframework:spring-webmvc:${spring_framework_version}"
-
     implementation "gov.va.starter:exceptions"
     implementation project(':persistence:model')
     implementation project(':service:spi')

--- a/service/provider/build.gradle
+++ b/service/provider/build.gradle
@@ -10,9 +10,10 @@ dependencies {
     annotationBom platform("gov.va.starter:starter-bom:${starter_boot_version}")
     checkstyleRules platform("gov.va.starter:checkstyle-bom:${starter_boot_version}")
 
-    implementation "gov.va.starter:exceptions"
     implementation project(':persistence:model')
     implementation project(':service:spi')
+
+    implementation "gov.va.starter:exceptions"
     implementation 'gov.va.starter:test-data'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 

--- a/service/spi/build.gradle
+++ b/service/spi/build.gradle
@@ -6,8 +6,7 @@ dependencies {
     annotationBom platform("gov.va.starter:starter-bom:${starter_boot_version}")
     checkstyleRules platform("gov.va.starter:checkstyle-bom:${starter_boot_version}")
 
+    implementation project(':domain')
 
     implementation "gov.va.starter:exceptions"
-
-    implementation project(':domain')
 }

--- a/service/spi/build.gradle
+++ b/service/spi/build.gradle
@@ -3,9 +3,6 @@ plugins {
 }
 
 dependencies {
-    annotationBom platform("gov.va.starter:starter-bom:${starter_boot_version}")
-    checkstyleRules platform("gov.va.starter:checkstyle-bom:${starter_boot_version}")
-
     implementation project(':domain')
 
     // implementation "gov.va.starter:exceptions"

--- a/service/spi/build.gradle
+++ b/service/spi/build.gradle
@@ -6,9 +6,6 @@ dependencies {
     annotationBom platform("gov.va.starter:starter-bom:${starter_boot_version}")
     checkstyleRules platform("gov.va.starter:checkstyle-bom:${starter_boot_version}")
 
-    // override starter-bom
-    implementation "org.springframework.boot:spring-boot-dependencies:${spring_boot_version}"
-    implementation "org.springframework:spring-webmvc:${spring_framework_version}"
 
     implementation "gov.va.starter:exceptions"
 

--- a/service/spi/build.gradle
+++ b/service/spi/build.gradle
@@ -8,5 +8,5 @@ dependencies {
 
     implementation project(':domain')
 
-    implementation "gov.va.starter:exceptions"
+    // implementation "gov.va.starter:exceptions"
 }


### PR DESCRIPTION
# Feature Name <!-- replace this with the feature/bug name -->

## Description

<!-- you don't need to write anything here -->

### What was the problem?

<!-- brief description of how things worked before this PR -->

To fix security vulnerabilities, **direct** dependencies were added to update versions of vulnerable **transitive** dependencies. Gradle dependency `constraints` should be used instead so that Gradle subprojects are not unnecessarily directly dependent on them - https://docs.gradle.org/current/userguide/dependency_constraints.html.

### How does this fix it?

<!-- brief description of how things will work after this PR -->

Clean up build.gradle files with dependency `constraints`.
Also re-order for consistency, and comment out unused dependencies.

Used task `generateGradleLintReport` to show unused dependencies:
```
./gradlew generateGradleLintReport

cat */build/reports/gradleLint/*.txt
```

For future PR: If desired, using [rich version constraints](https://docs.gradle.org/current/userguide/rich_versions.html) may be better.

## How to test this PR

Run SecRel with each change to make sure they don't cause SecRel alerts.

https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline

