### PR TITLE
Notify deploys in GH Action Slack thread

### DIFF
--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -31,28 +31,15 @@ on:
         required: true
         type: string
 env:
-  GITHUB_ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
   COMMIT_SHA: ${{ inputs.target_release }}
   DEV_KUBE_CONFIG: ${{ secrets.DEV_KUBE_CONFIG }}
   TARGET_ENV: ${{ inputs.target_env }}
-  # Default to failure messages
-  DEPLOY_STATE_TEXT: ':panda_shocked: Deployment failed!'
-  DEPLOY_STATE_EMOJI: 'x'
 
 jobs:
   deploy-core-services:
     if: github.repository == 'department-of-veterans-affairs/abd-vro'
     runs-on: ubuntu-latest
     steps:
-      #- name: "Notify Slack: Deploying..."
-      #  id: notify-slack-deploying
-      #  uses: archive/github-actions-slack@v2.6.0
-      #  with:
-      #    slack-bot-user-oauth-access-token: ${{ secrets.SLACK_BOT_USER_OAUTH_ACCESS_TOKEN }}
-      #    slack-channel: ${{ fromJson(steps.notify-slack.outputs.slack-result).response.channel }}
-      #    slack-optional-thread_ts: ${{ fromJson(steps.notify-slack.outputs.slack-result).response.message.ts }}
-      #    slack-text: ":panda_coffee: Deploying services to ${{ env.TARGET_ENV }}..."
-
       - name: "Set up kube config"
         run: |
           mkdir ~/.kube

--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -14,7 +14,7 @@ on:
         - sandbox
         - prod-test
         - prod
-      
+
       target_release:
         description: 'Target release tag or SHA'
         required: true
@@ -66,8 +66,5 @@ jobs:
         uses: actions/checkout@v3
 
       - name: "Deploy core to ${{ env.TARGET_ENV }} env"
-        env:
-          GITHUB_ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
-          GITHUB_USERNAME: ${{ secrets.USERNAME }}
         run: |
           ./scripts/deploy-app.sh ${{ env.TARGET_ENV }} ${{ env.COMMIT_SHA }}

--- a/.github/workflows/deploy-services.yml
+++ b/.github/workflows/deploy-services.yml
@@ -14,7 +14,7 @@ on:
         - sandbox
         - prod-test
         - prod
-      
+
       target_service:
         description: 'Target LHDI Service'
         required: true
@@ -26,7 +26,7 @@ on:
         - db
         - redis
         - mq
-        
+
       target_release:
         description: 'Target release tag or SHA'
         required: true
@@ -46,29 +46,16 @@ on:
         required: true
         type: string
 env:
-  GITHUB_ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
   COMMIT_SHA: ${{ inputs.target_release }}
   SERVICE: ${{ inputs.target_service }}
   DEV_KUBE_CONFIG: ${{ secrets.DEV_KUBE_CONFIG }}
   TARGET_ENV: ${{ inputs.target_env }}
-  # Default to failure messages
-  DEPLOY_STATE_TEXT: ':panda_shocked: Deployment failed!'
-  DEPLOY_STATE_EMOJI: 'x'
 
 jobs:
   deploy-core-services:
     if: github.repository == 'department-of-veterans-affairs/abd-vro'
     runs-on: ubuntu-latest
     steps:
-      #- name: "Notify Slack: Deploying..."
-      #  id: notify-slack-deploying
-      #  uses: archive/github-actions-slack@v2.6.0
-      #  with:
-      #    slack-bot-user-oauth-access-token: ${{ secrets.SLACK_BOT_USER_OAUTH_ACCESS_TOKEN }}
-      #    slack-channel: ${{ fromJson(steps.notify-slack.outputs.slack-result).response.channel }}
-      #    slack-optional-thread_ts: ${{ fromJson(steps.notify-slack.outputs.slack-result).response.message.ts }}
-      #    slack-text: ":panda_coffee: Deploying services to ${{ env.TARGET_ENV }}..."
-
       - name: "Set up kube config"
         run: |
           mkdir ~/.kube
@@ -82,43 +69,31 @@ jobs:
         uses: actions/checkout@v3
 
       - name: "Deploy core to ${{ env.TARGET_ENV }} env"
-        env:
-          GITHUB_ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
-          GITHUB_USERNAME: ${{ secrets.USERNAME }}
         run: |
           if [ "${{ env.SERVICE }}" == "all" ] || [ "${{ env.SERVICE }}" == "core" ]
           then
             pwd
             ./scripts/deploy-core.sh ${{ env.TARGET_ENV }}
-          fi  
+          fi
 
       - name: "Deploy redis to ${{ env.TARGET_ENV }} env"
-        env:
-          GITHUB_ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
-          GITHUB_USERNAME: ${{ secrets.USERNAME }}
         run: |
           if [ "${{ env.SERVICE }}" == "redis" ]
           then
             ./scripts/deploy-${{ env.SERVICE }}.sh ${{ env.TARGET_ENV }} 1
-          fi  
-      
+          fi
+
       - name: "Deploy RabbitMQ to ${{ env.TARGET_ENV }} env"
-        env:
-          GITHUB_ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
-          GITHUB_USERNAME: ${{ secrets.USERNAME }}
         run: |
           if [ "${{ env.SERVICE }}" == "mq" ]
           then
-            ./scripts/deploy-${{ env.SERVICE }}.sh ${{ env.TARGET_ENV }} 1 
-          fi  
+            ./scripts/deploy-${{ env.SERVICE }}.sh ${{ env.TARGET_ENV }} 1
+          fi
 
       - name: "Deploy DB to ${{ env.TARGET_ENV }} env"
