### PR TITLE
MCP-2086: Refine audit event messages

### DIFF
--- a/app/src/docker/Dockerfile
+++ b/app/src/docker/Dockerfile
@@ -1,7 +1,7 @@
 FROM eclipse-temurin:17-jre-alpine
 LABEL org.opencontainers.image.source=https://github.com/department-of-veterans-affairs/abd-vro
 
-RUN apk update && apk --no-cache add expat=2.5.0-r0 curl=7.83.1-r4
+RUN apk update && apk --no-cache add expat=2.5.0-r0 curl=7.86.0-r1
 
 ARG JAR_FILE
 ARG ENTRYPOINT_FILE

--- a/app/src/docker/Dockerfile
+++ b/app/src/docker/Dockerfile
@@ -1,7 +1,7 @@
 FROM eclipse-temurin:17-jre-alpine
 LABEL org.opencontainers.image.source=https://github.com/department-of-veterans-affairs/abd-vro
 
-RUN apk update && apk --no-cache add expat=2.5.0-r0 curl=7.86.0-r1
+RUN apk update && apk --no-cache add expat=2.5.0-r0 curl=7.83.1-r4
 
 ARG JAR_FILE
 ARG ENTRYPOINT_FILE

--- a/controller/src/main/java/gov/va/vro/controller/MasController.java
+++ b/controller/src/main/java/gov/va/vro/controller/MasController.java
@@ -66,7 +66,10 @@ public class MasController implements MasResource {
         .routeId("/automatedClaim")
         .message(
             String.format(
-                "Request with collection Id %s is not in scope.", payload.getCollectionId()))
+                "Request with [collection id = %s], [diagnostic code = %s], and [disability action type = %s] is not in scope.",
+                payload.getCollectionId(),
+                payload.getDiagnosticCode(),
+                payload.getDisabilityActionType()))
         .build();
   }
 }

--- a/service/provider/src/main/java/gov/va/vro/service/provider/camel/MasIntegrationRoutes.java
+++ b/service/provider/src/main/java/gov/va/vro/service/provider/camel/MasIntegrationRoutes.java
@@ -81,8 +81,7 @@ public class MasIntegrationRoutes extends RouteBuilder {
         .routeId("mas-claim-processing")
         .unmarshal(new JacksonDataFormat(MasAutomatedClaimPayload.class))
         .process(masPollingProcessor)
-        .setExchangePattern(ExchangePattern.InOnly)
-        .log("MAS response: ${body}");
+        .setExchangePattern(ExchangePattern.InOnly);
   }
 
   private void configureMasProcessing() {

--- a/service/provider/src/main/java/gov/va/vro/service/provider/mas/service/MasApiService.java
+++ b/service/provider/src/main/java/gov/va/vro/service/provider/mas/service/MasApiService.java
@@ -43,11 +43,11 @@ public class MasApiService implements IMasApiService {
       ResponseEntity<String> masResponse =
           restTemplate.exchange(url, HttpMethod.POST, httpEntity, String.class);
       log.info("Call {} to get MAS collection status.", url);
-      log.info("MAS Collection Status Response {}.", masResponse);
+      log.info("MAS Collection Status Response Status {}.", masResponse.getStatusCode());
 
       String masReturn = masResponse.getBody();
 
-      log.info("MAS Collection Status Response body {}.", masReturn);
+      log.trace("MAS Collection Status Response body {}.", masReturn);
       return mapper.readValue(masReturn, new TypeReference<>() {});
     } catch (RestClientException | IOException e) {
       log.error("Failed to get collection status.", e);

--- a/shared/domain/src/main/java/gov/va/vro/model/event/AuditEvent.java
+++ b/shared/domain/src/main/java/gov/va/vro/model/event/AuditEvent.java
@@ -50,7 +50,7 @@ public class AuditEvent {
   public String toString() {
     if (isException()) {
       return String.format(
-          "Exception occurred on route %s for %s(id = %s): %s\n"
+          "Exception occurred on route %s for %s(id = %s): %s.\n"
               + "Please check the audit store for more information.",
           routeId, payloadType.getSimpleName(), eventId, message);
     } else {
@@ -64,7 +64,7 @@ public class AuditEvent {
         + routeId
         + '\''
         + ", payloadType="
-        + payloadType
+        + payloadType.getSimpleName()
         + ", message='"
         + message
         + '}';


### PR DESCRIPTION
<!-- Ensure the PR title reflects the feature or bug name -->

## What was the problem?
Slack notifications for claims that are not in scope should provide more information.

Associated tickets or Slack threads:
<!-- replace "000" with ticket number in both places -->
- [MCP-2086](https://amida.atlassian.net/browse/MCP-2086)

## How does this fix it?[^1]

1. Make slack notifications more informative

AuditEvent{routeId='/automatedClaim', payloadType=MasAutomatedClaimPayload, message='Request with [collection id = 350], [diagnostic code = 7101], and [disability action type = d] is not in scope.}

2. Remove wordy logs that don't add value

## How to test this PR
- Test a claim that is not in scope and look at slack notification


[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
