### PR TITLE
MCP-2093: Fixed exception occuring during MAS processing

### DIFF
--- a/service/provider/src/main/java/gov/va/vro/service/provider/CamelEntrance.java
+++ b/service/provider/src/main/java/gov/va/vro/service/provider/CamelEntrance.java
@@ -60,12 +60,13 @@ public class CamelEntrance {
   }
 
   public void processClaim(MasAutomatedClaimPayload masAutomatedClaimPayload) {
-    producerTemplate.sendBody(
+    producerTemplate.requestBody(
         MasIntegrationRoutes.ENDPOINT_MAS_PROCESSING, masAutomatedClaimPayload);
   }
 
   public void offRampClaim(MasAutomatedClaimPayload masAutomatedClaimPayload) {
-    producerTemplate.sendBody(MasIntegrationRoutes.ENDPOINT_MAS_OFFRAMP, masAutomatedClaimPayload);
+    producerTemplate.requestBody(
+        MasIntegrationRoutes.ENDPOINT_MAS_OFFRAMP, masAutomatedClaimPayload);
   }
 
   public void sendSlack(AuditEvent auditEvent) {


### PR DESCRIPTION
<!-- Ensure the PR title reflects the feature or bug name -->

## What was the problem?
MAS processing terminates with an exception suggesting that it did not properly communicate with Lighthouse.
The problem was occuring because the exchange was incorrectly set as one-way communication instead of request/response.

Associated tickets or Slack threads:

- [MCP-2093](https://amida.atlassian.net/browse/MCP-2093)

## How does this fix it?[^1]

Using "requestBody" instead of "sendBody" implicitly sets the exchange to the request/response

## How to test this PR
- Run "automatedClaim" with collection 350. Note that you will still get an exception in the "order exam" step because this endpoint is not implemented by IBM. But there will be no exception during lighthouse processing.


[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
