### PR TITLE
use spring.rabbitmq.username vs user (#719)

### DIFF
--- a/app/src/main/resources/conf-camel-rabbitmq.yml
+++ b/app/src/main/resources/conf-camel-rabbitmq.yml
@@ -12,5 +12,5 @@ spring:
   rabbitmq:
     host: "${RABBITMQ_PLACEHOLDERS_HOST:localhost}"
     port: 5672
-    user: "${RABBITMQ_PLACEHOLDERS_USERNAME:guest}"
+    username: "${RABBITMQ_PLACEHOLDERS_USERNAME:guest}"
     password: "${RABBITMQ_PLACEHOLDERS_USERPASSWORD:guest}"


### PR DESCRIPTION
Co-authored-by: Afsin Ustundag <afsin@amida.com>

<!-- Ensure the PR title reflects the feature or bug name -->

## What was the problem?
<!-- brief description of how things worked before this PR -->

spring.rabbitmq.user property is not correct causing usernames other than guest fail healthcheck

Associated tickets or Slack threads:
<!-- replace "000" with ticket number in both places -->
- [MCP-000](https://amida.atlassian.net/browse/MCP-000)

## How does this fix it?[^1]
<!-- description of how things will work after this PR -->

spring.rabbitmq.user property replaced with spring.rabbitmq.username

## How to test this PR
- Step 1
- Step 2[^secrel]


[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
