### PR TITLE
add additional fields temporarily

### DIFF
--- a/app/src/end2endTest/resources/test-6602-01/assessment.json
+++ b/app/src/end2endTest/resources/test-6602-01/assessment.json
@@ -149,5 +149,6 @@
   "evidenceSummary": {
     "relevantMedCount": 4,
     "totalMedCount": 11
-  }
+  },
+  "sufficientForFastTracking": false
 }

--- a/app/src/end2endTest/resources/test-7101-01/assessment.json
+++ b/app/src/end2endTest/resources/test-7101-01/assessment.json
@@ -130,5 +130,6 @@
     "totalBpReadings": 8,
     "recentBpReadings": 3,
     "medicationsCount": 7
-  }
+  },
+  "sufficientForFastTracking": false
 }


### PR DESCRIPTION
<!-- Ensure the PR title reflects the feature or bug name -->

## What was the problem?
<!-- brief description of how things worked before this PR -->

End to end test started to fail since the last PR. That is because we are adding a new field sufficientForFastTracking to 7701 and 6602 results and end to end tests are gold file based.

Associated tickets or Slack threads:
<!-- replace "000" with ticket number in both places -->
- [MCP-000](https://amida.atlassian.net/browse/MCP-000)

## How does this fix it?[^1]
<!-- description of how things will work after this PR -->

The gold files are updated so that the tests pass. Will write a ticket for so that the right fix can be done. Probably adding field is good but it should not be false for version 1 logic.

## How to test this PR
- Step 1
- Step 2[^secrel]


[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
