### PR TITLE
Don't use qa_* images for deployments to the QA env

### DIFF
--- a/scripts/deploy-app.sh
+++ b/scripts/deploy-app.sh
@@ -28,7 +28,7 @@ generateImageArgs(){
 
   # sandbox (in nonprod cluster) and prod and prod-test (in the prod cluster) requires signed-images from SecRel
   case "$1" in
-    dev|qa) IMG_NAME_PREFIX="${1}_";;
+    dev|qa) IMG_NAME_PREFIX="dev_";;
     sandbox|prod|prod-test) USE_SECREL_IMAGES="true";;
     *) { echo "Unknown environment: $1"; exit 20; }
   esac

--- a/scripts/tag-and-push-images.sh
+++ b/scripts/tag-and-push-images.sh
@@ -12,14 +12,21 @@ REPO="$1"
 # Images will also be tagged as 'latest', overriding any previous images
 IMG_TAG="$2"
 # Target environment, e.g., 'dev' or 'qa'
-# Used as a prefix for the image name
+# Used to determine the prefix for the image name
 TARGET_ENV="$3"
+
+# sandbox (in nonprod cluster) and prod and prod-test (in the prod cluster) requires signed-images from SecRel
+case "$TARGET_ENV" in
+  dev|qa) IMG_NAME_PREFIX="dev_";;
+  sandbox|prod|prod-test) IMG_NAME_PREFIX="";;
+  *) { echo "Unknown environment: $TARGET_ENV"; exit 20; }
+esac
 
 # Tag and push images using commit hash and `latest`
 source scripts/image_vars.src
 for PREFIX in "${VAR_PREFIXES_ARR[@]}"; do
   GRADLE_IMG_NAME=$(getVarValue "${PREFIX}" _GRADLE_IMG)
-  IMG_NAME=${TARGET_ENV}_$(getVarValue "${PREFIX}" _IMG)
+  IMG_NAME=${IMG_NAME_PREFIX}$(getVarValue "${PREFIX}" _IMG)
 
   echo "Tagging image '$GRADLE_IMG_NAME' as '$IMG_NAME:${IMG_TAG}' and 'latest'"
   docker tag "$GRADLE_IMG_NAME" "ghcr.io/${REPO}/${IMG_NAME}:${IMG_TAG}"


### PR DESCRIPTION
<!-- Ensure the PR title reflects the feature or bug name -->

## What was the problem?
<!-- brief description of how things worked before this PR -->

We have dev_ and qa_ [image prefixes](https://github.com/department-of-veterans-affairs/abd-vro/blob/598db9f9c6715155add8f359c0003d65c3a9466f/scripts/deploy-app.sh#L29-L34) for the corresponding deployment environments.
* Do we want to continue to do this?
* If yes, why?

[Here](https://github.com/department-of-veterans-affairs/abd-vro/blob/598db9f9c6715155add8f359c0003d65c3a9466f/scripts/tag-and-push-images.sh#L22) is where we push the images with the prefixes. This script is only called for dev and qa envs.

For other envs (sandbox, prod-test, prod), creating a GH release triggers SecRel 3 (will be obsolete on Feb 14th) to push images without prefix to GHCR. (SecRel 4 will behave differently, which is one reason for why I'm revisiting these image prefixes.)

Considerations:

- Having an image prefix clearly identifies what the image is used for, which is very useful when we have to delete a GHCR package (including all image versions) -- e.g., deleting dev_ images can be done readily with no concern for interrupting deploys to prod (which use the images without prefixes)
- More prefixes implies more maintenance.
- Maybe we just need 2 categories: a dev_ prefix and a no-prefix.

## How does this fix it?
<!-- description of how things will work after this PR -->

Use `dev_*` instead of `qa_*` images for deployments to the QA env.

## How to test this PR
Deploy to QA. Check that `dev_*` images are being used