### PR TITLE
Aqua Trivy action: don't create/scan images

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -49,11 +49,13 @@ jobs:
           format: 'sarif'
           output: 'trivy-rootfs-results.sarif'
           severity: 'CRITICAL,HIGH'
-      - name: Upload rootfs results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v2
-        with:
-          sarif_file: 'trivy-rootfs-results.sarif'
-          category: trivy-rootfs
+# Alerts aren't consistent with SecRel scan alerts,
+# so prevent PR check from failing by not uploading results for now.
+#      - name: Upload rootfs results to GitHub Security tab
+#        uses: github/codeql-action/upload-sarif@v2
+#        with:
+#          sarif_file: 'trivy-rootfs-results.sarif'
+#          category: trivy-rootfs
 
 # Trivy's image scan shows duplicate alerts as the rootfs scan
 # Disabling for now since SecRel does image scans

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -46,8 +46,8 @@ jobs:
         uses: aquasecurity/trivy-action@master
         with:
           scan-type: 'rootfs'
-          format: 'sarif'
-          output: 'trivy-rootfs-results.sarif'
+#          format: 'sarif'
+#          output: 'trivy-rootfs-results.sarif'
           severity: 'CRITICAL,HIGH'
 # Alerts aren't consistent with SecRel scan alerts,
 # so prevent PR check from failing by not uploading results for now.

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -40,7 +40,7 @@ jobs:
       - name: "Set up VRO build env"
         uses: ./.github/actions/setup-vro
       - name: "Build jars and Docker images"
-        run: ./gradlew :app:docker -PGITHUB_ACCESS_TOKEN=${{ env.GITHUB_ACCESS_TOKEN }}
+        run: ./gradlew assemble -PGITHUB_ACCESS_TOKEN=${{ env.GITHUB_ACCESS_TOKEN }}
 
       - name: "Scan rootfs"
         uses: aquasecurity/trivy-action@master


### PR DESCRIPTION
# Feature Name <!-- replace this with the feature/bug name -->

## Description

<!-- you don't need to write anything here -->

### What was the problem?

<!-- brief description of how things worked before this PR -->

SecRel's Aqua scans images on the internal repo. This Trivy action, which runs on PRs, doesn't need to create or scan those images.

Also, Trivy alerts aren't consistent with SecRel scan alerts, so prevent PR check from failing by not uploading results for now.

### How does this fix it?

<!-- brief description of how things will work after this PR -->
For the Aqua Trivy GH Action, don't create/scan images.

Don't upload Trivy results for now. Output the results as a table in the GH Action console.

