### PR TITLE
Use gradle-build-action for better caching

### DIFF
--- a/.github/actions/setup-vro/action.yml
+++ b/.github/actions/setup-vro/action.yml
@@ -10,7 +10,15 @@ runs:
       with:
         distribution: temurin
         java-version: '17'
-        cache: 'gradle'
+        # "When using gradle-build-action we recommend that you
+        # not use actions/cache or actions/setup-java@v3 to explicitly
+        # cache the Gradle User Home" so use 'maven' cache setting
+        cache: 'maven'
+
+    - name: "Setup Gradle"
+      uses: gradle/gradle-build-action@v2
+      with:
+        gradle-home-cache-cleanup: true
 
     - uses: ./.github/actions/install-java-tools
 

--- a/.github/actions/setup-vro/action.yml
+++ b/.github/actions/setup-vro/action.yml
@@ -18,7 +18,12 @@ runs:
     - name: "Setup Gradle"
       uses: gradle/gradle-build-action@v2
       with:
-        cache-read-only: false
+        # Only write to the cache for builds on the 'main' and 'develop' branches. (Default is 'main' only.)
+        # Builds on other branches will only read existing entries from the cache.
+        cache-read-only: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/develop' }}
+        # To avoid a growing cache over time, attempt to delete any files in the Gradle User Home
+        # that were not used by Gradle during the workflow, prior to saving the cache.
+        # https://github.com/gradle/gradle-build-action#removing-unused-files-from-gradle-user-home-before-saving-to-cache
         gradle-home-cache-cleanup: true
 
     - uses: ./.github/actions/install-java-tools

--- a/.github/actions/setup-vro/action.yml
+++ b/.github/actions/setup-vro/action.yml
@@ -12,8 +12,8 @@ runs:
         java-version: '17'
         # "When using gradle-build-action we recommend that you
         # not use actions/cache or actions/setup-java@v3 to explicitly
-        # cache the Gradle User Home" so use 'maven' cache setting
-        cache: 'maven'
+        # cache the Gradle User Home"
+        # cache: 'gradle'
 
     - name: "Setup Gradle"
       uses: gradle/gradle-build-action@v2

--- a/.github/actions/setup-vro/action.yml
+++ b/.github/actions/setup-vro/action.yml
@@ -18,6 +18,7 @@ runs:
     - name: "Setup Gradle"
       uses: gradle/gradle-build-action@v2
       with:
+        cache-read-only: false
         gradle-home-cache-cleanup: true
 
     - uses: ./.github/actions/install-java-tools

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,7 @@ jobs:
         # `check` runs hadolint and shellcheck
         run: ./gradlew build check
 
-      - name: "Upload build reports"
+      - name: "Upload gradle reports"
         uses: actions/upload-artifact@v3
         with:
           name: gradle-build-reports

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,6 +40,12 @@ jobs:
         # `check` runs hadolint and shellcheck
         run: ./gradlew build check
 
+      - name: "Upload build reports"
+        uses: actions/upload-artifact@v3
+        with:
+          name: gradle-build-reports
+          path: "**/build/reports/"
+
   build-docker-images:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
<!-- Ensure the PR title reflects the feature or bug name -->

## What was the problem?
<!-- brief description of how things worked before this PR -->

[Our cache](https://github.com/department-of-veterans-affairs/abd-vro/actions/caches) exceeds 10GB and our oldest cache is only 2 days old (except for one 4.5MB 7-day-old cache)
<img width="678" alt="image" src="https://user-images.githubusercontent.com/55255674/201235299-720143af-c3d9-4f04-bac3-9dff80d0a999.png">

This suggest better caching can be done.

## How does this fix it?
<!-- description of how things will work after this PR -->

Try `gradle-build-action` to see if there are any improvements.
https://github.com/gradle/gradle-build-action#why-use-the-gradle-build-action