-        env:
-          GITHUB_ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
-          GITHUB_USERNAME: ${{ secrets.USERNAME }}
         run: |
           if [ "${{ env.SERVICE }}" == "db" ]
           then
             pwd
             ./scripts/deploy-${{ env.SERVICE }}.sh ${{ env.TARGET_ENV }} 1 ${{ env.COMMIT_SHA }}
-          fi  
+          fi

--- a/.github/workflows/deploy-unsigned.yml
+++ b/.github/workflows/deploy-unsigned.yml
@@ -106,8 +106,7 @@ jobs:
 
       - name: "Deploy to ${{ env.TARGET_ENV }} env"
         env:
-          GITHUB_ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
-          GITHUB_USERNAME: ${{ secrets.USERNAME }}
+          SLACK_THREAD_TS: ${{ needs.publish-images.outputs.slack-response-ts }}
         run: |
           ./scripts/deploy-app.sh ${{ env.TARGET_ENV }} ${COMMIT_SHA:0:7}
 

--- a/.github/workflows/deploy-unsigned.yml
+++ b/.github/workflows/deploy-unsigned.yml
@@ -106,6 +106,7 @@ jobs:
 
       - name: "Deploy to ${{ env.TARGET_ENV }} env"
         env:
+          SLACK_CHANNEL: ${{ env.SLACK_CHANNEL }}
           SLACK_THREAD_TS: ${{ needs.publish-images.outputs.slack-response-ts }}
         run: |
           ./scripts/deploy-app.sh ${{ env.TARGET_ENV }} ${COMMIT_SHA:0:7}

--- a/scripts/deploy-app.sh
+++ b/scripts/deploy-app.sh
@@ -8,11 +8,6 @@ then
   echo "Please enter valid environment (dev, sandbox, qa, prod, prod-test)" && exit 1
 fi
 
-if [ "${GITHUB_ACCESS_TOKEN}" == "" ]
-then
-  echo "please set your github access token environment variable (export GITHUB_ACCESS_TOKEN=XXXXXX)" && exit 2
-fi
-
 #get the current sha from github repository
 GIT_SHA=$(git rev-parse HEAD)
 if [ -n "$2" ]

--- a/scripts/deploy-core.sh
+++ b/scripts/deploy-core.sh
@@ -8,11 +8,6 @@ then
   echo "Please enter valid environment (dev, sandbox, qa, prod, prod-test)" && exit 1
 fi
 
-if [ "${GITHUB_ACCESS_TOKEN}" == "" ]
-then
-  echo "please set your github access token environment variable (export GITHUB_ACCESS_TOKEN=XXXXXX)" && exit 2
-fi
-
 #get the current sha from github repository
 GIT_SHA=$(git rev-parse HEAD)
 if [ -n "$2" ]

--- a/scripts/deploy-db.sh
+++ b/scripts/deploy-db.sh
@@ -9,11 +9,6 @@ then
   echo "Please enter valid environment (dev, sandbox, qa, prod, prod-test)" && exit 1
 fi
 
-if [ "${GITHUB_ACCESS_TOKEN}" == "" ]
-then
-  echo "please set your github access token environment variable (export GITHUB_ACCESS_TOKEN=XXXXXX)" && exit 2
-fi
-
 #get the current sha from github repository
 GIT_SHA=$(git rev-parse HEAD)
 if [ -n "$3" ]

--- a/scripts/deploy-mq.sh
+++ b/scripts/deploy-mq.sh
@@ -9,11 +9,6 @@ then
   echo "Please enter valid environment (dev, sandbox, qa, prod, prod-test)" && exit 1
 fi
 
-if [ "${GITHUB_ACCESS_TOKEN}" == "" ]
-then
-  echo "please set your github access token environment variable (export GITHUB_ACCESS_TOKEN=XXXXXX)" && exit 2
-fi
-
 #get the current sha from github repository
 GIT_SHA=$(git rev-parse HEAD)
 if [ -n "$3" ]

--- a/scripts/deploy-redis.sh
+++ b/scripts/deploy-redis.sh
@@ -9,11 +9,6 @@ then
   echo "Please enter valid environment (dev, sandbox, qa, prod, prod-test)" && exit 1
 fi
 
-if [ "${GITHUB_ACCESS_TOKEN}" == "" ]
-then
-  echo "please set your github access token environment variable (export GITHUB_ACCESS_TOKEN=XXXXXX)" && exit 2
-fi
-
 #get the current sha from github repository
 GIT_SHA=$(git rev-parse HEAD)
 if [ -n "$3" ]


### PR DESCRIPTION
<!-- Ensure the PR title reflects the feature or bug name -->

## What was the problem?
<!-- brief description of how things worked before this PR -->

When called from GH Action workflows, Slack notifications from `deploy-*.sh` scripts create new Slack threads.

## How does this fix it?[^1]
<!-- description of how things will work after this PR -->

When called from GH Action workflows, specify the `SLACK_THREAD_TS` env variable so that `deploy-*.sh` scripts send notifications to the Slack thread created by the GH workflow.

Bonus: Remove `GITHUB_ACCESS_TOKEN` requirement for `deploy-*.sh` scripts. `GITHUB_ACCESS_TOKEN` is only needed for building VRO and publishing images.

## How to test this PR
Run the `Deploy to Dev` GH Action workflow and watch Slack, e.g., [example thread](https://dsva.slack.com/archives/C04CA47HV96/p1673385767718159).

[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
