### PR TITLE
fix NPE in the absence of the mandatory observation date

### DIFF
--- a/service/provider/src/main/java/gov/va/vro/service/provider/mas/service/mapper/MasCollectionAnnotsResults.java
+++ b/service/provider/src/main/java/gov/va/vro/service/provider/mas/service/mapper/MasCollectionAnnotsResults.java
@@ -110,7 +110,11 @@ public class MasCollectionAnnotsResults {
 
     AbdBloodPressure abdBloodPressure = new AbdBloodPressure();
     abdBloodPressure.setDataSource(DATA_SOURCE);
-    abdBloodPressure.setDate(masAnnotation.getObservationDate().replaceAll("Z", ""));
+    if (masAnnotation.getObservationDate() != null) {
+      abdBloodPressure.setDate(masAnnotation.getObservationDate().replaceAll("Z", ""));
+    }  else {
+      abdBloodPressure.setDate("");
+    }
     abdBloodPressure.setSystolic(systolicReading);
     abdBloodPressure.setDiastolic(diastolicReading);
     abdBloodPressure.setOrganization(null);


### PR DESCRIPTION
<!-- Ensure the PR title reflects the feature or bug name -->

## What was the problem?
Fix NPE in the absence of observation data for BP readings in the response from MAS

Associated tickets or Slack threads:
<!-- replace "000" with ticket number in both places -->
- [MCP-000](https://amida.atlassian.net/browse/MCP-000)

## How does this fix it?[^1]
Avoid NPE

## How to test this PR
- Step 1
- Step 2[^secrel]


[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
