### PR TITLE
Code cleanup and remove addClaimContention function in BipApiService.

### DIFF
--- a/api/src/main/java/gov/va/vro/api/resources/BipResource.java
+++ b/api/src/main/java/gov/va/vro/api/resources/BipResource.java
@@ -3,10 +3,8 @@ package gov.va.vro.api.resources;
 import gov.va.vro.api.responses.BipClaimContentionsResponse;
 import gov.va.vro.api.responses.BipClaimResponse;
 import gov.va.vro.api.responses.BipClaimStatusResponse;
-import gov.va.vro.api.responses.BipContentionCreationResponse;
 import gov.va.vro.api.responses.BipContentionUpdateResponse;
 import gov.va.vro.api.responses.BipFileUploadResponse;
-import gov.va.vro.model.bip.BipCreateClaimContentionPayload;
 import gov.va.vro.model.bip.BipUpdateClaimContentionPayload;
 import gov.va.vro.model.bip.BipUpdateClaimPayload;
 import gov.va.vro.model.bipevidence.BipFileProviderData;
@@ -141,30 +139,6 @@ public interface BipResource {
           @Valid
           @RequestBody
           BipUpdateClaimContentionPayload payload);
-
-  @Operation(
-      summary = "Create a claim contention",
-      description = "Request to create a claim contention.")
-  @PostMapping("/claim/contention")
-  @ResponseStatus(HttpStatus.OK)
-  @ApiResponses(
-      value = {
-        @ApiResponse(responseCode = "201", description = "Successful Request"),
-        @ApiResponse(
-            responseCode = "500",
-            description = "Data Access Server Error",
-            content = @Content(schema = @Schema(hidden = true)))
-      })
-  @Timed(value = "bip-claim-contention-create")
-  @Tag(name = "BIP Integration")
-  ResponseEntity<BipContentionCreationResponse> createContentions(
-      @Parameter(
-              description = "Request to create a contention for a claim.",
-              required = true,
-              schema = @Schema(implementation = BipCreateClaimContentionPayload.class))
-          @Valid
-          @RequestBody
-          BipCreateClaimContentionPayload payload);
 
   @Operation(summary = "Upload evidence file", description = "Upload evidence PDF file.")
   @PostMapping(

--- a/controller/src/main/java/gov/va/vro/controller/BipController.java
+++ b/controller/src/main/java/gov/va/vro/controller/BipController.java
@@ -4,17 +4,13 @@ import gov.va.vro.api.resources.BipResource;
 import gov.va.vro.api.responses.BipClaimContentionsResponse;
 import gov.va.vro.api.responses.BipClaimResponse;
 import gov.va.vro.api.responses.BipClaimStatusResponse;
-import gov.va.vro.api.responses.BipContentionCreationResponse;
 import gov.va.vro.api.responses.BipContentionUpdateResponse;
 import gov.va.vro.api.responses.BipFileUploadResponse;
 import gov.va.vro.model.bip.BipClaim;
-import gov.va.vro.model.bip.BipCreateClaimContentionPayload;
 import gov.va.vro.model.bip.BipUpdateClaimContentionPayload;
 import gov.va.vro.model.bip.BipUpdateClaimPayload;
 import gov.va.vro.model.bip.BipUpdateClaimResp;
 import gov.va.vro.model.bip.ClaimContention;
-import gov.va.vro.model.bip.CreateContention;
-import gov.va.vro.model.bip.CreateContentionReq;
 import gov.va.vro.model.bip.FileIdType;
 import gov.va.vro.model.bip.UpdateContention;
 import gov.va.vro.model.bip.UpdateContentionReq;
@@ -134,36 +130,6 @@ public class BipController implements BipResource {
     } catch (BipException e) {
       BipContentionUpdateResponse badResp =
           BipContentionUpdateResponse.builder().updated(false).message(e.getMessage()).build();
-      return ResponseEntity.internalServerError().body(badResp);
-    }
-  }
-
-  @Override
-  public ResponseEntity<BipContentionCreationResponse> createContentions(
-      @Valid BipCreateClaimContentionPayload payload) {
-    log.info("Create a contention for claim ID {}", payload.getClaimId());
-
-    try {
-      List<CreateContention> contentions = Collections.singletonList(payload.getContention());
-      CreateContentionReq req = new CreateContentionReq();
-      req.setCreateContentions(contentions);
-      BipUpdateClaimResp resp = service.addClaimContention(payload.getClaimId(), req);
-      boolean isCreated = resp.getStatus() == HttpStatus.CREATED;
-      BipContentionCreationResponse response =
-          BipContentionCreationResponse.builder()
-              .claimId(payload.getClaimId())
-              .created(isCreated)
-              .message(resp.getMessage())
-              .build();
-      return ResponseEntity.status(resp.getStatus()).body(response);
-    } catch (BipException e) {
-      log.error("failed to create contention for claim {}", payload.getClaimId(), e);
-      BipContentionCreationResponse badResp =
-          BipContentionCreationResponse.builder()
-              .contentionId(payload.getClaimId())
-              .created(false)
-              .message(e.getMessage())
-              .build();
       return ResponseEntity.internalServerError().body(badResp);
     }
   }

