### PR TITLE
Ignore fhir resources without key fields

### DIFF
--- a/service-data-access/src/main/java/gov/va/vro/abddataaccess/service/FhirClient.java
+++ b/service-data-access/src/main/java/gov/va/vro/abddataaccess/service/FhirClient.java
@@ -189,13 +189,42 @@ public class FhirClient {
     return result;
   }
 
+  private boolean validateMedication(AbdMedication med) {
+    boolean result = true;
+
+    if (med.getDescription() == null) {
+      log.warn("Found a med without description.");
+      result = false;
+    }
+
+    if (med.getAuthoredOn() == null) {
+      log.warn("Found a med without authored on.");
+      result = false;
+    }
+
+    if (med.getStatus() == null) {
+      log.warn("Found a med without status.");
+      result = false;
+    }
+
+    return result;
+  }
+
   private List<AbdMedication> getPatientMedications(List<BundleEntryComponent> entries) {
     log.info("Extract patient medication entries. number of entries: {}", entries.size());
+    int ignored = 0;
     List<AbdMedication> result = new ArrayList<>();
     for (BundleEntryComponent entry : entries) {
       MedicationRequest resource = (MedicationRequest) entry.getResource();
       AbdMedication summary = FieldExtractor.extractMedication(resource);
-      result.add(summary);
+      if (validateMedication(summary)) {
+        result.add(summary);
+      } else {
+        ignored = ignored + 1;
+      }
+    }
+    if (ignored > 0) {
+      log.warn("The number of ignored medications is: {}", ignored);
     }
     result.sort(null);
     return result;
@@ -212,6 +241,27 @@ public class FhirClient {
     return result;
   }
 
+  private boolean validateBloodPressure(AbdBloodPressure bp) {
+    boolean result = true;
+
+    if (bp.getSystolic() == null) {
+      log.warn("Found a blood pressure record without systolic.");
+      result = false;
+    }
+
+    if (bp.getDiastolic() == null) {
+      log.warn("Found a blood pressure record without diastolic.");
+      result = false;
+    }
+
+    if (bp.getDate() == null) {
+      log.warn("Found a blood pressure record without date.");
+      result = false;
+    }
+
+    return result;
+  }
+
   /**
    * Gets a list of blood pressure readings.
    *
@@ -220,11 +270,19 @@ public class FhirClient {
    */
   public List<AbdBloodPressure> getPatientBloodPressures(List<BundleEntryComponent> entries) {
     log.info("Extract patient blood pressure entries. number of entries: {}", entries.size());
+    int ignored = 0;
     List<AbdBloodPressure> result = new ArrayList<>();
     for (BundleEntryComponent entry : entries) {
       Observation resource = (Observation) entry.getResource();
       AbdBloodPressure summary = FieldExtractor.extractBloodPressure(resource);
-      result.add(summary);
+      if (validateBloodPressure(summary)) {
+        result.add(summary);
+      } else {
+        ignored = ignored + 1;
+      }
+    }
+    if (ignored > 0) {
+      log.warn("The number of ignored blood pressures is: {}", ignored);
     }
     result.sort(null);
     return result;

--- a/service-data-access/src/main/java/gov/va/vro/abddataaccess/service/FieldExtractor.java
+++ b/service-data-access/src/main/java/gov/va/vro/abddataaccess/service/FieldExtractor.java
@@ -254,11 +254,15 @@ public class FieldExtractor {
               String bpType = codingInner.getCode();
               if ("8480-6".equals(bpType)) {
                 AbdBpMeasurement m = extractBpMeasurement(codingInner, component);
-                result.setSystolic(m);
+                if (m.getValue() != null) {
+                  result.setSystolic(m);
+                }
               }
               if ("8462-4".equals(bpType)) {
                 AbdBpMeasurement m = extractBpMeasurement(codingInner, component);
-                result.setDiastolic(m);
+                if (m.getValue() != null) {
+                  result.setDiastolic(m);
+                }
               }
             }
           }


### PR DESCRIPTION
<!-- Ensure the PR title reflects the feature or bug name -->

## What was the problem?
<!-- brief description of how things worked before this PR -->

It appears that in production some medication and/or observation (blood pressure) resources are coming without the required fields in the assessment algorithms causing 500 errors.

Associated tickets or Slack threads:
<!-- replace "000" with ticket number in both places -->
- [MCP-000](https://amida.atlassian.net/browse/MCP-000)

## How does this fix it?[^1]
<!-- description of how things will work after this PR -->

Observation resources (blood pressure) without these fields are ignored: systolic, diastolic, date
Med resources without these fields are ignored: authoredOn, description, status

## How to test this PR
- Step 1
- Step 2[^secrel]


[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
