### PR TITLE
End2End Test: Wait for VRO to be ready

### DIFF
--- a/.github/workflows/end2end-test.yml
+++ b/.github/workflows/end2end-test.yml
@@ -57,9 +57,19 @@ jobs:
       - name: "Start the containers"
         run: ./gradlew :app:dockerComposeUp
 
-      - name: "Sleep 25 seconds"
-        # it appears app container is not immediately ready
-        run: sleep 25
+      - name: "Sleep 20 seconds"
+        # App container is not immediately ready
+        run: sleep 20
+
+      - name: "Wait for VRO to be ready"
+        uses: nev7n/wait_for_response@v1
+        with:
+          url: 'http://localhost:8081/health'
+          responseCode: 200
+          # Retry every 2 seconds
+          interval: 2000
+          # Quite after 30 seconds
+          timeout: 30000
 
       - name: "Run the end-to-end tests"
         run: ./gradlew :app:end2EndTest --info

--- a/.github/workflows/end2end-test.yml
+++ b/.github/workflows/end2end-test.yml
@@ -57,9 +57,9 @@ jobs:
       - name: "Start the containers"
         run: ./gradlew :app:dockerComposeUp
 
-      - name: "Sleep 20 seconds"
+      - name: "Sleep 15 seconds"
         # App container is not immediately ready
-        run: sleep 20
+        run: sleep 15
 
       - name: "Wait for VRO to be ready"
         uses: nev7n/wait_for_response@v1


### PR DESCRIPTION
<!-- Ensure the PR title reflects the feature or bug name -->

## What was the problem?
<!-- brief description of how things worked before this PR -->
End2End Test [keeps failing](https://dsva.slack.com/archives/C01Q7979Z7D/p1668538190502119)

## How does this fix it?[^1]
<!-- description of how things will work after this PR -->

Poll VRO until it's ready

## How to test this PR
Check on the End2EndTest Action

[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
