### PR TITLE
MCP-2278 Unavailable for Review PDF Template Update

### DIFF
--- a/service-python/pdfgenerator/src/lib/templates/hypertension-v2.html
+++ b/service-python/pdfgenerator/src/lib/templates/hypertension-v2.html
@@ -375,16 +375,12 @@
       <table id="unavailable-automated-review" class="table table-bordered">
         <thead>
           <tr>
-            <th style="width: 271px !important;">Document</th>
-            <th style="width: 90px !important;">VBMS receipt date</th>
-            <th style="width: 240px !important;">Document ID</th>
+            <th>Document ID</th>
           </tr>
         </thead>
         <tbody>
           {% for review in evidence.unavailable_reviews %}
           <tr>
-            <td>{{ review.document }}</td>
-            <td>{{ review.receipt_date }}</td>
             <td>{{ review.document_id }}</td>
           </tr>
           {% endfor %}


### PR DESCRIPTION
<!-- Ensure the PR title reflects the feature or bug name -->

## What was the problem?
<!-- brief description of how things worked before this PR -->
MAS sent us a sample of the data that will be provided for unavailable for review items. From the sample, it only displays the `document id` but we currently have `document`, `receipt date`, and `document id`

`"documentsWithoutAnnotationsChecked": ["{part1-part2-part3-ofguid1}","{part1-part2-part3-ofguid2}","{part1-part2-part3-ofguidN}"]`

Associated tickets or Slack threads:
<!-- replace "000" with ticket number in both places -->
- [MCP-2278](https://amida.atlassian.net/browse/MCP-2278)

## How does this fix it?
<!-- description of how things will work after this PR -->
Remove the extra columns we don't have data for

## How to test this PR
- Generate a PDF, the extra columns should not be in the Unavailable for Review table
