### PR TITLE
Use two way TLS for BIP Claims API

### DIFF
--- a/service/provider/src/main/java/gov/va/vro/service/provider/bip/service/BipApiService.java
+++ b/service/provider/src/main/java/gov/va/vro/service/provider/bip/service/BipApiService.java
@@ -47,7 +47,7 @@ public class BipApiService implements IBipApiService {
 
   private static final String HTTPS = "https://";
 
-  @Qualifier("bipRestTemplate")
+  @Qualifier("bipCERestTemplate")
   @NonNull
   private final RestTemplate restTemplate;
 


### PR DESCRIPTION
<!-- Ensure the PR title reflects the feature or bug name -->

## What was the problem?
<!-- brief description of how things worked before this PR -->

Call to BIP Claims API did not use two way TLS

Associated tickets or Slack threads:
<!-- replace "000" with ticket number in both places -->
- [MCP-000](https://amida.atlassian.net/browse/MCP-000)

## How does this fix it?[^1]
<!-- description of how things will work after this PR -->

This will change BIP Claims API calls so that it uses the same CA certificates BIP Claim Evidence uses.  Both APIs use the same CA's; experimented from GFE.

## How to test this PR
- See the BIP Claim End points are still working (cannot be done before deployment)


[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
