### PR TITLE
Update expat package versions to fix failing SecRel

### DIFF
--- a/app/src/docker/Dockerfile
+++ b/app/src/docker/Dockerfile
@@ -1,7 +1,7 @@
 FROM eclipse-temurin:17-jre-alpine
 LABEL org.opencontainers.image.source=https://github.com/department-of-veterans-affairs/abd-vro
 
-RUN apk update && apk --no-cache add expat=2.4.9-r0 curl=7.83.1-r4
+RUN apk update && apk --no-cache add expat=2.5.0-r0 curl=7.83.1-r4
 
 ARG JAR_FILE
 ARG ENTRYPOINT_FILE

--- a/console/src/docker/Dockerfile
+++ b/console/src/docker/Dockerfile
@@ -1,6 +1,6 @@
 FROM eclipse-temurin:17-jre-alpine
 LABEL org.opencontainers.image.source=https://github.com/department-of-veterans-affairs/abd-vro
-RUN apk update && apk --no-cache add expat=2.4.9-r0
+RUN apk update && apk --no-cache add expat=2.5.0-r0
 
 ARG JAR_FILE
 

--- a/db-init/src/docker/Dockerfile
+++ b/db-init/src/docker/Dockerfile
@@ -2,7 +2,7 @@ FROM flyway/flyway:9.5-alpine
 
 LABEL org.opencontainers.image.source=https://github.com/department-of-veterans-affairs/abd-vro
 
-RUN apk update && apk --no-cache add expat=2.4.9-r0
+RUN apk update && apk --no-cache add expat=2.5.0-r0
 
 COPY database /flyway/sql
 COPY flyway.conf /flyway/conf

--- a/service-python/assessclaimdc6602/src/docker/Dockerfile
+++ b/service-python/assessclaimdc6602/src/docker/Dockerfile
@@ -6,7 +6,7 @@ LABEL org.opencontainers.image.source=https://github.com/department-of-veterans-
 ENV PYTHONDONTWRITEBYTECODE 1
 ENV PYTHONUNBUFFERED 1
 
-RUN apk update && apk --no-cache add expat=2.4.9-r0
+RUN apk update && apk --no-cache add expat=2.5.0-r0
 
 RUN adduser --disabled-password docker
 USER docker

--- a/service-python/assessclaimdc7101/src/docker/Dockerfile
+++ b/service-python/assessclaimdc7101/src/docker/Dockerfile
@@ -6,7 +6,7 @@ LABEL org.opencontainers.image.source=https://github.com/department-of-veterans-
 ENV PYTHONDONTWRITEBYTECODE 1
 ENV PYTHONUNBUFFERED 1
 
-RUN apk update && apk --no-cache add expat=2.4.9-r0
+RUN apk update && apk --no-cache add expat=2.5.0-r0
 
 RUN adduser --disabled-password docker
 USER docker

--- a/svc-lighthouse-api/src/docker/Dockerfile
+++ b/svc-lighthouse-api/src/docker/Dockerfile
@@ -1,7 +1,7 @@
 FROM eclipse-temurin:17-jre-alpine
 LABEL org.opencontainers.image.source=https://github.com/department-of-veterans-affairs/abd-vro
 
-RUN apk update && apk --no-cache add expat=2.4.9-r0
+RUN apk update && apk --no-cache add expat=2.5.0-r0
 
 ARG JAR_FILE
 ARG ENTRYPOINT_FILE


### PR DESCRIPTION
Update package versions in Dockerfiles for app and pdfgenerator to fix failing SecRel

## What was the problem?
Although the expat versions were earlier bumped to 2.5.0-r0, there were still many references in various Dockerfiles trying to run the old version (which was failing SecRel)

Associated tickets or Slack threads:
- [PR 588 from MCP-1939](https://amida.atlassian.net/browse/MCP-000)](https://github.com/department-of-veterans-affairs/abd-vro/pull/588)

## How does this fix it?[^1]
Dockerfiles were updated to use the correct version

## How to test this PR
- Run the branch through SecRel, enjoy the green success status


[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
