### PR TITLE
JWT scope validation

### DIFF
--- a/app/src/test/java/gov/va/vro/config/MasAuthTest.java
+++ b/app/src/test/java/gov/va/vro/config/MasAuthTest.java
@@ -12,6 +12,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.security.core.Authentication;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
@@ -20,7 +21,6 @@ import org.springframework.test.context.ActiveProfiles;
 @ActiveProfiles("test")
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 public class MasAuthTest extends BaseControllerTest {
-
   @Mock Authentication authentication;
 
   @InjectMocks @Autowired JwtValidator jwtValidator;
@@ -33,16 +33,20 @@ public class MasAuthTest extends BaseControllerTest {
 
   @Test
   void testAuthenticateHeader() {
+
+    MockHttpServletRequest httpServletRequest = new MockHttpServletRequest();
+    httpServletRequest.setRequestURI("/v2/automatedClaim");
+    apiAuthKeyManager.setHttpServletRequest(httpServletRequest);
     String sampleJwt =
         """
-               eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6ImMwOTI5NTJlLTM4ZDYtNDNjNi0\
-               5MzBlLWZmOTNiYTUxYjA4ZiJ9.eyJleHAiOjk5OTk5OTk5OTksImlhdCI6MTY0MTA2Nzk0O\
-               SwianRpIjoiNzEwOTAyMGEtMzlkOS00MWE4LThlNzgtNTllZjAwYTlkNDJlIiwiaXNzIjoi\
-               aHR0cHM6Ly9zYW5kYm94LWFwaS52YS5nb3YvaW50ZXJuYWwvYXV0aC92Mi92YWxpZGF0aW9\
-               uIiwiYXVkIjoibWFzX2RldiIsInN1YiI6IjhjNDkyY2NmLTk0OGYtNDQ1Zi05NmY4LTMxZT\
-               dmODU5MDlkMiIsInR5cCI6IkJlYXJlciIsImF6cCI6Im1hc19kZXYiLCJzY29wZSI6Im9wZ\
-               W5pZCB2cm9fbWFzIiwiY2xpZW50SWQiOiJtYXNfZGV2In0.Qb41CR1JIGGRlryi-XVtqyeN\
-               W73cU1YeBVqs9Bps3TA""";
+                   eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6ImMwOTI5NTJlLTM4ZDYtNDNjNi0\
+                   5MzBlLWZmOTNiYTUxYjA4ZiJ9.eyJleHAiOjk5OTk5OTk5OTksImlhdCI6MTY0MTA2Nzk0O\
+                   SwianRpIjoiNzEwOTAyMGEtMzlkOS00MWE4LThlNzgtNTllZjAwYTlkNDJlIiwiaXNzIjoi\
+                   aHR0cHM6Ly9zYW5kYm94LWFwaS52YS5nb3YvaW50ZXJuYWwvYXV0aC92Mi92YWxpZGF0aW9\
+                   uIiwiYXVkIjoibWFzX2RldiIsInN1YiI6IjhjNDkyY2NmLTk0OGYtNDQ1Zi05NmY4LTMxZT\
+                   dmODU5MDlkMiIsInR5cCI6IkJlYXJlciIsImF6cCI6Im1hc19kZXYiLCJzY29wZSI6Im9wZ\
+                   W5pZCB2cm9fbWFzIiwiY2xpZW50SWQiOiJtYXNfZGV2In0.Qb41CR1JIGGRlryi-XVtqyeN\
+                   W73cU1YeBVqs9Bps3TA""";
 
     String authorizationHdr = "Bearer " + sampleJwt;
     when(authentication.getPrincipal()).thenReturn(authorizationHdr);

--- a/app/src/test/resources/application-test.yml
+++ b/app/src/test/resources/application-test.yml
@@ -32,3 +32,8 @@ spring:
           mas:
             client-id: "${MAS_API_AUTH_CLIENTID:placeholderId}"
             client-secret: "${MAS_API_AUTH_CLIENT_SECRET:placeholderClientSecret}"
+lhAPIProvider:
+  tokenValidatorURL: "${LH_API_AUTH_URL:placeholderUrl}"
+  vroAudURL: "${VRO_AUD_URL:placeholderUrl}"
+  apiKey: "${LH_VRO_API_KEY:placeholderKey}"
+  validateToken: "NO"


### PR DESCRIPTION
<!-- Ensure the PR title reflects the feature or bug name -->

## What was the problem?
Validate JWT scope by the endpoint

Associated tickets or Slack threads:
- [MCP-2039](https://amida.atlassian.net/browse/MCP-2039)

## How does this fix it?[^1]
The JWT scope validation by the endpoint

## How to test this PR
- Step 1  Generate a JWT with a different scope than the end point and the call should fail with a 401.
- Step 2[^secrel]


[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
