### PR TITLE
MCP-2247: fix NPE in BipClaimService

### DIFF
--- a/app/src/main/java/gov/va/vro/config/SecurityConfig.java
+++ b/app/src/main/java/gov/va/vro/config/SecurityConfig.java
@@ -3,7 +3,6 @@ package gov.va.vro.config;
 import gov.va.vro.security.ApiAuthKeyFilter;
 import gov.va.vro.security.ApiAuthKeyManager;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -16,7 +15,6 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.HttpStatusEntryPoint;
 
-@Slf4j
 @Configuration
 @EnableWebSecurity
 @Order(Ordered.HIGHEST_PRECEDENCE)

--- a/app/src/test/java/gov/va/vro/service/BipClaimServiceTest.java
+++ b/app/src/test/java/gov/va/vro/service/BipClaimServiceTest.java
@@ -11,7 +11,6 @@ import gov.va.vro.model.mas.response.FetchPdfResponse;
 import gov.va.vro.service.provider.bip.BipException;
 import gov.va.vro.service.provider.bip.service.BipClaimService;
 import gov.va.vro.service.provider.bip.service.IBipApiService;
-import gov.va.vro.service.provider.mas.MasException;
 import gov.va.vro.service.provider.mas.MasProcessingObject;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -136,8 +135,8 @@ class BipClaimServiceTest {
     try {
       claimService.uploadPdf(fetchPdfResponse);
       fail();
-    } catch (MasException e) {
-
+    } catch (BipException e) {
+      assertEquals("PDF Response does not contain any data", e.getMessage());
     }
   }
 

--- a/app/src/test/java/gov/va/vro/service/BipClaimServiceTest.java
+++ b/app/src/test/java/gov/va/vro/service/BipClaimServiceTest.java
@@ -1,20 +1,23 @@
 package gov.va.vro.service;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 import gov.va.vro.MasTestData;
 import gov.va.vro.model.bip.BipClaim;
 import gov.va.vro.model.bip.ClaimContention;
 import gov.va.vro.model.bip.UpdateContentionReq;
 import gov.va.vro.model.mas.MasAutomatedClaimPayload;
+import gov.va.vro.model.mas.response.FetchPdfResponse;
 import gov.va.vro.service.provider.bip.BipException;
 import gov.va.vro.service.provider.bip.service.BipClaimService;
 import gov.va.vro.service.provider.bip.service.IBipApiService;
+import gov.va.vro.service.provider.mas.MasException;
 import gov.va.vro.service.provider.mas.MasProcessingObject;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.List;
 
 class BipClaimServiceTest {
@@ -123,6 +126,29 @@ class BipClaimServiceTest {
     var payload = MasTestData.getMasAutomatedClaimPayload(collectionId, "1701", claimId);
     assertTrue(claimService.completeProcessing(getMpo(payload)).isTSOJ());
     Mockito.verify(bipApiService).setClaimToRfdStatus(collectionId);
+  }
+
+  @Test
+  void uploadPdf_missingData() {
+    IBipApiService bipApiService = Mockito.mock(IBipApiService.class);
+    BipClaimService claimService = new BipClaimService(bipApiService);
+    FetchPdfResponse fetchPdfResponse = new FetchPdfResponse();
+    try {
+      claimService.uploadPdf(fetchPdfResponse);
+      fail();
+    } catch (MasException e) {
+
+    }
+  }
+
+  @Test
+  void uploadPdf() {
+    IBipApiService bipApiService = Mockito.mock(IBipApiService.class);
+    BipClaimService claimService = new BipClaimService(bipApiService);
+    FetchPdfResponse fetchPdfResponse = new FetchPdfResponse();
+    var data = Base64.getEncoder().encode("Hello!".getBytes(StandardCharsets.UTF_8));
+    fetchPdfResponse.setPdfData(new String(data));
+    claimService.uploadPdf(fetchPdfResponse);
   }
 
   private ClaimContention createContention(List<String> codes) {

--- a/service-python/pdfgenerator/src/requirements.txt
+++ b/service-python/pdfgenerator/src/requirements.txt
@@ -7,7 +7,7 @@ pdfkit==1.0.0
 pika==1.3.1
 pytest==7.2.0
 pytest-cov==4.0.0
-pytest-mock-resources==2.6.5
+pytest-mock-resources==2.6.6
 python-dateutil==2.8.2
 pytz==2022.7
 redis==4.4.1

--- a/service/provider/src/main/java/gov/va/vro/service/provider/bip/BipException.java
+++ b/service/provider/src/main/java/gov/va/vro/service/provider/bip/BipException.java
@@ -6,11 +6,6 @@ package gov.va.vro.service.provider.bip;
  * @author warren date 10/31/22
  */
 public class BipException extends RuntimeException {
-  private static final String BIP_ERROR = "VA BIP API access error.";
-
-  public BipException() {
-    super(BIP_ERROR);
-  }
 
   public BipException(String message) {
     super(message);

--- a/service/provider/src/main/java/gov/va/vro/service/provider/bip/service/BipClaimService.java
+++ b/service/provider/src/main/java/gov/va/vro/service/provider/bip/service/BipClaimService.java
@@ -9,6 +9,7 @@ import gov.va.vro.model.bip.UpdateContention;
 import gov.va.vro.model.bip.UpdateContentionReq;
 import gov.va.vro.model.mas.response.FetchPdfResponse;
 import gov.va.vro.service.provider.bip.BipException;
+import gov.va.vro.service.provider.mas.MasException;
 import gov.va.vro.service.provider.mas.MasProcessingObject;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -169,6 +170,9 @@ public class BipClaimService {
    */
   public FetchPdfResponse uploadPdf(FetchPdfResponse pdfResponse) {
     log.info("Uploading pdf for claim {}...", pdfResponse.getClaimSubmissionId());
+    if (pdfResponse.getPdfData() == null) {
+      throw new MasException("PDF Response does not contain any data");
+    }
     String filename = String.format("temp_evidence-%s.pdf", pdfResponse.getClaimSubmissionId());
     File file = null;
     try {
@@ -192,7 +196,7 @@ public class BipClaimService {
               .alternativeDocmentTypeIds(List.of(1))
               .actionable(false)
               .associatedClaimIds(List.of("1"))
-              .notes(List.of(pdfResponse.getReason()))
+              .notes(pdfResponse.getReason() == null ? List.of() : List.of(pdfResponse.getReason()))
               .payeeCode("00")
               .endProductCode("130DPNDCY")
               .regionalProcessingOffice("Buffalo") // get an office.


### PR DESCRIPTION
<!-- Ensure the PR title reflects the feature or bug name -->

## What was the problem?
BipClaimService fails with NPE when pdfResponse.reason is null.

Associated tickets or Slack threads:

- [MCP-2247](https://amida.atlassian.net/browse/MCP-0002247)

## How does this fix it?[^1]
Handle the null condition gracefully.

## How to test this PR
- Run the normal automatedClaimRoute in test or local. 
- Look in the database for the audit trail. There should be no exceptions.


[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
