### PR TITLE
MCP 2136 Date exception

### DIFF
--- a/service-python/assessclaimdc7101/src/lib/utils.py
+++ b/service-python/assessclaimdc7101/src/lib/utils.py
@@ -12,7 +12,7 @@ def extract_date(date_string):
     try:
         date_entity = datetime.strptime(date_string, "%Y-%m-%dT%H:%M:%SZ").date()
     except ValueError:
-        date_entity = datetime.today()
+        date_entity = datetime.today().date()
 
     return date_entity
 


### PR DESCRIPTION
<!-- Ensure the PR title reflects the feature or bug name -->

## What was the problem?
<!-- brief description of how things worked before this PR -->
Date time and date object are not comparable exception started occuring. Date of claim refactor affected how date of claim is set in the health assessment service. https://github.com/department-of-veterans-affairs/abd-vro/pull/996

Associated tickets or Slack threads:
<!-- replace "000" with ticket number in both places -->
- [MCP-2136](https://amida.atlassian.net/browse/MCP-2136)

## How does this fix it?[^1]
<!-- description of how things will work after this PR -->
Add call to make date object in case there is no date provided. 

## How to test this PR
- Step 1 build and run the default body for automatedClaim
- Step 2[^secrel]


[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
