### PR TITLE
add bp annotation type

### DIFF
--- a/service/provider/src/main/java/gov/va/vro/service/provider/mas/service/mapper/MasCollectionAnnotsResults.java
+++ b/service/provider/src/main/java/gov/va/vro/service/provider/mas/service/mapper/MasCollectionAnnotsResults.java
@@ -67,7 +67,7 @@ public class MasCollectionAnnotsResults {
               AbdCondition abdCondition = createCondition(masAnnotation);
               conditions.add(abdCondition);
             }
-            case LABRESULT -> {
+            case LABRESULT, BLOOD_PRESSURE -> {
               if (isConditionBp && masAnnotation.getAnnotVal().matches(BP_READING_REGEX)) {
                 AbdBloodPressure abdBloodPressure = createBloodPressure(masAnnotation);
                 bpReadings.add(abdBloodPressure);

--- a/shared/domain/src/main/java/gov/va/vro/model/mas/MasAnnotType.java
+++ b/shared/domain/src/main/java/gov/va/vro/model/mas/MasAnnotType.java
@@ -7,6 +7,9 @@ package gov.va.vro.model.mas;
 public enum MasAnnotType {
   MEDICATION("medication"),
   LABRESULT("lab_result"),
+
+  BLOOD_PRESSURE("blood_pressure"),
+
   PROCEDURE("procedure"),
   SERVICE("service"),
   CONDITION("medical_condition"),


### PR DESCRIPTION
<!-- Ensure the PR title reflects the feature or bug name -->

## What was the problem?
added blood_pressure annotation type (which was missing in the mas documentation)

Associated tickets or Slack threads:
- [MCP-000](https://amida.atlassian.net/browse/MCP-000)

## How does this fix it?[^1]
The BP readings in the blood_pressure annotation will be extracted and mapped for evidence

## How to test this PR
- Step 1
- Step 2[^secrel]


[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
