### PR TITLE
Upgrade SecRel to 3.2.0

### DIFF
--- a/.github/workflows/secrel.yml
+++ b/.github/workflows/secrel.yml
@@ -20,7 +20,7 @@ jobs:
     # only run for the internal repo
     if: github.repository == 'department-of-veterans-affairs/abd-vro-internal'
     name: Tornado Pipeline
-    uses: department-of-veterans-affairs/lighthouse-tornado-secrel-pipeline/.github/workflows/pipeline.yml@bert-test
+    uses: department-of-veterans-affairs/lighthouse-tornado-secrel-pipeline/.github/workflows/pipeline.yml@v3.2.0
     with:
       config-file: .github/secrel/config.yml
     secrets: inherit


### PR DESCRIPTION
## What was the problem?
A new SecRel version became available (3.2.0). After a small hiccup on LH's end, this feature branch [passed SecRel scanning](https://github.com/department-of-veterans-affairs/abd-vro-internal/actions/runs/3632830769).

Associated tickets or Slack threads:
- [790](https://github.com/department-of-veterans-affairs/abd-vro/issues/790)

## How does this fix it?[^1]
secrel.yml updated w/reference to 3.2.0

## How to test this PR
- Run a SecRel scan

[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
