### PR TITLE
MCP-2073 Improve test coverage for persistence module

### DIFF
--- a/persistence/model/build.gradle
+++ b/persistence/model/build.gradle
@@ -4,7 +4,7 @@ plugins {
 
 ext {
   // TODO: improve test code coverage so that the following can be removed
-  jacoco_minimum_coverage = 0.2
+  jacoco_minimum_coverage = 0.8
 }
 
 dependencies {

--- a/persistence/model/src/test/java/gov/va/vro/persistence/repository/ClaimRepositoryTest.java
+++ b/persistence/model/src/test/java/gov/va/vro/persistence/repository/ClaimRepositoryTest.java
@@ -1,0 +1,54 @@
+package gov.va.vro.persistence.repository;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import gov.va.vro.persistence.model.AssessmentResultEntity;
+import gov.va.vro.persistence.model.ContentionEntity;
+import gov.va.vro.persistence.model.EvidenceSummaryDocumentEntity;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@DataJpaTest
+public class ClaimRepositoryTest {
+  @Autowired private VeteranRepository veteranRepository;
+  @Autowired private ClaimRepository claimRepository;
+
+  @Test
+  void test() {
+    var veteran = TestDataSupplier.createVeteran("X", "Y");
+    veteranRepository.save(veteran);
+    assertNotNull(veteran.getIcn());
+    assertNotNull(veteran.getCreatedAt());
+    assertNotNull(veteran.getUpdatedAt());
+    ContentionEntity contention1 = new ContentionEntity("c1");
+    AssessmentResultEntity assessmentResult = new AssessmentResultEntity();
+    EvidenceSummaryDocumentEntity evidenceSummaryDocument1 = new EvidenceSummaryDocumentEntity();
+    EvidenceSummaryDocumentEntity evidenceSummaryDocument2 = new EvidenceSummaryDocumentEntity();
+    Map<String, String> count1 = new HashMap<>();
+    Map<String, String> count2 = new HashMap<>();
+    count1.put("count", "1");
+    evidenceSummaryDocument1.setEvidenceCount(count1);
+    evidenceSummaryDocument1.setDocumentName("documentName1");
+    count2.put("count2", "2");
+    evidenceSummaryDocument2.setEvidenceCount(count2);
+    evidenceSummaryDocument2.setDocumentName("documentName2");
+    Map<String, String> evidence = new HashMap<>();
+    evidence.put("medicationsCount", "10");
+    assessmentResult.setEvidenceCountSummary(evidence);
+    contention1.addAssessmentResult(assessmentResult);
+    contention1.addEvidenceSummaryDocument(evidenceSummaryDocument1);
+    contention1.addEvidenceSummaryDocument(evidenceSummaryDocument2);
+    var claim = TestDataSupplier.createClaim("123", "type", veteran);
+    claim.addContention(contention1);
+    claim = claimRepository.save(claim);
+    assertNotNull(claim.getId());
+    assertNotNull(claim.getCreatedAt());
+    assertNotNull(claim.getContentions().get(0));
+    assertEquals(claim.getContentions().get(0).getDiagnosticCode(), "c1");
+  }
+}


### PR DESCRIPTION
<!-- Ensure the PR title reflects the feature or bug name -->

## What was the problem?
Jacoco test coverage showed that the persistence module tests were only covering 20% of instructions.  We need to test at least 80%.

Associated tickets or Slack threads:
<!-- replace "000" with ticket number in both places -->
- [MCP-2073](https://amida.atlassian.net/browse/MCP-2073)

## How does this fix it?[^1]
Introduced a claim repository test to bring the coverage up above 80% coverage.

## How to test this PR
- Step 1:  Build the project locally
- Step 2:  Verify that the jacoco persistence testing coverage passes with above 80%



[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
