### PR TITLE
MCP-2056: Update server response for malformed JSON from 500 to 400

### DIFF
--- a/app/src/test/java/gov/va/vro/controller/BaseControllerTest.java
+++ b/app/src/test/java/gov/va/vro/controller/BaseControllerTest.java
@@ -18,6 +18,11 @@ public abstract class BaseControllerTest extends BaseIntegrationTest {
     return exchange(url, request, HttpMethod.POST, responseType);
   }
 
+  protected <I, O> ResponseEntity<O> post(
+      String url, I request, Map<String, String> headers, Class<O> responseType) {
+    return exchange(url, request, HttpMethod.POST, headers, responseType);
+  }
+
   protected <I, O> ResponseEntity<O> get(String url, I request, Class<O> responseType) {
     return exchange(url, request, HttpMethod.GET, responseType);
   }

--- a/app/src/test/java/gov/va/vro/controller/VroControllerTest.java
+++ b/app/src/test/java/gov/va/vro/controller/VroControllerTest.java
@@ -190,6 +190,20 @@ class VroControllerTest extends BaseControllerTest {
   }
 
   @Test
+  void fullHealthAssessmentMalformedJson() {
+    Map<String, String> headers = new HashMap<>();
+    headers.put("accept", "application/json");
+    headers.put("content-type", "application/json");
+    var responseEntity =
+        post(
+            "/v1/full-health-data-assessment",
+            "{ \"one\":\"one\", \"two\":\"two\",}",
+            headers,
+            ClaimProcessingError.class);
+    assertEquals(HttpStatus.BAD_REQUEST, responseEntity.getStatusCode());
+  }
+
+  @Test
   @DirtiesContext
   void generatePdf() throws Exception {
     var mapper = new ObjectMapper();

--- a/controller/src/main/java/gov/va/vro/controller/exception/GlobalExceptionHandler.java
+++ b/controller/src/main/java/gov/va/vro/controller/exception/GlobalExceptionHandler.java
@@ -1,9 +1,11 @@
 package gov.va.vro.controller.exception;
 
+import com.fasterxml.jackson.core.JsonParseException;
 import gov.va.vro.api.model.ClaimProcessingException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
@@ -40,5 +42,13 @@ public class GlobalExceptionHandler {
   public ResponseEntity<ClaimProcessingError> handleClaimProcessingException(
       ClaimProcessingException exception) {
     return new ResponseEntity<>(new ClaimProcessingError(exception), exception.getHttpStatus());
+  }
+
+  @ExceptionHandler(HttpMessageNotReadableException.class)
+  public ResponseEntity<ClaimProcessingError> handleJsonParseException(
+      JsonParseException exception) {
+    log.error("Unexpected error", exception);
+    ClaimProcessingError cpe = new ClaimProcessingError(HttpStatus.BAD_REQUEST.getReasonPhrase());
+    return new ResponseEntity<>(cpe, HttpStatus.BAD_REQUEST);
   }
 }


### PR DESCRIPTION
MCP-2056: Update server response for malformed JSON from 500 to 400

## What was the problem?
If you enter an invalid JSON in our end points you will get a 500 Internal Error. We should instead get a 400 and error should indicate that JSON is wrong.

Associated tickets or Slack threads:
- [MCP-2056](https://amida.atlassian.net/browse/MCP-2056)

## How does this fix it?[^1]
As it says, when you attempt to submit malformed JSON against any endpoint, Spring should capture it first (before any other layer) and trigger a `HttpMessageNotReadableException` which then filters the capture to a `JsonParseException` and specifically triggers a `400 Bad Request` instead of the catch-all `500 Server Error` from before

## How to test this PR
- Step 1: Use curl or Postman and attempt to post sample malformed JSON to an endpoint:
POST to `http://localhost:8080/v1/full-health-data-assessment`
```JSON
{
  "veteranIcn": "9000682",
  "diagnosticCode": "7101",
  "claimSubmissionId": "1234",
  "disabilityActionType": "NEW",
  "extra-field": "hkjsdfjkhsfjfd",
}
```
You should get back a `400 Bad Request`