### PR TITLE
MCP-2181 PDF Generator Schema + Template Update

### DIFF
--- a/app/src/end2endTest/resources/test-7101-01/assessment.json
+++ b/app/src/end2endTest/resources/test-7101-01/assessment.json
@@ -82,6 +82,7 @@
     "bp_readings": [
       {
         "date": "2022-07-20",
+        "dateFormatted": "07/20/2022",
         "diastolic": {
           "code": "8462-4",
           "display": "Diastolic blood pressure",
@@ -100,6 +101,7 @@
       },
       {
         "date": "2022-06-20",
+        "dateFormatted": "06/20/2022",
         "diastolic": {
           "code": "8462-4",
           "display": "Diastolic blood pressure",
@@ -118,6 +120,7 @@
       },
       {
         "date": "2022-05-20",
+        "dateFormatted": "05/20/2022",
         "diastolic": {
           "code": "8462-4",
           "display": "Diastolic blood pressure",

--- a/service-python/pdfgenerator/src/lib/templates/hypertensionv2.html
+++ b/service-python/pdfgenerator/src/lib/templates/hypertensionv2.html
@@ -267,7 +267,7 @@
           {% for bp_reading in evidence.bp_readings %}
           <tr>
             <th>{{ bp_reading.systolic.value |int }} / {{ bp_reading.diastolic.value |int }}</th>
-            <th>{{ bp_reading.date }}</th>
+            <th>{{ bp_reading.dateFormatted }}</th>
             <td>VAMC record - {{ bp_reading.organization }}</td>
             <td class="empty">n.a.</td>
             <td class="empty">n.a.</td>

--- a/shared/domain/src/main/java/gov/va/vro/model/AbdBloodPressure.java
+++ b/shared/domain/src/main/java/gov/va/vro/model/AbdBloodPressure.java
@@ -37,6 +37,9 @@ public class AbdBloodPressure implements Comparable<AbdBloodPressure> {
       example = "WASHINGTON VA MEDICAL CENTER")
   private String organization;
 
+  @Schema(description = "Formatted date", example = "01/01/2023")
+  private String dateFormatted;
+
   @Schema(description = "Source of this data", example = "LH")
   private String dataSource = "LH";
 

--- a/shared/domain/src/main/java/gov/va/vro/model/AbdCondition.java
+++ b/shared/domain/src/main/java/gov/va/vro/model/AbdCondition.java
@@ -21,6 +21,7 @@ public class AbdCondition implements Comparable<AbdCondition> {
   @EqualsAndHashCode.Include private String onsetDate;
   private String recordedDate;
   private String relevant;
+
   @Schema(description = "Formatted date", example = "01/01/2023")
   private String dateFormatted;
 

--- a/shared/domain/src/main/java/gov/va/vro/model/AbdCondition.java
+++ b/shared/domain/src/main/java/gov/va/vro/model/AbdCondition.java
@@ -21,6 +21,7 @@ public class AbdCondition implements Comparable<AbdCondition> {
   @EqualsAndHashCode.Include private String onsetDate;
   private String recordedDate;
   private String relevant;
+  @Schema(description = "Formatted date", example = "01/01/2023")
   private String dateFormatted;
 
   @Schema(description = "Source of this data", example = "LH")

--- a/shared/domain/src/main/java/gov/va/vro/model/AbdMedication.java
+++ b/shared/domain/src/main/java/gov/va/vro/model/AbdMedication.java
@@ -37,6 +37,7 @@ public class AbdMedication implements Comparable<AbdMedication> {
 
   private Boolean conditionRelated;
   private String suggestedCategory;
+
   @Schema(description = "Formatted date", example = "01/01/2023")
   private String dateFormatted;
 
@@ -65,7 +66,7 @@ public class AbdMedication implements Comparable<AbdMedication> {
       example = "Medical Treatment Record - Government Facility")
   private String document;
 
-  @Schema(description = "VBMS Receipt Date", example = "2021-04-05")
+  @Schema(description = "VBMS Receipt Date", example = "04/05/2021")
   private String receiptDate;
 
   @Schema(description = "Document Page Number", example = "55")

--- a/shared/domain/src/main/java/gov/va/vro/model/AbdMedication.java
+++ b/shared/domain/src/main/java/gov/va/vro/model/AbdMedication.java
@@ -37,6 +37,7 @@ public class AbdMedication implements Comparable<AbdMedication> {
 
   private Boolean conditionRelated;
   private String suggestedCategory;
+  @Schema(description = "Formatted date", example = "01/01/2023")
   private String dateFormatted;
 
   @EqualsAndHashCode.Include
@@ -70,7 +71,7 @@ public class AbdMedication implements Comparable<AbdMedication> {
   @Schema(description = "Document Page Number", example = "55")
   private String page;
 
-  @Schema(description = "Document Identifier", example = "")
+  @Schema(description = "Document Identifier", example = "{BFA4943C-4F56-4AC5-B48F-5FDE469B1226}")
   private String documentId;
 
   @Override

--- a/shared/domain/src/main/java/gov/va/vro/model/ServiceLocation.java
+++ b/shared/domain/src/main/java/gov/va/vro/model/ServiceLocation.java
@@ -20,7 +20,12 @@ public class ServiceLocation {
       example = "VA 21-3101 Request for Information")
   private String document;
 
+  @Schema(description = "Receipt date", example = "01/01/2023")
   private String receiptDate;
+
+  @Schema(description = "Page", example = "1")
   private String page;
+
+  @Schema(description = "Document Identifier", example = "{BFA4943C-4F56-4AC5-B48F-5FDE469B1226}")
   private String documentId;
 }

--- a/shared/domain/src/main/java/gov/va/vro/model/VeteranSrvcLocations.java
+++ b/shared/domain/src/main/java/gov/va/vro/model/VeteranSrvcLocations.java
@@ -26,6 +26,6 @@ public class VeteranSrvcLocations {
   @Schema(description = "Document Page Number", example = "55")
   private String page;
 
-  @Schema(description = "Document Identifier", example = "")
+  @Schema(description = "Document Identifier", example = "{BFA4943C-4F56-4AC5-B48F-5FDE469B1226}")
   private String documentId;
 }


### PR DESCRIPTION
<!-- Ensure the PR title reflects the feature or bug name -->

## What was the problem?
<!-- brief description of how things worked before this PR -->
Schema was not sending fields that get used like `dateFormatted`, `documentId`, etc. Just adding them to make Swagger testing easier. 

Also updated a date field in the template since it should be using `dateFormatted`

Associated tickets or Slack threads:
<!-- replace "000" with ticket number in both places -->
- [MCP-2181](https://amida.atlassian.net/browse/MCP-2181)

## How to test this PR
- Generate a PDF or look at the Swagger example schema for the generate endpoint to verify
