### PR TITLE
MCP-2111 WeasyPrint PDF Package

### DIFF
--- a/api/src/main/java/gov/va/vro/api/requests/GeneratePdfRequest.java
+++ b/api/src/main/java/gov/va/vro/api/requests/GeneratePdfRequest.java
@@ -26,6 +26,10 @@ public class GeneratePdfRequest {
   @Schema(description = "Diagnostic code", example = "7101")
   private String diagnosticCode;
 
+  @NotBlank
+  @Schema(description = "PDF package", example = "wkhtmltopdf")
+  private String pdfPackage;
+
   @NotNull
   @Schema(description = "Veteran data for the pdf")
   private VeteranInfo veteranInfo;

--- a/app/src/test/java/gov/va/vro/controller/VroControllerTest.java
+++ b/app/src/test/java/gov/va/vro/controller/VroControllerTest.java
@@ -247,6 +247,7 @@ class VroControllerTest extends BaseControllerTest {
   void generatePdfInvalidInput() {
     var generatePdf = new GeneratePdfRequest();
     generatePdf.setClaimSubmissionId("1234");
+    generatePdf.setPdfPackage("wkhtmltopdf");
     generatePdf.setVeteranInfo(new VeteranInfo());
     generatePdf.setEvidence(new AbdEvidence());
     var response = post("/v1/evidence-pdf", generatePdf, ClaimProcessingError.class);

--- a/app/src/test/resources/test-data/pdf-generator-input-01.json
+++ b/app/src/test/resources/test-data/pdf-generator-input-01.json
@@ -1,6 +1,7 @@
 {
   "claimSubmissionId": "1234",
   "diagnosticCode": "7101",
+  "pdfPackage": "wkhtmltopdf",
   "veteranInfo": {
     "first": "Joe",
     "middle": "M",

--- a/service-python/Dockerfile
+++ b/service-python/Dockerfile
@@ -9,7 +9,7 @@ ENV PYTHONDONTWRITEBYTECODE 1
 # Send logs directly to container
 ENV PYTHONUNBUFFERED 1
 
-RUN apk update && apk --no-cache add expat=2.5.0-r0 py3-pip gcc musl-dev python3-dev pango zlib-dev jpeg-dev openjpeg-dev g++ libffi-dev && mkdir -p /home/docker
+RUN apk update && apk --no-cache add expat=2.5.0-r0 py3-pip=22.1.1-r0 gcc=11.2.1_git20220219-r2 musl-dev=1.2.3-r2 python3-dev=3.10.9-r0 pango=1.50.7-r0 zlib-dev=1.2.12-r3 jpeg-dev=9d-r1 openjpeg-dev=2.5.0-r0 g++=11.2.1_git20220219-r2 libffi-dev=3.4.2-r1 && mkdir -p /home/docker
 RUN adduser --disabled-password docker && chown -hR docker:docker /home/docker/
 
 # SERVICE_SRC_FOLDER is used by secrel/config.yml

--- a/service-python/Dockerfile
+++ b/service-python/Dockerfile
@@ -9,7 +9,7 @@ ENV PYTHONDONTWRITEBYTECODE 1
 # Send logs directly to container
 ENV PYTHONUNBUFFERED 1
 
-RUN apk update && apk --no-cache add expat=2.5.0-r0 && mkdir -p /home/docker
+RUN apk update && apk --no-cache add expat=2.5.0-r0 py3-pip gcc musl-dev python3-dev pango zlib-dev jpeg-dev openjpeg-dev g++ libffi-dev && mkdir -p /home/docker
 RUN adduser --disabled-password docker && chown -hR docker:docker /home/docker/
 
 # SERVICE_SRC_FOLDER is used by secrel/config.yml

--- a/service-python/pdfgenerator/src/lib/local_pdf_test.py
+++ b/service-python/pdfgenerator/src/lib/local_pdf_test.py
@@ -2,14 +2,18 @@ from .pdf_generator import PDFGenerator
 from .settings import pdf_options
 
 if __name__ == '__main__':
-    diagnosis_name = "summary"
-    message = {}
-    pdf_generator = PDFGenerator(pdf_options)
+    diagnosis_name = "hypertensionv2"
+    message = {"pdfPackage": "weasyprint"}
+    pdf_generator = PDFGenerator(pdf_options, message)
     variables = pdf_generator.generate_template_variables(diagnosis_name, message)
     # print("Variables: ", variables)
     template = pdf_generator.generate_template_file(diagnosis_name, variables, test_mode=True, loader="local_pdf_test")
     # print("Template: ", template)
     with open("test.html", "w") as file:
         file.write(template)
-    pdf = pdf_generator.generate_pdf_from_string(diagnosis_name, template, variables, 'test.pdf')
-    # print("PDF: ", pdf)
+    # WKHMTMLTOPDF
+    # pdf = pdf_generator.generate_pdf_from_string(diagnosis_name, template, variables, 'test.pdf')
+    # WEASYPRINT
+    pdf = pdf_generator.generate_pdf_from_string(diagnosis_name, template, variables)
+    with open("test.pdf", "wb") as file:
+        file.write(pdf)

--- a/service-python/pdfgenerator/src/lib/queues.py
+++ b/service-python/pdfgenerator/src/lib/queues.py
@@ -16,11 +16,11 @@ FETCH_QUEUE = queue_config["fetch_queue_name"]
 
 def on_generate_callback(channel, method, properties, body):
     try:
-        redis_client = RedisClient(redis_config)
-        pdf_generator = PDFGenerator(pdf_options)
-
-        # binding_key = method.routing_key
         message = json.loads(body)
+
+        redis_client = RedisClient(redis_config)
+        pdf_generator = PDFGenerator(pdf_options, message)
+        # binding_key = method.routing_key
         # logging.info(f" [x] {binding_key}: Received message: {message}")
         claim_id = message["claimSubmissionId"]
         message["veteran_info"] = message["veteranInfo"]

--- a/service-python/pdfgenerator/src/requirements.txt
+++ b/service-python/pdfgenerator/src/requirements.txt
@@ -2,6 +2,7 @@
 # Linting + Testing
 flake8==6.0.0
 isort==5.11.3
+
 Jinja2==3.1.2
 pdfkit==1.0.0
 pika==1.3.1
@@ -11,3 +12,4 @@ pytest-mock-resources==2.6.3
 python-dateutil==2.8.2
 pytz==2022.7
 redis==4.4.0
+weasyprint==57.2

--- a/service/db/src/test/resources/test-data/evidence-summary-document-data.json
+++ b/service/db/src/test/resources/test-data/evidence-summary-document-data.json
@@ -1,6 +1,7 @@
 {
   "claimSubmissionId": "1234",
   "diagnosticCode": "7101",
+  "pdfPackage": "wkhtmltopdf",
   "veteranInfo": {
     "first": "Joe",
     "middle": "M",

--- a/service/spi/src/main/java/gov/va/vro/service/spi/model/GeneratePdfPayload.java
+++ b/service/spi/src/main/java/gov/va/vro/service/spi/model/GeneratePdfPayload.java
@@ -23,6 +23,8 @@ public class GeneratePdfPayload implements Auditable {
 
   @NonNull private String diagnosticCode;
 
+  @NonNull private String pdfPackage;
+
   @JsonProperty("veteranInfo")
   private VeteranInfo veteranInfo;
 


### PR DESCRIPTION
<!-- Ensure the PR title reflects the feature or bug name -->

## What was the problem?
<!-- brief description of how things worked before this PR -->
WKHTMLTOPDF runs on Webkit 2.2 which means a lot of the newer HTML features don’t work. There’s also issues with the engine it uses that causes a DPI issue and leads to inconsistency between the design and HTML page.

Associated tickets or Slack threads:
<!-- replace "000" with ticket number in both places -->
- [MCP-2111](https://amida.atlassian.net/browse/MCP-2111)

## How does this fix it?[^1]
<!-- description of how things will work after this PR -->
Adds a new `pdfPackage` optional field to the PDF Generation request. If the field is not passed, it defaults to `wkhtmltopdf` which is what its currently running using. You can pass `weasyprint` to generate the same PDF using the new engine.

NOTE: This PR is just to add the functionality to use a different package. Since the end goal is to move over, subsequent PRs will work on fixing the templates so they render properly using WeasyPrint

## How to test this PR
- Build and run the containers. Use the swagger example for the PDF generate route and add `pdfPackage: "weasyprint"` to the request. The request should complete and you should be able to download the new PDF how you normally would using the fetch route. Note: The new PDF will not visually match the old version
