### PR TITLE
Allow docker to use image caches

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -71,10 +71,6 @@ tasks.dockerPrepare.configure {
     dependsOn(tasks.bootJar)
 }
 
-docker {
-    noCache false
-}
-
 bootJar {
     manifest {
         attributes(

--- a/build.gradle
+++ b/build.gradle
@@ -92,6 +92,14 @@ subprojects {
             implementation "org.yaml:snakeyaml:1.33"
         }
     }
+
+    afterEvaluate {
+        if (tasks.findByName('docker')) {
+            docker {
+                noCache false
+            }
+        }
+    }
 }
 
 ext {


### PR DESCRIPTION
# Feature Name <!-- replace this with the feature/bug name -->

## Description

<!-- you don't need to write anything here -->

### What was the problem?

<!-- brief description of how things worked before this PR -->

Gradle was unnecessarily rebuilding Docker image layers instead of using its cache.

### How does this fix it?

<!-- brief description of how things will work after this PR -->

Allowing docker to use image caches and not forcing it to recreate the same image layer for all projects with the `docker` Gradle task.

## How to test this PR

You can double-check by running `./gradlew :app:docker` and it should say `CACHED` if nothing has changed:
```
#6 [3/7] WORKDIR /project
#6 sha256:60ed93b080ff8a664f6b2614f423ad674ce0b98e8e61f8b33c9fa9b3d1127f68
#6 CACHED

#8 [4/7] COPY entrypoint.sh entrypoint.sh
#8 sha256:0b74e2307f05f49125a38ef5ff143ebd80d5a38471494b144ac2332f3d70931e
#8 CACHED
```

Make a change to the Dockerfile and it should say `DONE` instead.

Revert the change and it should say `CACHED`.