### PR TITLE
Python code: use durable RabbitMQ queues

### DIFF
--- a/service-python/assessclaimdc6602/src/lib/queues.py
+++ b/service-python/assessclaimdc6602/src/lib/queues.py
@@ -33,7 +33,7 @@ def queue_setup(channel):
     channel.exchange_declare(
         exchange=EXCHANGE, exchange_type="direct", durable=True, auto_delete=True
     )
-    channel.queue_declare(queue=SERVICE_QUEUE)
+    channel.queue_declare(queue=SERVICE_QUEUE, durable=True, auto_delete=True)
     channel.queue_bind(queue=SERVICE_QUEUE, exchange=EXCHANGE)
 
     channel.basic_qos(prefetch_count=250)

--- a/service-python/assessclaimdc7101/src/lib/queues.py
+++ b/service-python/assessclaimdc7101/src/lib/queues.py
@@ -36,7 +36,7 @@ def queue_setup(channel):
     channel.exchange_declare(
         exchange=EXCHANGE, exchange_type="direct", durable=True, auto_delete=True
     )
-    channel.queue_declare(queue=SERVICE_QUEUE)
+    channel.queue_declare(queue=SERVICE_QUEUE, durable=True, auto_delete=True)
     channel.queue_bind(queue=SERVICE_QUEUE, exchange=EXCHANGE)
 
     channel.basic_qos(prefetch_count=250)

--- a/service-python/pdfgenerator/examples/generate_pdf.py
+++ b/service-python/pdfgenerator/examples/generate_pdf.py
@@ -12,7 +12,7 @@ connection = pika.BlockingConnection(pika.ConnectionParameters(
                "localhost"))
 channel = connection.channel()
 
-channel.queue_declare(queue=QUEUE_NAME)
+channel.queue_declare(queue=QUEUE_NAME, durable=True, auto_delete=True)
 
 code = "7101"
 

--- a/service-python/pdfgenerator/src/lib/queues.py
+++ b/service-python/pdfgenerator/src/lib/queues.py
@@ -64,11 +64,11 @@ def on_fetch_callback(channel, method, properties, body):
 def queue_setup(channel):
     channel.exchange_declare(exchange=EXCHANGE, exchange_type="direct", durable=True, auto_delete=True)
     # Generate PDF Queue
-    channel.queue_declare(queue=GENERATE_QUEUE)
+    channel.queue_declare(queue=GENERATE_QUEUE, durable=True, auto_delete=True)
     channel.queue_bind(queue=GENERATE_QUEUE, exchange=EXCHANGE)
     channel.basic_consume(queue=GENERATE_QUEUE, on_message_callback=on_generate_callback, auto_ack=True)
     # Fetch PDF Queue
-    channel.queue_declare(queue=FETCH_QUEUE)
+    channel.queue_declare(queue=FETCH_QUEUE, durable=True, auto_delete=True)
     channel.queue_bind(queue=FETCH_QUEUE, exchange=EXCHANGE)
     channel.basic_consume(queue=FETCH_QUEUE, on_message_callback=on_fetch_callback, auto_ack=True)
     logging.info(f" [*] Waiting for data for queue: {GENERATE_QUEUE}. To exit press CTRL+C")

--- a/service/provider/build.gradle
+++ b/service/provider/build.gradle
@@ -21,20 +21,13 @@ dependencies {
     // Apache Camel
     implementation "org.apache.camel.springboot:camel-spring-boot-starter:${camel_version}"
     implementation "org.apache.camel.springboot:camel-jms-starter:${camel_version}"
-    implementation "org.apache.camel.springboot:camel-rabbitmq-starter:${camel_version}"
     implementation "org.apache.camel.springboot:camel-jackson-starter:${camel_version}"
     // Needed?
+    // implementation "org.apache.camel.springboot:camel-rabbitmq-starter:${camel_version}"
     // implementation "org.apache.camel.springboot:camel-jackson-starter:${camel_version}"
     // implementation "org.apache.camel.springboot:camel-servlet-starter:${camel_version}"
     // implementation "org.apache.camel.springboot:camel-swagger-java-starter:${camel_version}"
 
-    // Needed to send POST to external API
-    implementation "org.apache.camel.springboot:camel-http-starter:${camel_version}"
-
-    // To fix jackson error: Java 8 date/time type `java.time.Instant` not supported by default
-    // Also need to set `camel.dataformat.json-jackson.auto-discover-object-mapper: true`
-    // https://stackoverflow.com/questions/33397359/how-to-configure-jackson-objectmapper-for-camel-in-spring-boot
-    runtimeOnly "com.fasterxml.jackson.datatype:jackson-datatype-jsr310"
     implementation project(':domain')
 
 }

--- a/shared/lib-camel-connector/build.gradle
+++ b/shared/lib-camel-connector/build.gradle
@@ -9,7 +9,8 @@ dependencies {
     implementation "org.apache.camel.springboot:camel-rabbitmq-starter:${camel_version}"
     implementation "org.apache.camel.springboot:camel-jackson-starter:${camel_version}"
     // Needed to send POST to external API
-    // implementation "org.apache.camel.springboot:camel-http-starter:${camel_version}"
+    // and to fix org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'swaggerWelcome'
+    implementation "org.apache.camel.springboot:camel-http-starter:${camel_version}"
 
     // To fix jackson error: Java 8 date/time type `java.time.Instant` not supported by default
     // Also need to set `camel.dataformat.json-jackson.auto-discover-object-mapper: true`


### PR DESCRIPTION
<!-- Ensure the PR title reflects the feature or bug name -->

## What was the problem?
<!-- brief description of how things worked before this PR -->

RabbitMQ queues should be `durable`, along with exchanges.

https://hevodata.com/learn/rabbitmq-durable/#:~:text=RabbitMQ%20Durable%20queues%20are%20those,these%20configurations%20must%20be%20true.

## How does this fix it?
<!-- description of how things will work after this PR -->
Declare queue with `durable=True` and `auto_delete=True`, same as exchanges.

Plus some `build.gradle` cleanup

## How to test this PR
Manual testing
