### PR TITLE
Allow deploying SecRel images to dev and qa; Fix SecRel-built Java images

### DIFF
--- a/.github/secrel/config.yml
+++ b/.github/secrel/config.yml
@@ -23,7 +23,7 @@ snyk:
   - -PGITHUB_ACCESS_TOKEN=${{ secrets.ACCESS_TOKEN }}
 
 images:
-# BEGIN image-names.sh replacement block (do not modify this line)
+# BEGIN image-names.sh replacement block (do not modify this block)
 # The following image list is updated by image-names.sh
 - name: vro-app
   context: "./app/build/docker"
@@ -64,7 +64,7 @@ images:
   path: "./service-python/Dockerfile"
   args:
     - SERVICE_SRC_FOLDER=assessclaimdc6602/build/docker
-# END image-names.sh replacement block (do not modify this line)
+# END image-names.sh replacement block (do not modify this block)
 
 # Remove source block if you're not building sources
 #source:

--- a/.github/secrel/config.yml
+++ b/.github/secrel/config.yml
@@ -28,6 +28,9 @@ images:
 - name: vro-app
   context: "./app/build/docker"
   path: "./app/src/docker/Dockerfile"
+  args:
+    - JAR_FILE=app-*.jar
+    - ENTRYPOINT_FILE=entrypoint.sh
 - name: vro-postgres
   context: "./postgres/build/docker"
   path: "./postgres/src/docker/Dockerfile"
@@ -37,24 +40,30 @@ images:
 - name: vro-console
   context: "./console/build/docker"
   path: "./console/src/docker/Dockerfile"
+  args:
+    - JAR_FILE=console-*.jar
+    - ENTRYPOINT_FILE=entrypoint.sh
 - name: vro-service-data-access
   context: "./svc-lighthouse-api/build/docker"
   path: "./svc-lighthouse-api/src/docker/Dockerfile"
+  args:
+    - JAR_FILE=svc-lighthouse-api-*.jar
+    - ENTRYPOINT_FILE=entrypoint.sh
 - name: vro-service-pdfgenerator
   context: "./service-python"
   path: "./service-python/Dockerfile"
   args:
-  - SERVICE_SRC_FOLDER=pdfgenerator/build/docker
+    - SERVICE_SRC_FOLDER=pdfgenerator/build/docker
 - name: vro-service-assessclaimdc7101
   context: "./service-python"
   path: "./service-python/Dockerfile"
   args:
-  - SERVICE_SRC_FOLDER=assessclaimdc7101/build/docker
+    - SERVICE_SRC_FOLDER=assessclaimdc7101/build/docker
 - name: vro-service-assessclaimdc6602
   context: "./service-python"
   path: "./service-python/Dockerfile"
   args:
-  - SERVICE_SRC_FOLDER=assessclaimdc6602/build/docker
+    - SERVICE_SRC_FOLDER=assessclaimdc6602/build/docker
 # END image-names.sh replacement block (do not modify this line)
 
 # Remove source block if you're not building sources

--- a/helmchart/values.yaml
+++ b/helmchart/values.yaml
@@ -41,7 +41,7 @@ images:
   mq:
     imageName: vro-rabbitmq
     tag: 3
-# BEGIN image-names.sh replacement block (do not modify this line)
+# BEGIN image-names.sh replacement block (do not modify this block)
 # The following image list is updated by image-names.sh
   app:
     imageName: dev_vro-app
@@ -75,7 +75,7 @@ images:
     imageName: dev_vro-service-assessclaimdc6602
     tag: tagPlaceholder
     imagePullPolicy: Always
-# END image-names.sh replacement block (do not modify this line)
+# END image-names.sh replacement block (do not modify this block)
 
 resources:
   api:

--- a/scripts/deploy-app.sh
+++ b/scripts/deploy-app.sh
@@ -34,7 +34,7 @@ generateImageArgs(){
   # sandbox (in nonprod cluster) and prod and prod-test (in the prod cluster) requires signed-images from SecRel
   case "$1" in
     dev|qa) IMG_NAME_PREFIX="${1}_";;
-    sandbox|prod|prod-test) IMG_NAME_PREFIX="";;
+    sandbox|prod|prod-test) USE_SECREL_IMAGES="true";;
     *) { echo "Unknown environment: $1"; exit 20; }
   esac
 
@@ -53,57 +53,27 @@ generateImageArgs(){
 }
 VRO_IMAGE_ARGS=$(generateImageArgs "${ENV}" "${IMAGE_TAG}")
 
