### PR TITLE
mcp-2335

### DIFF
--- a/app/src/main/java/gov/va/vro/config/MasVeteranFlashConfig.java
+++ b/app/src/main/java/gov/va/vro/config/MasVeteranFlashConfig.java
@@ -1,0 +1,17 @@
+package gov.va.vro.config;
+
+import gov.va.vro.model.mas.MasVeteranFlashProps;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/** Configure Veteran Flash IDs. */
+@Configuration
+public class MasVeteranFlashConfig {
+
+  @Bean
+  MasVeteranFlashProps MasVeteranFlashConfigLoad(
+      @Value("${masVeteranFlashIds.agentOrange}") String[] agentOrangeFlashIds) {
+    return MasVeteranFlashProps.getInstance(agentOrangeFlashIds);
+  }
+}

--- a/app/src/main/resources/application.yml
+++ b/app/src/main/resources/application.yml
@@ -157,7 +157,7 @@ lhAPIProvider:
   validateToken: "${VALIDATE_TOKEN:NO}"
 
 masVeteranFlashIds:
-  agentOrange: "${MAS_FLASH_IDS_AGENT_ORANGE:266,266}"
+  agentOrange: "${MAS_FLASH_IDS_AGENT_ORANGE:Agent Orange Exposure Verified,266}"
 
 springdoc:
   writer-with-default-pretty-printer: true

--- a/app/src/main/resources/application.yml
+++ b/app/src/main/resources/application.yml
@@ -156,6 +156,9 @@ lhAPIProvider:
   apiKey: "${LH_VRO_API_KEY:placeholderKey}"
   validateToken: "${VALIDATE_TOKEN:NO}"
 
+masVeteranFlashIds:
+  agentOrange: "${MAS_FLASH_IDS_AGENT_ORANGE:266,266}"
+
 springdoc:
   writer-with-default-pretty-printer: true
   show-actuator: false

--- a/shared/domain/src/main/java/gov/va/vro/model/mas/MasAutomatedClaimPayload.java
+++ b/shared/domain/src/main/java/gov/va/vro/model/mas/MasAutomatedClaimPayload.java
@@ -8,6 +8,8 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.SneakyThrows;
 
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import javax.validation.Valid;
@@ -22,7 +24,6 @@ public class MasAutomatedClaimPayload implements Auditable {
   public static final String DISABILITY_ACTION_TYPE_NEW = "NEW";
   public static final String DISABILITY_ACTION_TYPE_INCREASE = "INCREASE";
   public static final String AGENT_ORANGE_FLASH_ID = "266";
-
   @JsonIgnore private final ObjectMapper objectMapper = new ObjectMapper();
 
   private String correlationId;
@@ -80,7 +81,10 @@ public class MasAutomatedClaimPayload implements Auditable {
   @JsonIgnore
   public Boolean isPresumptive() {
     if (Objects.equals(getDisabilityActionType(), DISABILITY_ACTION_TYPE_NEW)) {
-      return (veteranFlashIds != null && veteranFlashIds.contains(AGENT_ORANGE_FLASH_ID));
+      return (veteranFlashIds != null
+          && !Collections.disjoint(
+              veteranFlashIds,
+              Arrays.asList(MasVeteranFlashProps.getInstance().getAgentOrangeFlashIds())));
     }
     return null;
   }

--- a/shared/domain/src/main/java/gov/va/vro/model/mas/MasVeteranFlashProps.java
+++ b/shared/domain/src/main/java/gov/va/vro/model/mas/MasVeteranFlashProps.java
@@ -1,0 +1,26 @@
+package gov.va.vro.model.mas;
+
+import lombok.Getter;
+
+@Getter
+public class MasVeteranFlashProps {
+
+  private static MasVeteranFlashProps INSTANCE;
+  private String[] agentOrangeFlashIds = {};
+
+  private MasVeteranFlashProps(String[] agentOrangeFlashIds) {
+    this.agentOrangeFlashIds = agentOrangeFlashIds;
+  }
+  ;
+
+  public static MasVeteranFlashProps getInstance(String[] agentOrangeFlashIds) {
+    if (INSTANCE == null) {
+      INSTANCE = new MasVeteranFlashProps(agentOrangeFlashIds);
+    }
+    return INSTANCE;
+  }
+
+  public static MasVeteranFlashProps getInstance() {
+    return INSTANCE;
+  }
+}


### PR DESCRIPTION
<!-- Ensure the PR title reflects the feature or bug name -->

## What was the problem?
Veteran flash ID for Agent Orange(266) hardcoded 

Associated tickets or Slack threads:
- [MCP-2335(https://amida.atlassian.net/browse/MCP-2335)

## How does this fix it?[^1]
Added a property to get the list of possible Agent Orange related flash ids, shortname

## How to test this PR
- Step 1 set env variable MAS_FLASH_IDS_AGENT_ORANGE with list of Agent Orange FlashIds and pass them in automatedclaim request
- Step 2[^secrel]


[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
