### PR TITLE
Mcp 2182 - Fix swagger doc errors

### DIFF
--- a/api/src/main/java/gov/va/vro/api/resources/BipResource.java
+++ b/api/src/main/java/gov/va/vro/api/resources/BipResource.java
@@ -107,7 +107,7 @@ public interface BipResource {
   @ResponseStatus(HttpStatus.OK)
   @ApiResponses(
       value = {
-        @ApiResponse(responseCode = "201", description = "Successful Request"),
+        @ApiResponse(responseCode = "200", description = "Successful Request"),
         @ApiResponse(
             responseCode = "401",
             description = "Unauthorized",

--- a/api/src/main/java/gov/va/vro/api/resources/MasResource.java
+++ b/api/src/main/java/gov/va/vro/api/resources/MasResource.java
@@ -71,7 +71,7 @@ public interface MasResource {
   @ResponseStatus(HttpStatus.CREATED)
   @ApiResponses(
       value = {
-        @ApiResponse(responseCode = "201", description = "Successful Request"),
+        @ApiResponse(responseCode = "200", description = "Successful Request"),
         @ApiResponse(
             responseCode = "401",
             description = "Unauthorized",


### PR DESCRIPTION
For a couple of endpoints in swagger ui, the respond messages are incorrect.

## What was the problem?
For endpoint, /v2/examOrderingStatus, the successful response should be 200, but it shows 201 in the doc at present.
For endpoint, /v1/claim/contention/{id}, the successful response should be 200, but it shows 201 in the doc.

Associated tickets or Slack threads:

MCP-2182, MCP-2263

## How does this fix it?[^1]

Adjust the swagger documents.

## How to test this PR
- Step 1. Bring up the application.
- Step 2. Test the two endpoints. The successful responses show 200. 


[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