-if [ "${ENV}" == "qa" ] || [ "${ENV}" == "dev" ]
-then
+COMMON_HELM_ARGS="--set-string environment=${ENV} \
+--set-string info.version=${IMAGE_TAG} \
+--set-string info.git_hash=${GIT_SHA} \
+--set-string info.deploy_env=${ENV} \
+--set-string info.github_token=${GITHUB_ACCESS_TOKEN} \
+\
+--set-string images.redis.imageName=redis \
+--set-string images.redis.tag=latest \
+\
+--set-string images.mq.imageName=rabbitmq \
+--set-string images.mq.tag=3 \
+"
+
 : "${TEAMNAME:=va-abd-rrd}"
 : "${HELM_APP_NAME:=abd-vro}"
-helm del $HELM_APP_NAME -n ${TEAMNAME}-${ENV}
-helm upgrade --install $HELM_APP_NAME helmchart \
-              --set-string environment=${ENV} \
-              --set-string info.version=${IMAGE_TAG} \
-              --set-string info.git_hash=${GIT_SHA} \
-              --set-string info.deploy_env=${ENV} \
-              --set-string info.github_token=${GITHUB_ACCESS_TOKEN} \
-              --set-string images.redis.tag=latest \
-              --set-string images.redis.imageName=redis \
-              --set-string images.mq.tag="3" \
-              --set-string images.mq.imageName=vro-rabbitmq \
-              ${VRO_IMAGE_ARGS} \
+# K8s namespace
+NAMESPACE="${TEAMNAME}-${ENV}"
+
+echo helm del $HELM_APP_NAME -n ${NAMESPACE}
+echo helm upgrade --install $HELM_APP_NAME helmchart \
+              ${COMMON_HELM_ARGS} ${VRO_IMAGE_ARGS} \
               --debug \
-              -n ${TEAMNAME}-${ENV} #--dry-run
+              -n ${NAMESPACE} #--dry-run
               #-f helmchart/"${ENV}".yaml
-elif [ "${ENV}" == "sandbox" ] || [ "${ENV}" == "prod" ] || [ "${ENV}" == "prod-test" ]
-then
-: "${TEAMNAME:=va-abd-rrd}"
-: "${HELM_APP_NAME:=abd-vro}"
-helm del $HELM_APP_NAME -n ${TEAMNAME}-"${ENV}"
-helm upgrade --install $HELM_APP_NAME helmchart \
-              --set-string images.repo=abd-vro-internal \
-              --set-string environment="${ENV}"\
-              --set-string info.version="${IMAGE_TAG}"\
-              --set-string info.git_hash="${GIT_SHA}" \
-              --set-string info.deploy_env="${ENV}" \
-              --set-string info.github_token="${GITHUB_ACCESS_TOKEN}" \
-              --set-string images.redis.tag="latest"\
-              --set-string images.redis.imageName=redis \
-              --set-string images.mq.tag="3"\
-              --set-string images.mq.imageName=rabbitmq \
-              ${VRO_IMAGE_ARGS} \
-              --debug \
-              -n ${TEAMNAME}-"${ENV}"
-else
-helm del abd-vro
-helm upgrade --install abd-vro helmchart \
-              --set-string images.repo=abd-vro-internal \
-              --set-string environment="${ENV}"\
-              --set-string info.version="${IMAGE_TAG}"\
-              --set-string info.git_hash="${GIT_SHA}" \
-              --set-string info.deploy_env="${ENV}" \
-              --set-string info.github_token="${GITHUB_ACCESS_TOKEN}" \
-              --set-string images.redis.imageName=redis \
-              --set-string images.redis.tag="latest"\
-              --set-string images.mq.imageName=rabbitmq \
-              --set-string images.mq.tag="3"\
-              ${VRO_IMAGE_ARGS} \
-              --debug
-fi

--- a/scripts/deploy-app.sh
+++ b/scripts/deploy-app.sh
@@ -31,11 +31,18 @@ source scripts/image_vars.src
 generateImageArgs(){
   local _IMAGE_TAG=$2
 
+  # sandbox (in nonprod cluster) and prod and prod-test (in the prod cluster) requires signed-images from SecRel
   case "$1" in
     dev|qa) IMG_NAME_PREFIX="${1}_";;
     sandbox|prod|prod-test) IMG_NAME_PREFIX="";;
     *) { echo "Unknown environment: $1"; exit 20; }
   esac
+
+  # Set USE_SECREL_IMAGES to deploy SecRel images to any ENV
+  if [ "$USE_SECREL_IMAGES" ]; then
+    IMG_NAME_PREFIX=""
+    echo "--set-string images.repo=abd-vro-internal "
+  fi
 
   for PREFIX in "${VAR_PREFIXES_ARR[@]}"; do
     local HELM_KEY=$(getVarValue "${PREFIX}" _HELM_KEY)

--- a/scripts/deploy-app.sh
+++ b/scripts/deploy-app.sh
@@ -71,8 +71,8 @@ COMMON_HELM_ARGS="--set-string environment=${ENV} \
 # K8s namespace
 NAMESPACE="${TEAMNAME}-${ENV}"
 
