### PR TITLE
Replace VRO_NON_PROD with SWAGGER_ENABLED

### DIFF
--- a/.github/workflows/end2end-test.yml
+++ b/.github/workflows/end2end-test.yml
@@ -15,7 +15,6 @@ on:
 
 env:
   GITHUB_ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
-  SWAGGER_ENABLED: true
   COMPOSE_PROJECT_NAME: vro
   LH_TOKEN_URL: https://sandbox-api.va.gov/oauth2/health/system/v1/token
   LH_ASSERTION_URL: https://deptva-eval.okta.com/oauth2/aus8nm1q0f7VQ0a482p7/v1/token

--- a/.github/workflows/end2end-test.yml
+++ b/.github/workflows/end2end-test.yml
@@ -15,7 +15,7 @@ on:
 
 env:
   GITHUB_ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
-  VRO_NON_PROD: true
+  SWAGGER_ENABLED: true
   COMPOSE_PROJECT_NAME: vro
   LH_TOKEN_URL: https://sandbox-api.va.gov/oauth2/health/system/v1/token
   LH_ASSERTION_URL: https://deptva-eval.okta.com/oauth2/aus8nm1q0f7VQ0a482p7/v1/token

--- a/app/src/docker/docker-compose.yml
+++ b/app/src/docker/docker-compose.yml
@@ -140,7 +140,7 @@ services:
       ENV: ${ENV:-dev}
       # Cause application-compose.yml to be used
       JAVA_PROFILE: "-Dspring.profiles.include=compose"
-      VRO_NON_PROD: "$VRO_NON_PROD"
+      SWAGGER_ENABLED: ${SWAGGER_ENABLED:-true}
     depends_on:
       - postgres-service
       - rabbitmq-service

--- a/app/src/docker/docker-compose.yml
+++ b/app/src/docker/docker-compose.yml
@@ -140,7 +140,6 @@ services:
       ENV: ${ENV:-dev}
       # Cause application-compose.yml to be used
       JAVA_PROFILE: "-Dspring.profiles.include=compose"
-      SWAGGER_ENABLED: ${SWAGGER_ENABLED:-true}
     depends_on:
       - postgres-service
       - rabbitmq-service

--- a/app/src/main/resources/application.yml
+++ b/app/src/main/resources/application.yml
@@ -142,7 +142,7 @@ springdoc:
     operations-sorter: method
     tagsSorter: alpha
     path: swagger
-    enabled: ${VRO_NON_PROD:false}
+    enabled: ${SWAGGER_ENABLED:false}
 
 vro:
   env: ${ENV:local}

--- a/app/src/main/resources/application.yml
+++ b/app/src/main/resources/application.yml
@@ -142,7 +142,7 @@ springdoc:
     operations-sorter: method
     tagsSorter: alpha
     path: swagger
-    enabled: ${SWAGGER_ENABLED:false}
+    enabled: ${SWAGGER_ENABLED:true}
 
 vro:
   env: ${ENV:local}

--- a/helmchart/templates/api/deployment.yaml
+++ b/helmchart/templates/api/deployment.yaml
@@ -164,11 +164,6 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.redis.secretName }}
                   key: {{ .Values.redis.passwordKey }}
-            - name: VRO_NON_PROD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.api.apiKeySecret }}
-                  key: {{ .Values.api.vroNonProdKey }}
             - name: MAS_API_AUTH_CLIENTID
               valueFrom:
                 secretKeyRef:
@@ -267,11 +262,9 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.postgres.secretName }}
                   key: {{ .Values.postgres.schemaKey }}
-            - name: VRO_NON_PROD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.api.apiKeySecret }}
-                  key: {{ .Values.api.vroNonProdKey }}
+            - name: SWAGGER_ENABLED
+              # enabled when not in prod
+              value: {{ ne .Values.environment "prod" }}
             - name: SERVER_SERVLET_CONTEXTPATH
               value: /{{ .Values.name }}
             - name: STARTER_OPENAPI_SERVERURL

--- a/helmchart/values.yaml
+++ b/helmchart/values.yaml
@@ -168,7 +168,6 @@ api:
   apiKey01: apiKey01
   apiKey02: apiKey02
   vroNonProdKey: vroNonProd
-  swaggerEnabled: true
 
 postgres:
   dbName: vro

--- a/helmchart/values.yaml
+++ b/helmchart/values.yaml
@@ -168,6 +168,7 @@ api:
   apiKey01: apiKey01
   apiKey02: apiKey02
   vroNonProdKey: vroNonProd
+  swaggerEnabled: true
 
 postgres:
   dbName: vro


### PR DESCRIPTION
<!-- Ensure the PR title reflects the feature or bug name -->

## What was the problem?
<!-- brief description of how things worked before this PR -->

`VRO_NON_PROD` is too generic a name for how it is used. It is only used to disable Swagger UI for the prod deploys.

## How does this fix it?
<!-- description of how things will work after this PR -->

Replace VRO_NON_PROD with SWAGGER_ENABLED. Set its value to `true` by default, so we don't have to set it unnecessarily (Reminder to remove `VRO_NON_PROD` from `setenv.sh` in the secrets repo). Remove extraneous references to it.

## How to test this PR
```
❯ helm install -n va-abd-rrd-dev --dry-run --debug abd-vro helmchart | grep SWAGGER_ENABLED -C 3
...
            - name: SWAGGER_ENABLED
              # enabled when not in prod
              value: true
...
```

On [this line](https://github.com/department-of-veterans-affairs/abd-vro/pull/799/files#diff-26474d778a95df886b201f2062af38f6b8534d875c411efe228b4415c97e96c3R267), change 
* `value: {{ ne .Values.environment "prod" }}` to
* `value: {{ eq .Values.environment "prod" }}`
and re-run the helm command above to see `value: false`.
