### PR TITLE
Update pdf-generator to use Redis hash

### DIFF
--- a/service-python/pdfgenerator/src/lib/queues.py
+++ b/service-python/pdfgenerator/src/lib/queues.py
@@ -31,7 +31,7 @@ def on_generate_callback(channel, method, properties, body):
         # logging.info(f"Variables: {variables}")
         template = pdf_generator.generate_template_file(diagnosis_name, variables)
         pdf = pdf_generator.generate_pdf_from_string(template)
-        redis_client.save_hash_data(f"{claim_id}-pdf", mapping={"contents": base64.b64encode(pdf).decode("ascii"), "type": diagnosis_name})
+        redis_client.save_hash_data(f"{claim_id}-pdf", mapping={"contents": base64.b64encode(pdf).decode("ascii"), "diagnosis": diagnosis_name})
         logging.info("Saved PDF")
         response = {"claimSubmissionId": claim_id, "status": "COMPLETE"}
     except Exception as e:
@@ -48,7 +48,7 @@ def on_fetch_callback(channel, method, properties, body):
         logging.info(f" [x] {binding_key}: Received Claim Submission ID: {claim_id}")
         if redis_client.exists(f"{claim_id}-pdf"):
             pdf = redis_client.get_hash_data(f"{claim_id}-pdf", "contents")
-            diagnosis_name = redis_client.get_hash_data(f"{claim_id}-pdf", "type")
+            diagnosis_name = redis_client.get_hash_data(f"{claim_id}-pdf", "diagnosis")
             logging.info("Fetched PDF")
             response = {"claimSubmissionId": claim_id, "status": "COMPLETE", "diagnosis": str(diagnosis_name.decode("ascii")), "pdfData": str(pdf.decode("ascii"))}
         else:

--- a/service-python/pdfgenerator/src/lib/queues.py
+++ b/service-python/pdfgenerator/src/lib/queues.py
@@ -31,7 +31,7 @@ def on_generate_callback(channel, method, properties, body):
         # logging.info(f"Variables: {variables}")
         template = pdf_generator.generate_template_file(diagnosis_name, variables)
         pdf = pdf_generator.generate_pdf_from_string(template)
-        redis_client.save_hash_data(f"claim-{claim_id}", mapping={"pdf": base64.b64encode(pdf).decode("ascii"), "type": diagnosis_name})
+        redis_client.save_hash_data(f"{claim_id}-pdf", mapping={"contents": base64.b64encode(pdf).decode("ascii"), "type": diagnosis_name})
         logging.info("Saved PDF")
         response = {"claimSubmissionId": claim_id, "status": "COMPLETE"}
     except Exception as e:
@@ -46,9 +46,9 @@ def on_fetch_callback(channel, method, properties, body):
         binding_key = method.routing_key
         claim_id = str(body, 'UTF-8')
         logging.info(f" [x] {binding_key}: Received Claim Submission ID: {claim_id}")
-        if redis_client.exists(f"claim-{claim_id}"):
-            pdf = redis_client.get_hash_data(f"claim-{claim_id}", "pdf")
-            diagnosis_name = redis_client.get_hash_data(f"claim-{claim_id}", "type")
+        if redis_client.exists(f"{claim_id}-pdf"):
+            pdf = redis_client.get_hash_data(f"{claim_id}-pdf", "contents")
+            diagnosis_name = redis_client.get_hash_data(f"{claim_id}-pdf", "type")
             logging.info("Fetched PDF")
             response = {"claimSubmissionId": claim_id, "status": "COMPLETE", "diagnosis": str(diagnosis_name.decode("ascii")), "pdfData": str(pdf.decode("ascii"))}
         else:

--- a/service-python/pdfgenerator/src/lib/queues.py
+++ b/service-python/pdfgenerator/src/lib/queues.py
@@ -31,8 +31,9 @@ def on_generate_callback(channel, method, properties, body):
         # logging.info(f"Variables: {variables}")
         template = pdf_generator.generate_template_file(diagnosis_name, variables)
         pdf = pdf_generator.generate_pdf_from_string(template)
-        redis_client.save_hash_data(claim_id, "pdf", base64.b64encode(pdf).decode("ascii"))
-        redis_client.save_hash_data(claim_id, "type", diagnosis_name)
+        redis_client.save_hash_data(f"claim-{claim_id}", mapping={"pdf": base64.b64encode(pdf).decode("ascii"), "type": diagnosis_name})
+        # redis_client.save_hash_data(claim_id, "pdf", base64.b64encode(pdf).decode("ascii"))
+        # redis_client.save_hash_data(claim_id, "type", diagnosis_name)
         logging.info("Saved PDF")
         response = {"claimSubmissionId": claim_id, "status": "COMPLETE"}
     except Exception as e:
@@ -47,9 +48,9 @@ def on_fetch_callback(channel, method, properties, body):
         binding_key = method.routing_key
         claim_id = str(body, 'UTF-8')
         logging.info(f" [x] {binding_key}: Received Claim Submission ID: {claim_id}")
-        if redis_client.exists(claim_id):
-            pdf = redis_client.get_hash_data(claim_id, "pdf")
-            diagnosis_name = redis_client.get_hash_data(claim_id, "type")
+        if redis_client.exists(f"claim-{claim_id}"):
+            pdf = redis_client.get_hash_data(f"claim-{claim_id}", "pdf")
+            diagnosis_name = redis_client.get_hash_data(f"claim-{claim_id}", "type")
             logging.info("Fetched PDF")
             response = {"claimSubmissionId": claim_id, "status": "COMPLETE", "diagnosis": str(diagnosis_name.decode("ascii")), "pdfData": str(pdf.decode("ascii"))}
         else:

