### PR TITLE
Mcp 2323 - passing claim ID instead of collection ID to BipApiService

### DIFF
--- a/app/src/end2endTest/resources/test-mas/claim-351-7101-noanchor.json
+++ b/app/src/end2endTest/resources/test-mas/claim-351-7101-noanchor.json
@@ -12,7 +12,7 @@
     "participantId": "string"
   },
   "claimDetail": {
-    "benefitClaimId": "1234",
+    "benefitClaimId": "885491",
     "claimSubmissionDateTime": "2018-11-04T17:45:61Z",
     "claimSubmissionSource": "VA.GOV",
     "conditions": {

--- a/app/src/test/java/gov/va/vro/routes/MasIntegrationNegativeTest.java
+++ b/app/src/test/java/gov/va/vro/routes/MasIntegrationNegativeTest.java
@@ -50,6 +50,7 @@ public class MasIntegrationNegativeTest extends BaseIntegrationTest {
     Mockito.when(masApiService.getCollectionAnnotations(collectionId))
         .thenReturn(Collections.singletonList(collectionAnnotation));
     var payload = MasTestData.getMasAutomatedClaimPayload();
+    payload.getClaimDetail().getConditions().setDiagnosticCode("1233");
     try {
       camelEntrance.processClaim(payload);
       fail();

--- a/app/src/test/java/gov/va/vro/service/BipClaimServiceTest.java
+++ b/app/src/test/java/gov/va/vro/service/BipClaimServiceTest.java
@@ -27,52 +27,52 @@ class BipClaimServiceTest {
 
   @Test
   void hasAnchorsWrongJurisdiction() throws BipException {
-
+    long bipClaimId = Long.parseLong(claimId);
     IBipApiService bipApiService = Mockito.mock(IBipApiService.class);
-    Mockito.when(bipApiService.getClaimDetails(collectionId))
+    Mockito.when(bipApiService.getClaimDetails(bipClaimId))
         .thenReturn(createClaim("123", "King Cross"));
 
     BipClaimService claimService = new BipClaimService(bipApiService, null);
-    assertFalse(claimService.hasAnchors(collectionId));
+    assertFalse(claimService.hasAnchors(bipClaimId));
   }
 
   @Test
   void hasAnchorsMissingSpecialIssue() throws BipException {
-
+    long bipClaimId = Long.parseLong(claimId);
     IBipApiService bipApiService = Mockito.mock(IBipApiService.class);
-    Mockito.when(bipApiService.getClaimDetails(collectionId))
-        .thenReturn(createClaim(claimId, "398"));
-    Mockito.when(bipApiService.getClaimContentions(Integer.parseInt(claimId)))
+    Mockito.when(bipApiService.getClaimDetails(bipClaimId)).thenReturn(createClaim(claimId, "398"));
+    Mockito.when(bipApiService.getClaimContentions(bipClaimId))
         .thenReturn(
             List.of(
                 createContention(List.of("TEST", "RRD")),
                 createContention(List.of("RRD", "OTHER"))));
 
     BipClaimService claimService = new BipClaimService(bipApiService, null);
-    assertFalse(claimService.hasAnchors(collectionId));
+    assertFalse(claimService.hasAnchors(bipClaimId));
   }
 
   @Test
   void hasAnchors() throws BipException {
 
+    long bipClaimId = Long.parseLong(claimId);
     IBipApiService bipApiService = Mockito.mock(IBipApiService.class);
-    Mockito.when(bipApiService.getClaimDetails(collectionId))
-        .thenReturn(createClaim(claimId, "398"));
-    Mockito.when(bipApiService.getClaimContentions(Integer.parseInt(claimId)))
+    Mockito.when(bipApiService.getClaimDetails(bipClaimId)).thenReturn(createClaim(claimId, "398"));
+    Mockito.when(bipApiService.getClaimContentions(bipClaimId))
         .thenReturn(
             List.of(
                 createContention(List.of("TEST", "RRD")),
                 createContention(List.of("Rating Decision Review - Level 1", "OTHER"))));
 
     BipClaimService claimService = new BipClaimService(bipApiService, null);
-    assertTrue(claimService.hasAnchors(collectionId));
+    assertTrue(claimService.hasAnchors(bipClaimId));
   }
 
   @Test
   void removeSpecialIssueMissing() throws BipException {
+    long bipClaimId = Long.parseLong(claimId);
     IBipApiService bipApiService = Mockito.mock(IBipApiService.class);
 
-    Mockito.when(bipApiService.getClaimContentions(Integer.parseInt(claimId)))
+    Mockito.when(bipApiService.getClaimContentions(bipClaimId))
         .thenReturn(
             List.of(
                 createContention(List.of("TEST", "RRD")),
@@ -87,9 +87,10 @@ class BipClaimServiceTest {
 
   @Test
   void removeSpecialIssue() throws BipException {
+    long bipClaimId = Long.parseLong(claimId);
     IBipApiService bipApiService = Mockito.mock(IBipApiService.class);
 
-    Mockito.when(bipApiService.getClaimContentions(Integer.parseInt(claimId)))
+    Mockito.when(bipApiService.getClaimContentions(bipClaimId))
         .thenReturn(
             List.of(
                 createContention(List.of("TEST", "RRD")),
@@ -107,8 +108,9 @@ class BipClaimServiceTest {
 
   @Test
   void completeProcessingNotRightStation() throws BipException {
+    long bipClaimId = Long.parseLong(claimId);
     IBipApiService bipApiService = Mockito.mock(IBipApiService.class);
-    Mockito.when(bipApiService.getClaimDetails(collectionId))
+    Mockito.when(bipApiService.getClaimDetails(bipClaimId))
         .thenReturn(createClaim(claimId, "Short Line"));
 
     BipClaimService claimService = new BipClaimService(bipApiService, null);
@@ -118,14 +120,14 @@ class BipClaimServiceTest {
 
   @Test
   void completeProcessing() throws BipException {
+    long bipClaimId = Long.parseLong(claimId);
     IBipApiService bipApiService = Mockito.mock(IBipApiService.class);
-    Mockito.when(bipApiService.getClaimDetails(collectionId))
-        .thenReturn(createClaim(claimId, "398"));
+    Mockito.when(bipApiService.getClaimDetails(bipClaimId)).thenReturn(createClaim(claimId, "398"));
 
     BipClaimService claimService = new BipClaimService(bipApiService, null);
     var payload = MasTestData.getMasAutomatedClaimPayload(collectionId, "1701", claimId);
     assertTrue(claimService.completeProcessing(getMpo(payload)).isTSOJ());
-    Mockito.verify(bipApiService).setClaimToRfdStatus(collectionId);
+    Mockito.verify(bipApiService).setClaimToRfdStatus(bipClaimId);
   }
 
   @Test

--- a/controller/src/main/java/gov/va/vro/controller/exception/GlobalExceptionHandler.java
+++ b/controller/src/main/java/gov/va/vro/controller/exception/GlobalExceptionHandler.java
@@ -145,6 +145,10 @@ public class GlobalExceptionHandler {
   public ResponseEntity<ClaimProcessingError> handleBipClaimException(BipException exception) {
     log.error("BIP exception: {}", exception.getMessage(), exception);
     ClaimProcessingError cpe = new ClaimProcessingError(exception.getMessage());
-    return new ResponseEntity<>(cpe, exception.getStatus());
+    return new ResponseEntity<>(
+        cpe,
+        exception.getStatus() == HttpStatus.NOT_FOUND
+            ? HttpStatus.BAD_REQUEST
+            : exception.getStatus());
   }
 }

--- a/service/provider/src/main/java/gov/va/vro/service/provider/bip/service/BipApiService.java
+++ b/service/provider/src/main/java/gov/va/vro/service/provider/bip/service/BipApiService.java
@@ -67,6 +67,8 @@ public class BipApiService implements IBipApiService {
       if (bipResponse.getStatusCode() == HttpStatus.OK) {
         BipClaimResp result = mapper.readValue(bipResponse.getBody(), BipClaimResp.class);
         return result.getClaim();
+      } else if (bipResponse.getStatusCode() == HttpStatus.NOT_FOUND) {
+        return null;
       } else {
         log.error(
             "Failed to get claim details for {}. {} \n{}",

--- a/service/provider/src/main/java/gov/va/vro/service/provider/bip/service/BipApiService.java
+++ b/service/provider/src/main/java/gov/va/vro/service/provider/bip/service/BipApiService.java
@@ -67,8 +67,6 @@ public class BipApiService implements IBipApiService {
       if (bipResponse.getStatusCode() == HttpStatus.OK) {
         BipClaimResp result = mapper.readValue(bipResponse.getBody(), BipClaimResp.class);
         return result.getClaim();
-      } else if (bipResponse.getStatusCode() == HttpStatus.NOT_FOUND) {
-        return null;
       } else {
         log.error(
             "Failed to get claim details for {}. {} \n{}",

--- a/service/provider/src/main/java/gov/va/vro/service/provider/bip/service/BipClaimService.java
+++ b/service/provider/src/main/java/gov/va/vro/service/provider/bip/service/BipClaimService.java
@@ -131,11 +131,11 @@ public class BipClaimService {
    * @return the claim payload
    */
   public MasProcessingObject markAsRfd(MasProcessingObject payload) {
-    int collectionId = payload.getCollectionId();
-    log.info("Marking claim with collectionId = {} as Ready For Decision", collectionId);
+    long claimId = payload.getClaimIdAsLong();
+    log.info("Marking claim with claimId = {} as Ready For Decision", claimId);
 
     try {
-      bipApiService.updateClaimStatus(collectionId, ClaimStatus.RFD);
+      bipApiService.updateClaimStatus(claimId, ClaimStatus.RFD);
     } catch (Exception e) {
       throw new BipException("BIP update claim status resulted in an exception", e);
     }
@@ -145,8 +145,7 @@ public class BipClaimService {
   /** Check if claim is still eligible for fast tracking, and if so, update status. */
   public MasProcessingObject completeProcessing(MasProcessingObject payload) {
     int collectionId = payload.getCollectionId();
-    String claimIdString = payload.getClaimPayload().getClaimDetail().getBenefitClaimId();
-    long claimId = Long.parseLong(claimIdString);
+    long claimId = payload.getClaimIdAsLong();
 
     // check again if TSOJ. If not, abandon route
     var claim = bipApiService.getClaimDetails(claimId);

--- a/service/provider/src/main/java/gov/va/vro/service/provider/bip/service/MockBipApiService.java
+++ b/service/provider/src/main/java/gov/va/vro/service/provider/bip/service/MockBipApiService.java
@@ -105,7 +105,7 @@ public class MockBipApiService implements IBipApiService {
       // wrong station
       return buildClaim(999, "OTHER");
     } else if (collectionId == CLAIM_ID_404) { // invalid claim ID, return null per BipClaimService.
-      return null;
+      throw new BipException(HttpStatus.NOT_FOUND, ERR_MSG_404);
     } else if (collectionId == CLAIM_ID_401) { // not authorized, throw BipException
       throw new BipException(HttpStatus.UNAUTHORIZED, ERR_MSG_401);
     } else if (collectionId == CLAIM_ID_500) { // internal error, throw BipException

--- a/service/provider/src/main/java/gov/va/vro/service/provider/bip/service/MockBipApiService.java
+++ b/service/provider/src/main/java/gov/va/vro/service/provider/bip/service/MockBipApiService.java
@@ -101,9 +101,9 @@ public class MockBipApiService implements IBipApiService {
     if (collectionId == 350 || collectionId == 353) {
       // valid
       return buildClaim(1234, BipClaimService.TSOJ);
-    } else if (collectionId == 351) {
+    } else if (collectionId == 885491) {
       // wrong station
-      return buildClaim(999, "OTHER");
+      return buildClaim(885491, "OTHER");
     } else if (collectionId == CLAIM_ID_404) { // invalid claim ID, throw BipException.
       throw new BipException(HttpStatus.NOT_FOUND, ERR_MSG_404);
     } else if (collectionId == CLAIM_ID_401) { // not authorized, throw BipException

--- a/service/provider/src/main/java/gov/va/vro/service/provider/bip/service/MockBipApiService.java
+++ b/service/provider/src/main/java/gov/va/vro/service/provider/bip/service/MockBipApiService.java
@@ -104,7 +104,7 @@ public class MockBipApiService implements IBipApiService {
     } else if (collectionId == 351) {
       // wrong station
       return buildClaim(999, "OTHER");
-    } else if (collectionId == CLAIM_ID_404) { // invalid claim ID, return null per BipClaimService.
+    } else if (collectionId == CLAIM_ID_404) { // invalid claim ID, throw BipException.
       throw new BipException(HttpStatus.NOT_FOUND, ERR_MSG_404);
     } else if (collectionId == CLAIM_ID_401) { // not authorized, throw BipException
       throw new BipException(HttpStatus.UNAUTHORIZED, ERR_MSG_401);

--- a/service/provider/src/main/java/gov/va/vro/service/provider/bip/service/MockBipApiService.java
+++ b/service/provider/src/main/java/gov/va/vro/service/provider/bip/service/MockBipApiService.java
@@ -104,8 +104,8 @@ public class MockBipApiService implements IBipApiService {
     } else if (collectionId == 351) {
       // wrong station
       return buildClaim(999, "OTHER");
-    } else if (collectionId == CLAIM_ID_404) { // invalid claim ID, throw BipException
-      throw new BipException(HttpStatus.NOT_FOUND, ERR_MSG_404);
+    } else if (collectionId == CLAIM_ID_404) { // invalid claim ID, return null per BipClaimService.
+      return null;
     } else if (collectionId == CLAIM_ID_401) { // not authorized, throw BipException
       throw new BipException(HttpStatus.UNAUTHORIZED, ERR_MSG_401);
     } else if (collectionId == CLAIM_ID_500) { // internal error, throw BipException

--- a/service/provider/src/main/java/gov/va/vro/service/provider/mas/MasProcessingObject.java
+++ b/service/provider/src/main/java/gov/va/vro/service/provider/mas/MasProcessingObject.java
@@ -22,6 +22,12 @@ public class MasProcessingObject implements Auditable {
     return claimPayload.getClaimDetail().getBenefitClaimId();
   }
 
+  public long getClaimIdAsLong() {
+    String claimIdString = getClaimId();
+    long claimId = Long.parseLong(claimIdString);
+    return claimId;
+  }
+
   public String getVeteranIcn() {
     return claimPayload.getVeteranIcn();
   }

--- a/service/provider/src/main/java/gov/va/vro/service/provider/mas/service/MasProcessingService.java
+++ b/service/provider/src/main/java/gov/va/vro/service/provider/mas/service/MasProcessingService.java
@@ -72,7 +72,9 @@ public class MasProcessingService {
       return Optional.of(message);
     }
 
-    if (!bipClaimService.hasAnchors(payload.getCollectionId())) {
+    long claimId = Long.parseLong(payload.getClaimDetail().getBenefitClaimId());
+    log.info("Check hasAnchors for claim ID, {}", claimId); // TODO: remove it after test.
+    if (!bipClaimService.hasAnchors(claimId)) {
       var message =
           String.format(
               "Claim with [collection id = %s] does not qualify for"


### PR DESCRIPTION
The current code passes collection ID to BipApiService instead of claim ID it expects.

## What was the problem?
It appears the collection ID from MAS is different from the Claim ID used in BIP. It causes the claim not be found error.

Note: There is a unit test failed after merging the latest code from develop. 
MasIntegrationNegativeTest > processClaimLighthouseConnectFailed() FAILED
  org.opentest4j.AssertionFailedError at MasIntegrationNegativeTest.java:55

Associated tickets or Slack threads:
MCP-2323

## How does this fix it?[^1]
1. Replace collection ID with Claim ID found in MasAutomatedClaimRequest.getClaimDetail().getBenefitClaimId().2. 
2. When claim is not found in BIP, make automatedClaim endpoint return 400 with a message.
 
## How to test this PR
- Step 1
- Step 2[^secrel]


[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
