### PR TITLE
Save request payloads for MAS-called API endpoints

### DIFF
--- a/service/provider/src/main/java/gov/va/vro/service/provider/camel/MasIntegrationRoutes.java
+++ b/service/provider/src/main/java/gov/va/vro/service/provider/camel/MasIntegrationRoutes.java
@@ -58,6 +58,10 @@ public class MasIntegrationRoutes extends RouteBuilder {
   private static final String ENDPOINT_COLLECT_EVIDENCE = "direct:collect-evidence";
   public static final String ENDPOINT_OFFRAMP = "seda:offramp";
 
+  // Base names for wiretap endpoints
+  public static final String MAS_CLAIM_WIRETAP = "mas-claim-submitted";
+  public static final String EXAM_ORDER_STATUS_WIRETAP = "exam-order-status";
+
   private final BipClaimService bipClaimService;
 
   private final AuditEventService auditEventService;
@@ -91,6 +95,7 @@ public class MasIntegrationRoutes extends RouteBuilder {
     var checkClaimRouteId = "mas-claim-notification";
     from(ENDPOINT_AUTOMATED_CLAIM)
         .routeId(checkClaimRouteId)
+        .wireTap(VroCamelUtils.wiretapProducer(MAS_CLAIM_WIRETAP))
         .wireTap(ENDPOINT_AUDIT_WIRETAP)
         .onPrepare(auditProcessor(checkClaimRouteId, "Checking if claim is ready..."))
         .delay(header(MAS_DELAY_PARAM))
@@ -192,6 +197,7 @@ public class MasIntegrationRoutes extends RouteBuilder {
     String routeId = "mas-exam-order-status";
     from(ENDPOINT_EXAM_ORDER_STATUS)
         .routeId(routeId)
+        .wireTap(VroCamelUtils.wiretapProducer(EXAM_ORDER_STATUS_WIRETAP))
         .wireTap(ENDPOINT_AUDIT_WIRETAP)
         .onPrepare(auditProcessor(routeId, "Exam Order Status Called"))
         .log("Invoked " + routeId);

--- a/service/provider/src/main/java/gov/va/vro/service/provider/camel/RedisRoutes.java
+++ b/service/provider/src/main/java/gov/va/vro/service/provider/camel/RedisRoutes.java
@@ -21,12 +21,13 @@ class RedisRoutes extends RouteBuilder {
 
     // for v2
     saveToRedis(MasIntegrationRoutes.MAS_CLAIM_WIRETAP, "collectionId", "mas-claim");
-    saveToRedis(MasIntegrationRoutes.EXAM_ORDER_STATUS_WIRETAP, "collectionId", "exam-order-status");
+    saveToRedis(
+        MasIntegrationRoutes.EXAM_ORDER_STATUS_WIRETAP, "collectionId", "exam-order-status");
   }
 
   private void saveToRedis(String tapBasename, String idField, String hashKey) throws Exception {
-    RouteDefinition routeDef = from(VroCamelUtils.wiretapConsumer("redis", tapBasename))
-        .routeId("redis-" + tapBasename);
+    RouteDefinition routeDef =
+        from(VroCamelUtils.wiretapConsumer("redis", tapBasename)).routeId("redis-" + tapBasename);
     appendRedisCommand(routeDef, "HSET", redisKey(idField), hashKey).to(REDIS_ENDPOINT);
   }
 

--- a/service/provider/src/main/java/gov/va/vro/service/provider/camel/RedisRoutes.java
+++ b/service/provider/src/main/java/gov/va/vro/service/provider/camel/RedisRoutes.java
@@ -15,24 +15,19 @@ class RedisRoutes extends RouteBuilder {
 
   @Override
   public void configure() throws Exception {
-    saveIncomingClaimToRedis();
-    savePdfRequestToRedis();
+    // for v1
+    saveToRedis(PrimaryRoutes.INCOMING_CLAIM_WIRETAP, "claimSubmissionId", "submitted-claim");
+    saveToRedis(PrimaryRoutes.GENERATE_PDF_WIRETAP, "claimSubmissionId", "submitted-pdf");
+
+    // for v2
+    saveToRedis(MasIntegrationRoutes.MAS_CLAIM_WIRETAP, "collectionId", "mas-claim");
+    saveToRedis(MasIntegrationRoutes.EXAM_ORDER_STATUS_WIRETAP, "collectionId", "exam-order-status");
   }
 
-  void saveIncomingClaimToRedis() throws Exception {
-    String tapBasename = PrimaryRoutes.INCOMING_CLAIM_WIRETAP;
-    RouteDefinition routeDef =
-        from(VroCamelUtils.wiretapConsumer("redis", tapBasename)).routeId("redis-" + tapBasename);
-    appendRedisCommand(routeDef, "HSET", redisKey("claimSubmissionId"), "submitted-claim")
-        .to(REDIS_ENDPOINT);
-  }
-
-  void savePdfRequestToRedis() throws Exception {
-    String tapBasename = PrimaryRoutes.GENERATE_PDF_WIRETAP;
-    RouteDefinition routeDef =
-        from(VroCamelUtils.wiretapConsumer("redis", tapBasename)).routeId("redis-" + tapBasename);
-    appendRedisCommand(routeDef, "HSET", redisKey("claimSubmissionId"), "submitted-pdf")
-        .to(REDIS_ENDPOINT);
+  private void saveToRedis(String tapBasename, String idField, String hashKey) throws Exception {
+    RouteDefinition routeDef = from(VroCamelUtils.wiretapConsumer("redis", tapBasename))
+        .routeId("redis-" + tapBasename);
+    appendRedisCommand(routeDef, "HSET", redisKey(idField), hashKey).to(REDIS_ENDPOINT);
   }
 
   private ValueBuilder redisKey(String idField) {

--- a/service/provider/src/main/java/gov/va/vro/service/provider/camel/SaveToFileRoutes.java
+++ b/service/provider/src/main/java/gov/va/vro/service/provider/camel/SaveToFileRoutes.java
@@ -17,11 +17,14 @@ class SaveToFileRoutes extends RouteBuilder {
 
   @Override
   public void configure() {
-    // Do not save to file in PROD until we have the encrypted file system in place
-    // and the approved updated ATO
-    if (!config.vroEnv.equalsIgnoreCase("prod") && config.persistTrackingEnabled) {
+    if (config.persistTrackingEnabled) {
+      // for v1
       saveRequestToFile(PrimaryRoutes.INCOMING_CLAIM_WIRETAP);
       saveRequestToFile(PrimaryRoutes.GENERATE_PDF_WIRETAP);
+
+      // for v2
+      saveRequestToFile(MasIntegrationRoutes.MAS_CLAIM_WIRETAP);
+      saveRequestToFile(MasIntegrationRoutes.EXAM_ORDER_STATUS_WIRETAP);
     }
   }
 


### PR DESCRIPTION
<!-- Ensure the PR title reflects the feature or bug name -->

## What was the problem?
<!-- brief description of how things worked before this PR -->

For v2 endpoints, VRO API requests are not being saved to Redis and encrypted disk for diagnostics.

- #984

## How does this fix it?[^1]
<!-- description of how things will work after this PR -->

Add wiretaps that go to existing Camel routes that save VRO API requests to Redis and encrypted disk.

## How to test this PR
Deploy, submit API request, check Redis and disk.

[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
