### PR TITLE
GH Actions: use latest major version

### DIFF
--- a/.github/actions/setup-vro/action.yml
+++ b/.github/actions/setup-vro/action.yml
@@ -6,7 +6,7 @@ runs:
   using: composite
   steps:
     - name: "Install Java"
-      uses: actions/setup-java@v3.5.1
+      uses: actions/setup-java@v3
       with:
         distribution: temurin
         java-version: '17'
@@ -15,7 +15,7 @@ runs:
     - uses: ./.github/actions/install-java-tools
 
     - name: "Install Python"
-      uses: actions/setup-python@v4.3.0
+      uses: actions/setup-python@v4
       with:
         python-version: "3.9"
         cache: "pip"


### PR DESCRIPTION
<!-- Ensure the PR title reflects the feature or bug name -->

## What was the problem?
<!-- brief description of how things worked before this PR -->

Our `setup-vro` action yml file requires updating minor and patch version numbers.

## How does this fix it?[^1]
<!-- description of how things will work after this PR -->

Only specify the major version for the `setup-java` and `setup-python` actions since the tagged major version will always be the latest. E.g., in https://github.com/actions/setup-python/tags, v4 is the same commit hash as v4.3.0:
<img width="424" alt="image" src="https://user-images.githubusercontent.com/55255674/195697812-ac14c465-001f-4532-91fc-6876d887a147.png">


[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