--- a/service-python/pdfgenerator/src/lib/queues.py
+++ b/service-python/pdfgenerator/src/lib/queues.py
@@ -31,8 +31,8 @@ def on_generate_callback(channel, method, properties, body):
         # logging.info(f"Variables: {variables}")
         template = pdf_generator.generate_template_file(diagnosis_name, variables)
         pdf = pdf_generator.generate_pdf_from_string(template)
-        redis_client.save_data(claim_id, base64.b64encode(pdf).decode("ascii"))
-        redis_client.save_data(f"{claim_id}_type", diagnosis_name)
+        redis_client.save_hash_data(claim_id, "pdf", base64.b64encode(pdf).decode("ascii"))
+        redis_client.save_hash_data(claim_id, "type", diagnosis_name)
         logging.info("Saved PDF")
         response = {"claimSubmissionId": claim_id, "status": "COMPLETE"}
     except Exception as e:
@@ -48,8 +48,8 @@ def on_fetch_callback(channel, method, properties, body):
         claim_id = str(body, 'UTF-8')
         logging.info(f" [x] {binding_key}: Received Claim Submission ID: {claim_id}")
         if redis_client.exists(claim_id):
-            pdf = redis_client.get_data(claim_id)
-            diagnosis_name = redis_client.get_data(f"{claim_id}_type")
+            pdf = redis_client.get_hash_data(claim_id, "pdf")
+            diagnosis_name = redis_client.get_hash_data(claim_id, "type")
             logging.info("Fetched PDF")
             response = {"claimSubmissionId": claim_id, "status": "COMPLETE", "diagnosis": str(diagnosis_name.decode("ascii")), "pdfData": str(pdf.decode("ascii"))}
         else:

--- a/service-python/pdfgenerator/src/lib/queues.py
+++ b/service-python/pdfgenerator/src/lib/queues.py
@@ -32,8 +32,6 @@ def on_generate_callback(channel, method, properties, body):
         template = pdf_generator.generate_template_file(diagnosis_name, variables)
         pdf = pdf_generator.generate_pdf_from_string(template)
         redis_client.save_hash_data(f"claim-{claim_id}", mapping={"pdf": base64.b64encode(pdf).decode("ascii"), "type": diagnosis_name})
-        # redis_client.save_hash_data(claim_id, "pdf", base64.b64encode(pdf).decode("ascii"))
-        # redis_client.save_hash_data(claim_id, "type", diagnosis_name)
         logging.info("Saved PDF")
         response = {"claimSubmissionId": claim_id, "status": "COMPLETE"}
     except Exception as e:

--- a/service-python/pdfgenerator/src/lib/redis_client.py
+++ b/service-python/pdfgenerator/src/lib/redis_client.py
@@ -31,3 +31,10 @@ class RedisClient:
 
     def get_data(self, key):
         return self.client.get(key)
+
+    def save_hash_data(self, name, key, value, mapping=None, items=None):
+        self.client.hset(name, key, value, mapping, items)
+        self.client.expire(name, self.config["expiration"])
+
+    def get_hash_data(self, name, key):
+        return self.client.hget(name, key)

--- a/service-python/pdfgenerator/src/lib/redis_client.py
+++ b/service-python/pdfgenerator/src/lib/redis_client.py
@@ -32,7 +32,7 @@ class RedisClient:
     def get_data(self, key):
         return self.client.get(key)
 
-    def save_hash_data(self, name, key, value, mapping=None, items=None):
+    def save_hash_data(self, name, key=None, value=None, mapping=None, items=None):
         self.client.hset(name, key, value, mapping, items)
         self.client.expire(name, self.config["expiration"])
 


### PR DESCRIPTION
## What was the problem?
pdf generator stored multiple related items from a claim in separate keys

[Python code](https://github.com/department-of-veterans-affairs/abd-vro/blob/9a1ad2222ff5bd6c213d8ad3f34ecf7e5827a499/service-python/pdfgenerator/src/lib/redis_client.py#L29) saves the generated PDF doc as a [Redis String](https://redis.io/docs/data-types/#strings) with the lookup key being the claim id. 
1.  The key should probably be more descriptive like `1234-generated_pdf` , where `1234` is the claim id.
2.  The Python code is also saving another Redis String with key `1234_type` and value `hypertension`. Since these 2 Redis String entries are related, I'm wondering if they should be stored as a Redis Hash instead.

## How does this fix it?[^1]
Updates pdf generator to store related items to a single claim under one hash. Behaves as before otherwise.

## How to test this PR
- locally pulled in #614 to use redis in the console container as well
- generate a pdf using swagger (`test-key-01` to authorize locally). check generated submission in swagger also, this should work the same as before.

- inside the console container (`docker attach vro-console-1`), 
```
groovy:000> redis.keys "*"
===> [claim-1234]
groovy:000> redis.hlen("claim-1234")
===> 2
groovy:000> redis.hget("claim-1234", "type")
===> hypertension
groovy:000> redis.hget("claim-1234", "pdf")
===> JVBERi0xLjQKMSAwIG9iago8PAovVGl0bGUgKP7/KQovQ3JlYX ... (truncated base64 encoding of the generated pdf)
```


[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.