--- a/service/provider/src/main/java/gov/va/vro/service/provider/bip/service/BipApiService.java
+++ b/service/provider/src/main/java/gov/va/vro/service/provider/bip/service/BipApiService.java
@@ -8,7 +8,6 @@ import gov.va.vro.model.bip.BipContentionResp;
 import gov.va.vro.model.bip.BipUpdateClaimResp;
 import gov.va.vro.model.bip.ClaimContention;
 import gov.va.vro.model.bip.ClaimStatus;
-import gov.va.vro.model.bip.CreateContentionReq;
 import gov.va.vro.model.bip.UpdateContentionReq;
 import gov.va.vro.service.provider.BipApiProps;
 import gov.va.vro.service.provider.bip.BipException;
@@ -21,14 +20,23 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Conditional;
-import org.springframework.http.*;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 
 import java.nio.charset.StandardCharsets;
 import java.security.Key;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import javax.crypto.spec.SecretKeySpec;
 
 /**
@@ -164,27 +172,6 @@ public class BipApiService implements IBipApiService {
       }
     } catch (RestClientException | JsonProcessingException e) {
       log.error("failed to getClaimContentions for claim {}.", claimId, e);
-      throw new BipException(e.getMessage(), e);
-    }
-  }
-
-  @Override
-  public BipUpdateClaimResp addClaimContention(long claimId, CreateContentionReq contention)
-      throws BipException {
-    try {
-      String url = HTTPS + bipApiProps.getClaimBaseUrl() + String.format(CONTENTION, claimId);
-      log.info("Call {} to add claim contention for {}.", url, claimId);
-      HttpHeaders headers = getBipHeader();
-      String createContention = mapper.writeValueAsString(contention);
-      HttpEntity<String> request = new HttpEntity<>(createContention, headers);
-      ResponseEntity<String> bipResponse = restTemplate.postForEntity(url, request, String.class);
-      if (bipResponse.getStatusCode() == HttpStatus.CREATED) {
-        return new BipUpdateClaimResp(HttpStatus.CREATED, bipResponse.getBody());
-      } else {
-        throw new BipException(bipResponse.getStatusCode(), bipResponse.getBody());
-      }
-    } catch (RestClientException | JsonProcessingException e) {
-      log.error("failed to addClaimContentions for claim {}.", claimId, e);
       throw new BipException(e.getMessage(), e);
     }
   }

--- a/service/provider/src/main/java/gov/va/vro/service/provider/bip/service/BipClaimService.java
+++ b/service/provider/src/main/java/gov/va/vro/service/provider/bip/service/BipClaimService.java
@@ -33,11 +33,6 @@ public class BipClaimService {
 
   public static final String TSOJ = "398";
 
-  //  @Value("${bip.special_issue_1}")
-  //  public static final String SPECIAL_ISSUE_1;
-  //
-  //  @Value("${bip.special_issue_1}")
-  //  public static final String SPECIAL_ISSUE_2;
   private final ClaimProps claimPorps;
 
   private final IBipApiService bipApiService;

--- a/service/provider/src/main/java/gov/va/vro/service/provider/bip/service/IBipApiService.java
+++ b/service/provider/src/main/java/gov/va/vro/service/provider/bip/service/IBipApiService.java
@@ -4,7 +4,6 @@ import gov.va.vro.model.bip.BipClaim;
 import gov.va.vro.model.bip.BipUpdateClaimResp;
 import gov.va.vro.model.bip.ClaimContention;
 import gov.va.vro.model.bip.ClaimStatus;
-import gov.va.vro.model.bip.CreateContentionReq;
 import gov.va.vro.model.bip.UpdateContentionReq;
 import gov.va.vro.service.provider.bip.BipException;
 
@@ -63,16 +62,5 @@ public interface IBipApiService {
    * @throws BipException error occurs.
    */
   BipUpdateClaimResp updateClaimContention(long claimId, UpdateContentionReq contention)
