### PR TITLE
Camel: assign name to pdfRoute's queue

### DIFF
--- a/service/provider/src/main/java/gov/va/vro/service/provider/camel/PrimaryRoutes.java
+++ b/service/provider/src/main/java/gov/va/vro/service/provider/camel/PrimaryRoutes.java
@@ -120,7 +120,7 @@ public class PrimaryRoutes extends RouteBuilder {
   }
 
   private String pdfRoute(String queueName) {
-    return String.format("rabbitmq:%s?routingKey=%s", PDF_EXCHANGE, queueName);
+    return String.format("rabbitmq:%s?routingKey=%s&queue=%s", PDF_EXCHANGE, queueName, queueName);
   }
 
   private void configureExceptionHandling() {


### PR DESCRIPTION
<!-- Ensure the PR title reflects the feature or bug name -->

## What was the problem?
<!-- brief description of how things worked before this PR -->

If no queue name is provided, Camel assigns a numeric name to the queue for `pdfRoute`, making debugging difficult.

## How does this fix it?
<!-- description of how things will work after this PR -->

Set a name for the queue.

## How to test this PR

View the queue names at http://localhost:15672/#/queues before and after the PR.
Ensure pdf generation and fetching still work.
