### PR TITLE
Fix typo: slackExceptionWebhook

### DIFF
--- a/app/src/main/java/gov/va/vro/config/MasAuditConfig.java
+++ b/app/src/main/java/gov/va/vro/config/MasAuditConfig.java
@@ -21,7 +21,7 @@ public class MasAuditConfig {
             .masProcessingInitialDelay(masProcessingInitialDelay)
             .masProcessingSubsequentDelay(masProcessingSubsequentDelay)
             .masRetryCount(masRetryCount);
-    if (slackExceptionChannel != null && slackExceptionChannel != null) {
+    if (slackExceptionChannel != null && slackExceptionWebhook != null) {
       builder
           .slackExceptionChannel(slackExceptionChannel)
           .slackExceptionWebhook(slackExceptionWebhook);


### PR DESCRIPTION
<!-- Ensure the PR title reflects the feature or bug name -->

## What was the problem?
<!-- brief description of how things worked before this PR -->
`slackExceptionChannel != null` is checked twice -- copy-paste error?

## How does this fix it?
<!-- description of how things will work after this PR -->

Replace second `slackExceptionChannel` with `slackExceptionWebhook`
