### PR TITLE
MCP-2174 Race Condition + Minor Cleanup

### DIFF
--- a/service-python/pdfgenerator/src/lib/helper_functions.py
+++ b/service-python/pdfgenerator/src/lib/helper_functions.py
@@ -32,7 +32,7 @@ def toc_helper_all(toc_file_path, data):
     file_data = file_data.replace("{{file}}", data['fileIdentifier'])
     file_data = file_data.replace("{{date}}", f"{pytz.utc.localize(datetime.now()).strftime('%b. %d, %Y')}")
 
-    generated_toc_path = toc_file_path.replace("base_toc", "generated_toc")
+    generated_toc_path = toc_file_path.replace("base_toc", f"{data['claimSubmissionId']}_toc")
 
     with open(generated_toc_path, 'w') as file:
         file.write(file_data)

--- a/service-python/pdfgenerator/src/lib/pdf_generator.py
+++ b/service-python/pdfgenerator/src/lib/pdf_generator.py
@@ -44,6 +44,6 @@ class PDFGenerator:
             # Call a helper function that make adjustments to toc before creating
             generated_toc_file_path = toc_helper_all(base_toc_file_path, data) # noqa: F405, E261
             toc = {'xsl-style-sheet': generated_toc_file_path}
-            return pdfkit.from_string(html, output, options=self.options, toc=toc, verbose=True)
+            return pdfkit.from_string(html, output, options=self.options, toc=toc, verbose=False)
         else:
-            return pdfkit.from_string(html, output, options=self.options, verbose=True)
+            return pdfkit.from_string(html, output, options=self.options, verbose=False)

--- a/service-python/pdfgenerator/src/lib/queues.py
+++ b/service-python/pdfgenerator/src/lib/queues.py
@@ -29,7 +29,7 @@ def on_generate_callback(channel, method, properties, body):
         template = pdf_generator.generate_template_file(diagnosis_name, variables)
         pdf = pdf_generator.generate_pdf_from_string(diagnosis_name, template, variables)
         redis_client.save_hash_data(f"{claim_id}-pdf", mapping={"contents": base64.b64encode(pdf).decode("ascii"), "diagnosis": diagnosis_name})
-        logging.info("Saved PDF")
+        logging.info(f"Claim {claim_id}: Saved PDF")
         response = {"claimSubmissionId": claim_id, "status": "COMPLETE"}
     except Exception as e:
         logging.error(e, exc_info=True)

--- a/service-python/pdfgenerator/src/lib/template_variables/hypertensionv2.json
+++ b/service-python/pdfgenerator/src/lib/template_variables/hypertensionv2.json
@@ -1,9 +1,10 @@
 {
+  "claimSubmissionId": "1234",
   "code": "7101",
   "document_type": "hypertension",
   "conditions": [],
   "fileIdentifier": "12345",
-  "veteran_info": {
+  "veteranInfo": {
     "first": "Test",
     "middle": "",
     "last": "User",


### PR DESCRIPTION
<!-- Ensure the PR title reflects the feature or bug name -->


## What was the problem?
<!-- brief description of how things worked before this PR -->
WKHTMLTOPDF requires a file to generate the Table of Contents and it only accepts it in file format. This would lead to a race condition if multiple PDFs got requested at once since they would each read the `base_toc` template and then create a `generated_toc` file but would overwrite.

**Minor Cleanup:** Turning `verbose` off in the pdfgenerator since we don't need the extra messages and it slows down the generation process

Associated tickets or Slack threads:
<!-- replace "000" with ticket number in both places -->
- [MCP-2174](https://amida.atlassian.net/browse/MCP-2174)

## How does this fix it?
<!-- description of how things will work after this PR -->
Rather than make a custom version of WKHTMLTOPDF that accepts the ToC in another format, we prepend `claimSubmissionId` to the `generated_toc` so there are no overwrite issues.

**Minor Cleanup:** Turning `verbose` off in the pdfgenerator since we don't need the extra messages and it slows down the generation process

## How to test this PR
- Try to create 2 PDFs at the same time with different `claimSubmissionId`
or
- After creating a PDF, enter the pdfgenerator container to see the file that was generated for the ToC to verify that it has the `claimSubmissionId`
