### PR TITLE
Fix java-install-tools action step

### DIFF
--- a/.github/actions/install-java-tools/action.yml
+++ b/.github/actions/install-java-tools/action.yml
@@ -7,7 +7,7 @@ runs:
     # http://man7.org/linux/man-pages/man1/date.1.html
     - name: Get Date
       id: get-date
-      run: echo "today_date=$(/bin/date -u "+%Y%m%d")" >> $GITHUB_ENV
+      run: echo "today_date=$(/bin/date -u "+%Y%m%d")" >> $GITHUB_OUTPUT
       shell: bash
 
     - name: Restore hadolint

--- a/.github/actions/install-java-tools/action.yml
+++ b/.github/actions/install-java-tools/action.yml
@@ -7,7 +7,7 @@ runs:
     # http://man7.org/linux/man-pages/man1/date.1.html
     - name: Get Date
       id: get-date
-      run: echo "name=date::$(/bin/date -u "+%Y%m%d")" >> $GITHUB_ENV
+      run: echo "today_date=$(/bin/date -u "+%Y%m%d")" >> $GITHUB_ENV
       shell: bash
 
     - name: Restore hadolint
@@ -15,7 +15,7 @@ runs:
       id: cache-hadolint
       with:
         path: /usr/local/bin/hadolint
-        key: hadolint-${{ steps.get-date.outputs.date }}
+        key: hadolint-${{ steps.get-date.outputs.today_date }}
 
     - name: Install hadolint
       if: steps.cache-hadolint.outputs.cache-hit != 'true'


### PR DESCRIPTION
<!-- Ensure the PR title reflects the feature or bug name -->

## What was the problem?
<!-- brief description of how things worked before this PR -->

PR #521 incorrectly updated a line, causing the [cache key](https://github.com/department-of-veterans-affairs/abd-vro/actions/caches) to be just `hadolint-`:
<img width="305" alt="image" src="https://user-images.githubusercontent.com/55255674/201222314-34b68a59-0d28-4d72-8e13-4ad711a971d1.png">


## How does this fix it?[^1]
<!-- description of how things will work after this PR -->
Fix the echo command.

## How to test this PR
Check [cache](https://github.com/department-of-veterans-affairs/abd-vro/actions/caches) after the action runs