### PR TITLE
Mcp 2283 - Enhance BIP claim response data handling and fix swagger doc error.

### DIFF
--- a/api/src/main/java/gov/va/vro/api/resources/MasResource.java
+++ b/api/src/main/java/gov/va/vro/api/resources/MasResource.java
@@ -43,7 +43,7 @@ public interface MasResource {
   @ResponseStatus(HttpStatus.CREATED)
   @ApiResponses(
       value = {
-        @ApiResponse(responseCode = "201", description = "Successful Request"),
+        @ApiResponse(responseCode = "200", description = "Successful Request"),
         @ApiResponse(
             responseCode = "400",
             description = "Bad Request",

--- a/shared/domain/src/main/java/gov/va/vro/model/bip/BenefitClaimType.java
+++ b/shared/domain/src/main/java/gov/va/vro/model/bip/BenefitClaimType.java
@@ -1,5 +1,7 @@
 package gov.va.vro.model.bip;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
@@ -11,9 +13,14 @@ import lombok.RequiredArgsConstructor;
  */
 @RequiredArgsConstructor
 @Data
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class BenefitClaimType {
   private String name;
   private String code;
+
+  @JsonProperty("description")
+  private String description;
 
   @JsonProperty("attribute_one")
   private String attributeOne;

--- a/shared/domain/src/main/java/gov/va/vro/model/bip/BipClaim.java
+++ b/shared/domain/src/main/java/gov/va/vro/model/bip/BipClaim.java
@@ -1,5 +1,7 @@
 package gov.va.vro.model.bip;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
 
@@ -10,6 +12,8 @@ import lombok.RequiredArgsConstructor;
  */
 @RequiredArgsConstructor
 @Data
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class BipClaim {
   private String summaryDateTime;
   private String lastModified;

--- a/shared/domain/src/main/java/gov/va/vro/model/bip/ClaimContention.java
+++ b/shared/domain/src/main/java/gov/va/vro/model/bip/ClaimContention.java
@@ -1,5 +1,7 @@
 package gov.va.vro.model.bip;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -18,6 +20,8 @@ import java.util.List;
 @Builder(toBuilder = true)
 @AllArgsConstructor
 @NoArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class ClaimContention {
   private boolean medicalInd;
   private String beginDate;

--- a/shared/domain/src/main/java/gov/va/vro/model/bip/ContentionBaseInfo.java
+++ b/shared/domain/src/main/java/gov/va/vro/model/bip/ContentionBaseInfo.java
@@ -1,5 +1,7 @@
 package gov.va.vro.model.bip;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.Setter;
@@ -13,6 +15,8 @@ import java.util.List;
  */
 @Getter
 @Setter
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class ContentionBaseInfo {
   @Schema(description = "Medical Indicator", example = "true")
   protected boolean medicalInd;

--- a/shared/domain/src/main/java/gov/va/vro/model/bip/Suspense.java
+++ b/shared/domain/src/main/java/gov/va/vro/model/bip/Suspense.java
@@ -1,5 +1,7 @@
 package gov.va.vro.model.bip;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
 
@@ -10,6 +12,8 @@ import lombok.RequiredArgsConstructor;
  */
 @RequiredArgsConstructor
 @Data
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class Suspense {
   private String reason;
   private String reasonCode;

--- a/shared/domain/src/main/java/gov/va/vro/model/bip/TrackedItems.java
+++ b/shared/domain/src/main/java/gov/va/vro/model/bip/TrackedItems.java
@@ -1,5 +1,7 @@
 package gov.va.vro.model.bip;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
@@ -7,6 +9,8 @@ import lombok.Setter;
 @RequiredArgsConstructor
 @Getter
 @Setter
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class TrackedItems {
   private int trackedItemId;
 }

--- a/shared/domain/src/main/java/gov/va/vro/model/bip/Veteran.java
+++ b/shared/domain/src/main/java/gov/va/vro/model/bip/Veteran.java
@@ -1,5 +1,7 @@
 package gov.va.vro.model.bip;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
 
@@ -10,6 +12,8 @@ import lombok.RequiredArgsConstructor;
  */
 @RequiredArgsConstructor
 @Data
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class Veteran {
   private long participantId;
   private String firstName;


### PR DESCRIPTION
Ehance BIP claim data handling and fix minor swagger doc error.

## What was the problem?
1. I saw some data from BIP claim API in UAT that I didn't see in the past. Adding JsonIgonore to avoid error. 
2. The swagger document for automatedClaim successful response code is incorrect.

Associated tickets or Slack threads:

MCP-2283, MCP-2307

## How does this fix it?[^1]


## How to test this PR
- Step 1. Bring up the app, check the swagger ui for automatedClaim endpoint. The successful response code should be 200.
- Step 2. It cannot be tested in local environment for BIP claim response data handling enhancement. In dev, use ClaimID, 350, at automatedClaim.


[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
