### PR TITLE
Mcp 2319 - Add unit tests and code clean up.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -71,6 +71,7 @@ dependencies {
   testRuntimeOnly "com.h2database:h2:${h2_version}"
 
   testImplementation "org.apache.camel:camel-test-spring-junit5:${camel_version}"
+  testImplementation "io.jsonwebtoken:jjwt:0.2"
 
   // end to end dependencies
   end2endTestImplementation "org.junit.jupiter:junit-jupiter-api:${junit_jupiter_version}"

--- a/app/src/main/java/gov/va/vro/config/BipApiConfig.java
+++ b/app/src/main/java/gov/va/vro/config/BipApiConfig.java
@@ -1,6 +1,7 @@
 package gov.va.vro.config;
 
 import gov.va.vro.service.provider.BipApiProps;
+import gov.va.vro.service.provider.ClaimProps;
 import gov.va.vro.service.provider.bip.BipException;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
@@ -53,6 +54,11 @@ public class BipApiConfig {
   @Bean
   public BipApiProps getBipApiProps() {
     return new BipApiProps();
+  }
+
+  @Bean
+  public ClaimProps getClaimProps() {
+    return new ClaimProps();
   }
 
   private KeyStore getKeyStore(String base64, String password)

--- a/app/src/main/resources/application.yml
+++ b/app/src/main/resources/application.yml
@@ -221,7 +221,10 @@ truststore_password: "${BIP_PASSWORD}"
 keystore: "${BIP_KEYSTORE}"
 bipalias: "${BIP_ALIAS}"
 
+claim:
+  special_issue_1: "RDR1"
+  special_issue_2: "RRD"
+
 spring.config.import: >
   conf-camel.yml,
   conf-camel-rabbitmq.yml
-

--- a/app/src/test/java/gov/va/vro/service/BipApiServiceTest.java
+++ b/app/src/test/java/gov/va/vro/service/BipApiServiceTest.java
@@ -1,0 +1,266 @@
+package gov.va.vro.service;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import gov.va.vro.model.bip.BipClaim;
+import gov.va.vro.model.bip.BipUpdateClaimResp;
+import gov.va.vro.model.bip.ClaimContention;
+import gov.va.vro.model.bip.UpdateContentionReq;
+import gov.va.vro.service.provider.BipApiProps;
+import gov.va.vro.service.provider.bip.BipException;
+import gov.va.vro.service.provider.bip.service.BipApiService;
+import io.jsonwebtoken.Claims;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentMatchers;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestTemplate;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Objects;
+
+/** @author warren @Date 2/2/23 */
+@ExtendWith(MockitoExtension.class)
+@Slf4j
+public class BipApiServiceTest {
+  private static final long GOOD_CLAIM_ID = 9666959L;
+
+  private static final long BAD_CLAIM_ID = 9666958L;
+  private static final String CONTENTION_RESPONSE_200 =
+      "bip-test-data/contention_response_200.json";
+  private static final String CONTENTION_RESPONSE_412 =
+      "bip-test-data/contention_response_412.json";
+
+  private static final String CLAIM_RESPONSE_404 = "bip-test-data/claim_response_404.json";
+  private static final String CLAIM_RESPONSE_200 = "bip-test-data/claim_response_200.json";
+  private static final String CLAIM_DETAILS = "/claims/%s";
+  private static final String UPDATE_CLAIM_STATUS = "/claims/%s/lifecycle_status";
+  private static final String CONTENTION = "/claims/%s/contentions";
+  private static final String HTTPS = "https://";
+  private static final String CLAIM_URL = "claims.bip.va.gov";
+  private static final String CLAIM_SECRET = "secret";
+  private static final String CLAIM_USERID = "userid";
+  private static final String CLAIM_ISSUER = "issuer";
+  private static final String STATION_ID = "280";
+  private static final String APP_ID = "bip";
+  private static final String APP_NAME = "vro";
+  private static final String CLAIM_JTI = "032-83583455";
+
+  @InjectMocks private BipApiService service;
+
+  @Mock private RestTemplate restTemplate;
+
+  @Mock private BipApiProps bipApiProps;
+
+  private String getTestData(String data_file) throws Exception {
+    String filename =
+        Objects.requireNonNull(getClass().getClassLoader().getResource(data_file)).getPath();
+    Path filePath = Path.of(filename);
+    return Files.readString(filePath);
+  }
+
+  private void mockBipApiProp() {
+    BipApiProps props = new BipApiProps();
+    props.setApplicationId(APP_ID);
+    props.setApplicationId(CLAIM_ISSUER);
+    props.setJti(CLAIM_JTI);
+    props.setApplicationName(APP_NAME);
+    props.setStationId(STATION_ID);
+    props.setClaimClientId(CLAIM_USERID);
+
+    Claims claims = props.toCommonJwtClaims();
+
+    Mockito.doReturn(CLAIM_URL).when(bipApiProps).getClaimBaseUrl();
+    Mockito.doReturn(CLAIM_ISSUER).when(bipApiProps).getClaimIssuer();
+    Mockito.doReturn(CLAIM_SECRET).when(bipApiProps).getClaimSecret();
+    Mockito.doReturn(claims).when(bipApiProps).toCommonJwtClaims();
+  }
+
+  @Test
+  public void testGetClaimDetails() throws Exception {
+
+    String resp200Body = getTestData(CLAIM_RESPONSE_200);
+    String resp404Body = getTestData(CLAIM_RESPONSE_404);
+
+    ResponseEntity<String> resp200 = ResponseEntity.ok(resp200Body);
+    ResponseEntity<String> resp404 = ResponseEntity.status(HttpStatus.NOT_FOUND).body(resp404Body);
+    String baseUrl = HTTPS + CLAIM_URL;
+    String claimUrl = baseUrl + String.format(CLAIM_DETAILS, GOOD_CLAIM_ID);
+    String badClaimUrl = baseUrl + String.format(CLAIM_DETAILS, BAD_CLAIM_ID);
+
+    Mockito.doReturn(resp200)
+        .when(restTemplate)
+        .exchange(
+            ArgumentMatchers.eq(claimUrl),
+            ArgumentMatchers.eq(HttpMethod.GET),
+            ArgumentMatchers.any(HttpEntity.class),
+            ArgumentMatchers.eq(String.class));
+    Mockito.doReturn(resp404)
+        .when(restTemplate)
+        .exchange(
+            ArgumentMatchers.eq(badClaimUrl),
+            ArgumentMatchers.eq(HttpMethod.GET),
+            ArgumentMatchers.any(HttpEntity.class),
+            ArgumentMatchers.eq(String.class));
+    mockBipApiProp();
+    try {
+      BipClaim result = service.getClaimDetails(GOOD_CLAIM_ID);
+      assertNotNull(result);
+    } catch (BipException e) {
+      log.error("Positive getClaimDetails test failed.", e);
+      fail();
+    }
+
+    try {
+      BipClaim result = service.getClaimDetails(BAD_CLAIM_ID);
+      log.error("Negative getClaimDetails test failed. {}", result.getClaimId());
+      fail();
+    } catch (BipException e) {
+      assertSame(HttpStatus.NOT_FOUND, e.getStatus());
+    }
+  }
+
+  @Test
+  public void testSetClaimToRfdStatus() {
+    String baseUrl = HTTPS + CLAIM_URL;
+    String goodUrl = baseUrl + String.format(UPDATE_CLAIM_STATUS, GOOD_CLAIM_ID);
+    String badUrl = baseUrl + String.format(UPDATE_CLAIM_STATUS, BAD_CLAIM_ID);
+    ResponseEntity<String> resp200 = ResponseEntity.ok("{}");
+    ResponseEntity<String> resp500 =
+        ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("error");
+    Mockito.doReturn(resp200)
+        .when(restTemplate)
+        .exchange(
+            ArgumentMatchers.eq(goodUrl),
+            ArgumentMatchers.eq(HttpMethod.PUT),
+            ArgumentMatchers.any(HttpEntity.class),
+            ArgumentMatchers.eq(String.class));
+    Mockito.doReturn(resp500)
+        .when(restTemplate)
+        .exchange(
+            ArgumentMatchers.eq(badUrl),
+            ArgumentMatchers.eq(HttpMethod.PUT),
+            ArgumentMatchers.any(HttpEntity.class),
+            ArgumentMatchers.eq(String.class));
+
+    mockBipApiProp();
+    try {
+      BipUpdateClaimResp result = service.setClaimToRfdStatus(GOOD_CLAIM_ID);
+      assertSame(result.getStatus(), HttpStatus.OK);
+    } catch (BipException e) {
+      log.error("Positive setClaimToRfdStatus test failed.", e);
+      fail();
+    }
+
+    try {
+      BipUpdateClaimResp result = service.setClaimToRfdStatus(BAD_CLAIM_ID);
+      log.error("Negative setClaimToRfdStatus test failed.");
+      fail();
+    } catch (BipException e) {
+      assertSame(HttpStatus.INTERNAL_SERVER_ERROR, e.getStatus());
+    }
+  }
+
+  @Test
+  public void testGetClaimContention() throws Exception {
+    String resp200Body = getTestData(CONTENTION_RESPONSE_200);
+    String resp404Body = getTestData(CLAIM_RESPONSE_404);
+    ResponseEntity<String> resp200 = ResponseEntity.ok(resp200Body);
+    ResponseEntity<String> resp404 = ResponseEntity.status(HttpStatus.NOT_FOUND).body(resp404Body);
+
+    String baseUrl = HTTPS + CLAIM_URL;
+    String goodUrl = baseUrl + String.format(CONTENTION, GOOD_CLAIM_ID);
+    String badUrl = baseUrl + String.format(CONTENTION, BAD_CLAIM_ID);
+
+    Mockito.doReturn(resp200)
+        .when(restTemplate)
+        .exchange(
+            ArgumentMatchers.eq(goodUrl),
+            ArgumentMatchers.eq(HttpMethod.GET),
+            ArgumentMatchers.any(HttpEntity.class),
+            ArgumentMatchers.eq(String.class));
+    Mockito.doReturn(resp404)
+        .when(restTemplate)
+        .exchange(
+            ArgumentMatchers.eq(badUrl),
+            ArgumentMatchers.eq(HttpMethod.GET),
+            ArgumentMatchers.any(HttpEntity.class),
+            ArgumentMatchers.eq(String.class));
+
+    mockBipApiProp();
+    try {
+      List<ClaimContention> result = service.getClaimContentions(GOOD_CLAIM_ID);
+      assertTrue(result.size() > 0);
+    } catch (BipException e) {
+      log.error("Positive getClaimContentions test failed.", e);
+      fail();
+    }
+
+    try {
+      List<ClaimContention> result = service.getClaimContentions(BAD_CLAIM_ID);
+      log.error("Negative getClaimContentions test failed.");
+      fail();
+    } catch (BipException e) {
+      assertSame(HttpStatus.NOT_FOUND, e.getStatus());
+    }
+  }
+
+  @Test
+  public void testUpdateClaimContention() throws Exception {
+    String resp200Body = getTestData(CONTENTION_RESPONSE_200);
+    String resp412Body = getTestData(CONTENTION_RESPONSE_412);
+    ResponseEntity<String> resp200 = ResponseEntity.ok(resp200Body);
+    ResponseEntity<String> resp412 =
+        ResponseEntity.status(HttpStatus.PRECONDITION_FAILED).body(resp412Body);
+
+    String baseUrl = HTTPS + CLAIM_URL;
+    String goodUrl = baseUrl + String.format(CONTENTION, GOOD_CLAIM_ID);
+    String badUrl = baseUrl + String.format(CONTENTION, BAD_CLAIM_ID);
+
+    Mockito.doReturn(resp200)
+        .when(restTemplate)
+        .exchange(
+            ArgumentMatchers.eq(goodUrl),
+            ArgumentMatchers.eq(HttpMethod.PUT),
+            ArgumentMatchers.any(HttpEntity.class),
+            ArgumentMatchers.eq(String.class));
+    Mockito.doReturn(resp412)
+        .when(restTemplate)
+        .exchange(
+            ArgumentMatchers.eq(badUrl),
+            ArgumentMatchers.eq(HttpMethod.PUT),
+            ArgumentMatchers.any(HttpEntity.class),
+            ArgumentMatchers.eq(String.class));
+
+    mockBipApiProp();
+    UpdateContentionReq request = UpdateContentionReq.builder().build();
+    try {
+      BipUpdateClaimResp result = service.updateClaimContention(GOOD_CLAIM_ID, request);
+      assertSame(HttpStatus.OK, result.getStatus());
+    } catch (BipException e) {
+      log.error("Positive updateClaimContention test failed.", e);
+      fail();
+    }
+
+    try {
+      BipUpdateClaimResp result = service.updateClaimContention(BAD_CLAIM_ID, request);
+      log.error("Negative updateClaimContention test failed.");
+      fail();
+    } catch (BipException e) {
+      assertSame(HttpStatus.PRECONDITION_FAILED, e.getStatus());
+    }
+  }
+}

--- a/app/src/test/resources/bip-test-data/claim_response_200.json
+++ b/app/src/test/resources/bip-test-data/claim_response_200.json
@@ -1,0 +1,47 @@
+{
+  "claim": {
+    "summaryDateTime": "2023-02-06T18:06:11.943377Z",
+    "lastModified": "2022-11-15T20:32:20-06:00",
+    "claimId": 9666958,
+    "benefitClaimType": {
+      "name": "Privacy Act Request",
+      "code": "510PAR",
+      "attribute_one": "CLAIM_TYPE_LABEL",
+      "attribute_one_text": "Freedom of Information Act / Privacy Act Request",
+      "attribute_two": "USER_DISPLAY",
+      "attribute_two_text": "YES",
+      "attribute_three": "Rating/Non-rating"
+    },
+    "phase": "Pending Decision Approval",
+    "phaseLastChangedDate": "2021-05-15T12:29:04-05:00",
+    "claimLifecycleStatus": "Rating Decision Complete",
+    "claimant": {
+      "participantId": 439059
+    },
+    "veteran": {
+      "participantId": 439059,
+      "firstName": "AUGUST",
+      "lastName": "THIRD"
+    },
+    "receivedDate": "2006-05-01T00:00:00-05:00",
+    "payeeTypeCode": "00",
+    "serviceTypeCode": "CP",
+    "programTypeCode": "CPL",
+    "endProductCode": "510",
+    "tempStationOfJurisdiction": "499",
+    "claimStationOfJurisdiction": "317",
+    "awardStationOfJurisdiction": "317",
+    "suspense": {
+      "reason": "Documents uploaded into eFolder",
+      "reasonCode": "053",
+      "date": "2012-11-06T07:21:47-06:00",
+      "comment": "Adding custom text",
+      "changedDate": "2022-10-04T15:07:39-05:00",
+      "changedBy": "BIPCLAIMSYSACCT"
+    },
+    "suspenseReasonCode": "053",
+    "suspenseDate": "2012-11-06T07:21:47-06:00",
+    "suspenseComment": "Adding custom text",
+    "establishedDate": "2006-08-03T07:10:28-05:00"
+  }
+}

--- a/app/src/test/resources/bip-test-data/claim_response_404.json
+++ b/app/src/test/resources/bip-test-data/claim_response_404.json
@@ -1,0 +1,12 @@
+{
+  "messages": [
+    {
+      "timestamp": "2023-02-06T18:10:59.288",
+      "key": "bip.vetservices.claims.contentions.claimidnotfound",
+      "severity": "FATAL",
+      "status": "404",
+      "text": "Claim ID 600333556 not found",
+      "httpStatus": "NOT_FOUND"
+    }
+  ]
+}

--- a/app/src/test/resources/bip-test-data/contention_response_200.json
+++ b/app/src/test/resources/bip-test-data/contention_response_200.json
@@ -1,0 +1,32 @@
+{
+  "contentions": [
+    {
+      "medicalInd": true,
+      "beginDate": "2022-12-06T14:19:57-06:00",
+      "createDate": "2022-12-06T14:12:57-06:00",
+      "altContentionName": "string",
+      "completedDate": "2023-02-06T14:12:57-06:00",
+      "notificationDate": "2022-12-06T14:12:57-06:00",
+      "contentionTypeCode": "NEW",
+      "classificationType": 1250,
+      "diagnosticTypeCode": "6100",
+      "claimantText": "Test to update a contention.",
+      "contentionStatusTypeCode": "C",
+      "originalSourceTypeCode": "PHYS",
+      "specialIssueCodes": [
+        "ELIGIBILITY",
+        "AOOV"
+      ],
+      "associatedTrackedItems": [
+        {
+          "trackedItemId": 0
+        }
+      ],
+      "contentionId": 479847,
+      "lastModified": "2023-01-22T13:57:42-06:00",
+      "lifecycleStatus": "Ready for Decision",
+      "automationIndicator": false,
+      "summaryDateTime": "2023-02-06T18:24:36.649749Z"
+    }
+  ]
+}

--- a/app/src/test/resources/bip-test-data/contention_response_412.json
+++ b/app/src/test/resources/bip-test-data/contention_response_412.json
@@ -1,0 +1,12 @@
+{
+  "messages": [
+    {
+      "timestamp": "2023-02-06T18:27:32.316",
+      "key": "bip.vetservices.lastmodified.not.matched",
+      "severity": "ERROR",
+      "status": "412",
+      "text": "LastModified does not mach, possible concurrent modification",
+      "httpStatus": "PRECONDITION_FAILED"
+    }
+  ]
+}

--- a/controller/src/main/java/gov/va/vro/controller/BipController.java
+++ b/controller/src/main/java/gov/va/vro/controller/BipController.java
@@ -47,7 +47,7 @@ import javax.validation.Valid;
 @Slf4j
 @RestController
 @RequiredArgsConstructor
-@Profile("!qa & !sandbox & !prod")
+@Profile("dev")
 public class BipController implements BipResource {
   private final IBipApiService service;
 

--- a/service/provider/build.gradle
+++ b/service/provider/build.gradle
@@ -38,4 +38,5 @@ dependencies {
   implementation "org.springframework.boot:spring-boot-starter-security:${sb_security}"
 
   implementation 'io.jsonwebtoken:jjwt:0.2'
+  testImplementation 'io.jsonwebtoken:jjwt:0.2'
 }

--- a/service/provider/src/main/java/gov/va/vro/service/provider/BipApiProps.java
+++ b/service/provider/src/main/java/gov/va/vro/service/provider/BipApiProps.java
@@ -1,7 +1,6 @@
 package gov.va.vro.service.provider;
 
 import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.Header;
 import io.jsonwebtoken.Jwts;
 import lombok.Getter;
 import lombok.Setter;
@@ -9,8 +8,6 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 
 import java.util.Calendar;
 import java.util.Date;
-import java.util.HashMap;
-import java.util.Map;
 
 /**
  * Properties used in BIP API services.
@@ -63,9 +60,6 @@ public class BipApiProps {
     Date now = cal.getTime();
     claims.put("iat", now.getTime());
     claims.put("expires", expired.getTime());
-    Map<String, Object> headerType = new HashMap<>();
-    headerType.put("typ", Header.JWT_TYPE);
-
     return claims;
   }
 }

--- a/service/provider/src/main/java/gov/va/vro/service/provider/ClaimProps.java
+++ b/service/provider/src/main/java/gov/va/vro/service/provider/ClaimProps.java
@@ -1,0 +1,14 @@
+package gov.va.vro.service.provider;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/** @author warren @Date 2/7/23 */
+@Getter
+@Setter
+@ConfigurationProperties(prefix = "claim")
+public class ClaimProps {
+  private String specialIssue1;
+  private String specialIssue2;
+}

--- a/service/provider/src/main/java/gov/va/vro/service/provider/bip/service/MockBipApiService.java
+++ b/service/provider/src/main/java/gov/va/vro/service/provider/bip/service/MockBipApiService.java
@@ -135,8 +135,7 @@ public class MockBipApiService implements IBipApiService {
   @Override
   public List<ClaimContention> getClaimContentions(long claimId) throws BipException {
     if (claimId == 1234) {
-      return List.of(
-          buildContention(BipClaimService.SPECIAL_ISSUE_1, BipClaimService.SPECIAL_ISSUE_2));
+      return List.of(buildContention("RDR1", "RRD"));
     } else if (claimId == CLAIM_ID_204) { // No data. Returns an empty list.
       return new ArrayList<>();
     } else if (claimId == CLAIM_ID_404) { // invalid claim ID, throw BipException


### PR DESCRIPTION
Add unit test for BIP Claim API service, and minor code clean up.

## What was the problem?
BIP Claim API service is not covered by unit tests. There some unused code left and they should be removed.

Additional work has been added to this PR.
1. Set BIP Controller to be controlled by profile. It will show up only in dev environment. 
2. Refactor Contention Special_Issue code handling. Move the constants to application.yml. 
3. Minor change in checking contention special issue code to a possible mismatching, and add logs for debug. 

Associated tickets or Slack threads:
MCP-2319

## How does this fix it?[^1]
<!-- description of how things will work after this PR -->

## How to test this PR
- Step 1. Build the application
- Step 2. Check the test report for app. BipApiService should be covered.
- Step 3. When ENV is not set, BIP Controller endpoints should bot be shown. When EVN=dev, launch the app, BIP Controller endpoints should show up.
- Step 4. Test automatedClaim and check logs to see contention special issue checking.


[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
