### PR TITLE
Fix end2end test: add Slack env vars

### DIFF
--- a/.github/workflows/end2end-test.yml
+++ b/.github/workflows/end2end-test.yml
@@ -41,6 +41,8 @@ env:
   MAS_API_AUTH_CLIENT_SECRET: bogusClientSecret
   MAS_API_AUTH_TOKEN_URI: bogusToken
   MAS_API_AUTH_SCOPE: openid
+  SLACK_EXCEPTION_WEBHOOK: ${{ secrets.SLACK_EXCPTN_WEBHOOK_NONPROD }}
+  SLACK_EXCEPTION_CHANNEL: benefits-vro-nonprod
 
 jobs:
   end2end-test:


### PR DESCRIPTION
<!-- Ensure the PR title reflects the feature or bug name -->

## What was the problem?
<!-- brief description of how things worked before this PR -->

End2End test were failing b/c VRO was not starting up due to lack of `webhookUrl`: https://github.com/department-of-veterans-affairs/abd-vro/actions/runs/3596962791/jobs/6058218816#step:7:47

[Slack thread](https://dsva.slack.com/archives/C01Q7979Z7D/p1669825301369529)

## How does this fix it?[^1]
<!-- description of how things will work after this PR -->

Set those needed env variables for the GH Action.

## How to test this PR
Run end2end test manually for this PR.

[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