-      throws BipException;
-
-  /**
-   * Adds a contention for a claim.
-   *
-   * @param claimId claim
-   * @param contention contention to be added.
-   * @return an update status information object.
-   * @throws BipException error occurs.
-   */
-  BipUpdateClaimResp addClaimContention(long claimId, CreateContentionReq contention)
       throws BipException;
 }

--- a/service/provider/src/main/java/gov/va/vro/service/provider/bip/service/MockBipApiService.java
+++ b/service/provider/src/main/java/gov/va/vro/service/provider/bip/service/MockBipApiService.java
@@ -4,7 +4,6 @@ import gov.va.vro.model.bip.BipClaim;
 import gov.va.vro.model.bip.BipUpdateClaimResp;
 import gov.va.vro.model.bip.ClaimContention;
 import gov.va.vro.model.bip.ClaimStatus;
-import gov.va.vro.model.bip.CreateContentionReq;
 import gov.va.vro.model.bip.UpdateContentionReq;
 import gov.va.vro.service.provider.bip.BipException;
 import org.springframework.context.annotation.Conditional;
@@ -18,7 +17,6 @@ import java.util.List;
 @Service
 @Conditional(BipConditions.LocalEnvCondition.class)
 public class MockBipApiService implements IBipApiService {
-  private static final long CLAIM_ID_201 = 201L;
   private static final long CLAIM_ID_204 = 204L;
   private static final long CLAIM_ID_400 = 400L;
   private static final long CLAIM_ID_401 = 401L;
@@ -27,74 +25,79 @@ public class MockBipApiService implements IBipApiService {
   private static final long CLAIM_ID_501 = 501L;
 
   private static final String ERR_MSG_400 =
-      "{\n"
-          + "  \"messages\": [\n"
-          + "    {\n"
-          + "      \"timestamp\": \"2023-01-24T16:36:59.578\",\n"
-          + "      \"key\": \"Bad reqeust\",\n"
-          + "      \"severity\": \"ERROR\",\n"
-          + "      \"status\": \"400\",\n"
-          + "      \"text\": \"Invalid parameters.\",\n"
-          + "      \"httpStatus\": \"BAD_REQUEST\"\n"
-          + "    }\n"
-          + "  ]\n"
-          + "}";
+      """
+                  {
+                    "messages": [
+                      {
+                        "timestamp": "2023-01-24T16:36:59.578",
+                        "key": "Bad reqeust",
+                        "severity": "ERROR",
+                        "status": "400",
+                        "text": "Invalid parameters.",
+                        "httpStatus": "BAD_REQUEST"
+                      }
+                    ]
+                  }""";
 
   private static final String ERR_MSG_404 =
-      "{\n"
-          + "  \"messages\": [\n"
-          + "    {\n"
-          + "      \"timestamp\": \"2023-01-24T16:36:59.578\",\n"
-          + "      \"key\": \"bip.vetservices.claims.request.claimId.NotValid\",\n"
-          + "      \"severity\": \"ERROR\",\n"
-          + "      \"status\": \"404\",\n"
-          + "      \"text\": \"Claim not found.\",\n"
-          + "      \"httpStatus\": \"NOT_FOUND\"\n"
-          + "    }\n"
-          + "  ]\n"
-          + "}";
+      """
+                  {
+                    "messages": [
+                      {
+                        "timestamp": "2023-01-24T16:36:59.578",
+                        "key": "bip.vetservices.claims.request.claimId.NotValid",
+                        "severity": "ERROR",
+                        "status": "404",
+                        "text": "Claim not found.",
+                        "httpStatus": "NOT_FOUND"
+                      }
+                    ]
+                  }""";
 
   private static final String ERR_MSG_401 =
-      "{\n"
-          + "  \"messages\": [\n"
-          + "    {\n"
-          + "      \"timestamp\": \"2023-01-24T16:36:59.578\",\n"
-          + "      \"key\": \"UNAUTHORIZED\",\n"
-          + "      \"severity\": \"ERROR\",\n"
-          + "      \"status\": \"401\",\n"
-          + "      \"text\": \"No JWT Token in Header.\",\n"
-          + "      \"httpStatus\": \"UNAUTHORIZED\"\n"
-          + "    }\n"
-          + "  ]\n"
-          + "}";
+      """
+                  {
+                    "messages": [
+                      {
+                        "timestamp": "2023-01-24T16:36:59.578",
+                        "key": "UNAUTHORIZED",
+                        "severity": "ERROR",
+                        "status": "401",
+                        "text": "No JWT Token in Header.",
+                        "httpStatus": "UNAUTHORIZED"
+                      }
+                    ]
+                  }""";
 
   private static final String ERR_MSG_500 =
-      "{\n"
-          + "  \"messages\": [\n"
-          + "    {\n"
-          + "      \"timestamp\": \"2023-01-24T16:36:59.578\",\n"
-          + "      \"key\": \"bip.framework.global.general.exception\",\n"
-          + "      \"severity\": \"ERROR\",\n"
-          + "      \"status\": \"500\",\n"
-          + "      \"text\": \"Unexpected exception.\",\n"
-          + "      \"httpStatus\": \"INTERNAL_SERVER_ERROR\"\n"
-          + "    }\n"
-          + "  ]\n"
-          + "}";
+      """
+                  {
+                    "messages": [
+                      {
+                        "timestamp": "2023-01-24T16:36:59.578",
+                        "key": "bip.framework.global.general.exception",
+                        "severity": "ERROR",
+                        "status": "500",
+                        "text": "Unexpected exception.",
+                        "httpStatus": "INTERNAL_SERVER_ERROR"
+                      }
+                    ]
+                  }""";
 
   private static final String ERR_MSG_501 =
-      "{\n"
-          + "  \"messages\": [\n"
-          + "    {\n"
-          + "      \"timestamp\": \"2023-01-24T16:36:59.578\",\n"
-          + "      \"key\": \"system error\",\n"
-          + "      \"severity\": \"ERROR\",\n"
-          + "      \"status\": \"501\",\n"
-          + "      \"text\": \"Not implemented.\",\n"
-          + "      \"httpStatus\": \"INTERNAL_SERVER_ERROR\"\n"
-          + "    }\n"
-          + "  ]\n"
-          + "}";
+      """
+                  {
+                    "messages": [
+                      {
+                        "timestamp": "2023-01-24T16:36:59.578",
+                        "key": "system error",
+                        "severity": "ERROR",
+                        "status": "501",
+                        "text": "Not implemented.",
+                        "httpStatus": "INTERNAL_SERVER_ERROR"
+                      }
+                    ]
+                  }""";
 
   @Override
   public BipClaim getClaimDetails(long collectionId) {
@@ -182,24 +185,6 @@ public class MockBipApiService implements IBipApiService {
       throw new BipException(HttpStatus.UNAUTHORIZED, ERR_MSG_501);
     } else {
       return new BipUpdateClaimResp(HttpStatus.CREATED, "OK from mock service.");
-    }
-  }
-
-  @Override
-  public BipUpdateClaimResp addClaimContention(long claimId, CreateContentionReq contention)
-      throws BipException {
-    if (claimId == CLAIM_ID_404) { // invalid claim ID, throw BipException
-      throw new BipException(HttpStatus.NOT_FOUND, ERR_MSG_404);
-    } else if (claimId == CLAIM_ID_400) { // bad call, throw BipException
-      throw new BipException(HttpStatus.BAD_REQUEST, ERR_MSG_400);
-    } else if (claimId == CLAIM_ID_401) { // not authorized, throw BipException
-      throw new BipException(HttpStatus.UNAUTHORIZED, ERR_MSG_401);
-    } else if (claimId == CLAIM_ID_500) { // internal error, throw BipException
-      throw new BipException(HttpStatus.UNAUTHORIZED, ERR_MSG_500);
-    } else {
-      String message =
-          String.format("This is a mock response to create a contetion for claim %d.", claimId);
-      return new BipUpdateClaimResp(HttpStatus.CREATED, message);
     }
   }
 


### PR DESCRIPTION
Cleanup code and remove addClaimContention function.

## What was the problem?
There is an addClaimContention in BipApiService. It is no longer needed and should be removed.
There are some comments and logs that should be removed.

Associated tickets or Slack threads:
MCP-2320

## How does this fix it?[^1]
Removed the codes, comments, and logs that are no longer needed.

## How to test this PR
- Step 1. Build the app.
- Step 2. See no things broken.


[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