-echo helm del $HELM_APP_NAME -n ${NAMESPACE}
-echo helm upgrade --install $HELM_APP_NAME helmchart \
+helm del $HELM_APP_NAME -n ${NAMESPACE}
+helm upgrade --install $HELM_APP_NAME helmchart \
               ${COMMON_HELM_ARGS} ${VRO_IMAGE_ARGS} \
               --debug \
               -n ${NAMESPACE} #--dry-run

--- a/scripts/image-names.sh
+++ b/scripts/image-names.sh
@@ -157,7 +157,7 @@ echo '# for PREFIX in ${VAR_PREFIXES_ARR[@]}; do
 overwriteSrcFile > "$SRC_FILE"
 
 images_for_secrel_config_yml(){
-  echo '# BEGIN image-names.sh replacement block (do not modify this line)
+  echo '# BEGIN image-names.sh replacement block (do not modify this block)
 # The following image list is updated by image-names.sh'
 for IMG in "${IMAGES[@]}"; do
   echo "- name: $(secrel_image_name "$IMG")
@@ -169,12 +169,12 @@ for IMG in "${IMAGES[@]}"; do
 $BUILD_ARGS"
   fi
 done
-echo '# END image-names.sh replacement block (do not modify this line)'
+echo '# END image-names.sh replacement block (do not modify this block)'
 }
 
 images_for_helmchart_values_yaml(){
   local _ENV=$1
-  echo '# BEGIN image-names.sh replacement block (do not modify this line)
+  echo '# BEGIN image-names.sh replacement block (do not modify this block)
 # The following image list is updated by image-names.sh'
 for PREFIX in "${VAR_PREFIXES_ARR[@]}"; do
   echo "  $(getVarValue "${PREFIX}" _HELM_KEY):
@@ -182,7 +182,7 @@ for PREFIX in "${VAR_PREFIXES_ARR[@]}"; do
     tag: tagPlaceholder
     imagePullPolicy: Always"
 done
-echo '# END image-names.sh replacement block (do not modify this line)'
+echo '# END image-names.sh replacement block (do not modify this block)'
 }
 
 # shellcheck source=image_vars.src

--- a/scripts/image-names.sh
+++ b/scripts/image-names.sh
@@ -65,10 +65,12 @@ secrel_docker_context() {
   esac
 }
 
-secrel_docker_service_src_folder() {
+secrel_docker_build_args() {
   GRADLE_FOLDER=$(gradle_folder "$1")
   case "$1" in
-    pdfgenerator|assessclaim*) echo "SERVICE_SRC_FOLDER=$1/build/docker";;
+    pdfgenerator|assessclaim*) echo "    - SERVICE_SRC_FOLDER=$1/build/docker";;
+    app|console|svc-lighthouse-api) echo "    - JAR_FILE=$1-*.jar
+    - ENTRYPOINT_FILE=entrypoint.sh";;
     *) echo "";;
   esac
 }
@@ -161,10 +163,10 @@ for IMG in "${IMAGES[@]}"; do
   echo "- name: $(secrel_image_name "$IMG")
   context: \"$(secrel_docker_context "$IMG")\"
   path: \"$(secrel_dockerfile "$IMG")\""
-  SERVICE_SRC_FOLDER="$(secrel_docker_service_src_folder "$IMG")"
-  if [ "$SERVICE_SRC_FOLDER" ]; then
+  BUILD_ARGS="$(secrel_docker_build_args "$IMG")"
+  if [ "$BUILD_ARGS" ]; then
     echo "  args:
-  - $SERVICE_SRC_FOLDER"
+$BUILD_ARGS"
   fi
 done
 echo '# END image-names.sh replacement block (do not modify this line)'


### PR DESCRIPTION
<!-- Ensure the PR title reflects the feature or bug name -->

## What was the problem?
<!-- brief description of how things worked before this PR -->

I'd like the option of deploying the images created by SecRel, instead of using the created by our `deploy-dev.yml` or `deploy-qa` actions. These SecRel-created images are closer to those deployed to prod, so we'd have fewer differences between the dev and prod environments, which have caused lots of setbacks.

Once this was enabled, I discovered that SecRel isn't building Java-based images correctly, so this needed to be fixed.

## How does this fix it?[^1]
<!-- description of how things will work after this PR -->

Simplified `scripts/deploy-app.sh` by using new variable [USE_SECREL_IMAGES](https://github.com/department-of-veterans-affairs/abd-vro/pull/718/commits/bc1cfd96f762347a78aab5b9285f1fc6baf360d3)

Fixed SecRel-build images by updating `scripts/image-names.sh`, which is used to update `.github/secrel/config.yml` SecRel configuration.

## How to test this PR
- Run SecRel[^secrel]
- Test deploy: `USE_SECREL_IMAGES=true ./scripts/deploy-app.sh dev f1f5106106111054583df91cfc314f5841c048ff`


[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
