### PR TITLE
MCP-1972 PDF Generator Status Code Update

### DIFF
--- a/api/src/main/java/gov/va/vro/api/resources/VroResource.java
+++ b/api/src/main/java/gov/va/vro/api/resources/VroResource.java
@@ -46,7 +46,7 @@ public interface VroResource {
   @PostMapping("/evidence-pdf")
   @ApiResponses(
       value = {
-        @ApiResponse(responseCode = "201", description = "Successful Request"),
+        @ApiResponse(responseCode = "200", description = "Successful Request"),
         @ApiResponse(
             responseCode = "401",
             description = "Unauthorized",


### PR DESCRIPTION
<!-- Ensure the PR title reflects the feature or bug name -->

## What was the problem?
<!-- brief description of how things worked before this PR -->
Updating `201` status code to match the Swagger doc's `200` for the `POST` PDF Generation Request

Associated tickets or Slack threads:
<!-- replace "000" with ticket number in both places -->
- [MCP-1972](https://amida.atlassian.net/browse/MCP-1972)

## How does this fix it?[^1]
<!-- description of how things will work after this PR -->
Makes it a `200`

## How to test this PR
- Generate a PDF using the `POST` route and response code should be a `200`
- Step 2[^secrel]


[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
