### PR TITLE
MCP-2135 - Fix server response from 500 to 405 Unsupported on disallowed HTTP metthod for endpoint

### DIFF
--- a/app/src/test/java/gov/va/vro/controller/BaseControllerTest.java
+++ b/app/src/test/java/gov/va/vro/controller/BaseControllerTest.java
@@ -23,6 +23,11 @@ public abstract class BaseControllerTest extends BaseIntegrationTest {
     return exchange(url, request, HttpMethod.POST, headers, responseType);
   }
 
+  protected <I, O> ResponseEntity<O> put(
+      String url, I request, Map<String, String> headers, Class<O> responseType) {
+    return exchange(url, request, HttpMethod.PUT, headers, responseType);
+  }
+
   protected <I, O> ResponseEntity<O> get(String url, I request, Class<O> responseType) {
     return exchange(url, request, HttpMethod.GET, responseType);
   }

--- a/app/src/test/java/gov/va/vro/controller/VroControllerTest.java
+++ b/app/src/test/java/gov/va/vro/controller/VroControllerTest.java
@@ -202,6 +202,21 @@ class VroControllerTest extends BaseControllerTest {
   }
 
   @Test
+  void serverResponseUnsupportedHttpMethod() {
+    Map<String, String> headers = new HashMap<>();
+    headers.put("accept", "application/json");
+    headers.put("content-type", "application/json");
+    String url = "/v1/fetch-claims";
+    String sampleRequestBody = "{ \"one\":\"one\", \"two\":\"two\",}";
+    var getResponseEntity = get(url, headers, ClaimProcessingError.class);
+    var postResponseEntity = post(url, sampleRequestBody, headers, ClaimProcessingError.class);
+    var putResponseEntity = put(url, sampleRequestBody, headers, ClaimProcessingError.class);
+    assertEquals(HttpStatus.OK, getResponseEntity.getStatusCode());
+    assertEquals(HttpStatus.METHOD_NOT_ALLOWED, postResponseEntity.getStatusCode());
+    assertEquals(HttpStatus.METHOD_NOT_ALLOWED, putResponseEntity.getStatusCode());
+  }
+
+  @Test
   @DirtiesContext
   void generatePdf() throws Exception {
     var mapper = new ObjectMapper();

--- a/controller/build.gradle
+++ b/controller/build.gradle
@@ -11,6 +11,9 @@ dependencies {
 
   implementation "gov.va.starter:exceptions"
 
+  // https://mvnrepository.com/artifact/javax.servlet/javax.servlet-api
+  compileOnly group: 'javax.servlet', name: 'javax.servlet-api', version: '4.0.1'
+
   // Needed?
   // implementation 'gov.va.starter:test-data'
   // implementation "gov.va.starter:entity-lifecycle-notifier"

--- a/controller/src/main/java/gov/va/vro/controller/exception/GlobalExceptionHandler.java
+++ b/controller/src/main/java/gov/va/vro/controller/exception/GlobalExceptionHandler.java
@@ -7,6 +7,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.validation.FieldError;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -50,5 +51,14 @@ public class GlobalExceptionHandler {
     log.error("Bad Request: Malformed JSON", exception);
     ClaimProcessingError cpe = new ClaimProcessingError(HttpStatus.BAD_REQUEST.getReasonPhrase());
     return new ResponseEntity<>(cpe, HttpStatus.BAD_REQUEST);
+  }
+
+  @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+  public ResponseEntity<ClaimProcessingError> handleUnsupportedHttpMethodException(
+      HttpRequestMethodNotSupportedException exception) {
+    log.error("HTTP Method Not Supported");
+    ClaimProcessingError cpe =
+        new ClaimProcessingError(HttpStatus.METHOD_NOT_ALLOWED.getReasonPhrase());
+    return new ResponseEntity<ClaimProcessingError>(cpe, HttpStatus.METHOD_NOT_ALLOWED);
   }
 }


### PR DESCRIPTION
<!-- Ensure the PR title reflects the feature or bug name -->

## What was the problem?
<!-- brief description of how things worked before this PR -->
It looks like we are currently capturing Unsupported HTTP Request Method scenarios[*], but returning 500 Internal Server Error responses.

Associated tickets or Slack threads:
<!-- replace "000" with ticket number in both places -->
- [MCP-2135](https://amida.atlassian.net/browse/MCP-2135) (subtask of [MCP-2119](https://amida.atlassian.net/browse/MCP-2119))

## How does this fix it?[^1]
<!-- description of how things will work after this PR -->
This fixes it so we return 405 Method Not Allowed instead

## How to test this PR
1. `curl` or postman any number of endpoints such as `/v1/fetch-claims` or `/v1/full-health-data-assessment`
2. Using the swagger docs as a reference (`http://localhost:8080/swagger`), test a Happy Path case and ensure you get the correct server response status code back from the server -- i.e. GET `/v1/fetch-claims` should return `200 OK`
3. Now test an Unhappy Path case and ensure you get `405 Method Not Allowed` -- i.e. POST `/v1/fetch-claims` should return `405 Method Not Allowed`
4. Test a couple of other routes to be sure

NOTE that the current `/v2/...` MAS routes will, unless authed, default to `401 Unauthorized` no matter which method you use, which is desirable behavior in this case.

