### PR TITLE
disable MAS in qa, prod, and sandbox

### DIFF
--- a/app/bin/entrypoint.sh
+++ b/app/bin/entrypoint.sh
@@ -2,7 +2,6 @@
 # prepare the full URL based on the hostname from AWS
 
 exec java -jar \
-  -Dspring.profiles.active=local \
   -Djava.security.egd=file:/dev/./urandom \
   $JAVA_PROFILE \
   $JAVA_OPTS \

--- a/app/src/docker/docker-compose.yml
+++ b/app/src/docker/docker-compose.yml
@@ -28,7 +28,6 @@ services:
     environment:
       RABBITMQ_DEFAULT_USER: ${RABBITMQ_PLACEHOLDERS_USERNAME}
       RABBITMQ_DEFAULT_PASS: ${RABBITMQ_PLACEHOLDERS_USERPASSWORD}
-    restart: on-failure:5
 
   vro-api-redis-service:
     image: redis
@@ -39,7 +38,6 @@ services:
       - internal
     ports:
       - "6379:6379"
-    restart: on-failure:5
     command: redis-server --requirepass ${REDIS_PLACEHOLDERS_PASSWORD}
 
   vro-api-postgres-service:
@@ -62,7 +60,6 @@ services:
       - external
     ports:
       - "5432:5432"
-    restart: on-failure:5
 
   db-init:
     image: va/abd_vro-db-init:latest
@@ -81,7 +78,6 @@ services:
       FLYWAY_PLACEHOLDERS_DB_NAME: ${POSTGRES_DB}
       FLYWAY_PLACEHOLDERS_SCHEMA_NAME: ${POSTGRES_SCHEMA}
       FLYWAY_PLACEHOLDERS_USER_PASSWORD: ${POSTGRES_PASSWORD}
-    restart: on-failure:5
 
   abd_vro:
     image: va/abd_vro-app:latest
@@ -96,6 +92,7 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
       POSTGRES_URL: ${POSTGRES_URL} #jdbc:postgresql://vro-api-postgres-service:5432/vro
       POSTGRES_SCHEMA: claims
+      ENV: ${ENV}
       JAVA_PROFILE: "-Dspring.profiles.include=compose"
       # TODO: move these RabbitMQ configurations into a reusable yaml block
       RABBITMQ_PLACEHOLDERS_HOST: vro-api-rabbit-mq-service
@@ -115,7 +112,6 @@ services:
     networks:
       - internal
       - external
-    restart: on-failure:5
 
   assess-claim-dc7101:
     image: va/abd_vro-assessclaimdc7101:latest
@@ -151,7 +147,6 @@ services:
         condition: service_healthy
     networks:
       - internal
-    restart: on-failure:5
 
   pdf-generator:
     image: va/abd_vro-pdfgenerator:latest
@@ -173,7 +168,6 @@ services:
         condition: service_healthy
     networks:
       - internal
-    restart: on-failure:5
 
   service-data-access:
     image: va/abd_vro-service-data-access:latest
@@ -193,4 +187,4 @@ services:
         condition: service_healthy
     networks:
       - internal
-    restart: on-failure:5
+

--- a/app/src/main/resources/application.yml
+++ b/app/src/main/resources/application.yml
@@ -79,6 +79,8 @@ log4j2:
 spring:
   application:
     name: "abd-vro"
+  profiles:
+    active: ${ENV:default}
   servlet:
     multipart:
       maxFileSize: 25MB

--- a/controller/src/main/java/gov/va/vro/controller/MasController.java
+++ b/controller/src/main/java/gov/va/vro/controller/MasController.java
@@ -7,12 +7,14 @@ import gov.va.vro.service.provider.CamelEntrance;
 import gov.va.vro.service.provider.MasDelays;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Profile;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
 @RestController
 @RequiredArgsConstructor
+@Profile("!qa & !sandbox & !prod")
 public class MasController implements MasResource {
 
   private final CamelEntrance camelEntrance;


### PR DESCRIPTION
# Disable MAS in qa, prod and sandbox

## Description

<!-- you don't need to write anything here -->

### What was the problem?

There will be scans in qa and/or prod and we should disable mas end points there. 

<!-- brief description of how things worked before this PR -->

### How does this fix it?

This makes the MAS controller profile based and disables in qa, prod, and sandbox. In addition

1) Sets spring.profiles.active to $ENV. This is a precursor to using profile based properties files as well. For this PR this is necessary to disable based on profile active for environment.
2) Removes restart properties from docker-compose. We added those during SDE fixes but docker-compose file does not affect environments at all.
3) Also removed active profile local from entrypoint.sh. Local profile properties should not affect the docker image really.

<!-- brief description of how things will work after this PR -->

### Jira Tickets

<!-- replace "000" with ticket number in both places -->

- [MCP-1961](https://amida.atlassian.net/browse/MCP-1961)

## How to test this PR

- Set ENV tp qa and build abd-vro
- Make sure you cannot curl to MAS endpoints
- Set ENV dev
- Make sure you can curl to MAS enpoints

## Reminders

- Review [Pull-Requests](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests) guidelines
- [ ] If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) and
[Roadmap](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Roadmap) wiki pages
- [ ] If changing software behavior, post a link to the PR in Slack channel #benefits-virtual-regional-office
