### PR TITLE
Special Case RDR1 is not removed

### DIFF
--- a/service/provider/src/main/java/gov/va/vro/service/provider/bip/service/BipClaimService.java
+++ b/service/provider/src/main/java/gov/va/vro/service/provider/bip/service/BipClaimService.java
@@ -94,7 +94,8 @@ public class BipClaimService {
    */
   public MasProcessingObject removeSpecialIssue(MasProcessingObject payload) {
     var claimId = Long.parseLong(payload.getClaimId());
-    log.info("Attempting to remove special issue for claim id = {}", claimId);
+    String specialIssue1 = claimPorps.getSpecialIssue1();
+    log.info("Attempting to remove special issue {} for claim id = {}", specialIssue1, claimId);
 
     var contentions = bipApiService.getClaimContentions(claimId);
     if (ObjectUtils.isEmpty(contentions)) {
@@ -104,14 +105,17 @@ public class BipClaimService {
 
     List<ClaimContention> updatedContentions = new ArrayList<>();
     for (ClaimContention contention : contentions) {
-      if (!hasSpecialIssues(contention)) {
+      List<String> specialIssueCodes = contention.getSpecialIssueCodes();
+      if (specialIssueCodes == null) {
+        log.info("Contention {} has no special issues.", contention.getContentionId());
         continue;
       }
-      var codes =
-          contention.getSpecialIssueCodes().stream()
+      log.info("Special issue codes: {}", String.join(",", specialIssueCodes));
+      var codes = specialIssueCodes.stream()
               .map(String::toLowerCase)
               .collect(Collectors.toSet());
-      if (codes.contains(claimPorps.getSpecialIssue1())) {
+      if (codes.contains(specialIssue1.toLowerCase())) {
+        log.info("Found {} in contention {}", specialIssue1, contention.getContentionId());
         // remove string from contention
         List<String> updatedCodes =
             contention.getSpecialIssueCodes().stream()

--- a/service/provider/src/main/java/gov/va/vro/service/provider/bip/service/BipClaimService.java
+++ b/service/provider/src/main/java/gov/va/vro/service/provider/bip/service/BipClaimService.java
@@ -111,9 +111,7 @@ public class BipClaimService {
         continue;
       }
       log.info("Special issue codes: {}", String.join(",", specialIssueCodes));
-      var codes = specialIssueCodes.stream()
-              .map(String::toLowerCase)
-              .collect(Collectors.toSet());
+      var codes = specialIssueCodes.stream().map(String::toLowerCase).collect(Collectors.toSet());
       if (codes.contains(specialIssue1.toLowerCase())) {
         log.info("Found {} in contention {}", specialIssue1, contention.getContentionId());
         // remove string from contention


### PR DESCRIPTION
<!-- Ensure the PR title reflects the feature or bug name -->

## What was the problem?
<!-- brief description of how things worked before this PR -->

In VRO workflow when Special Case RDR1 needs to be removed it is not.

Associated tickets or Slack threads:
<!-- replace "000" with ticket number in both places -->
- [MCP-2344](https://amida.atlassian.net/browse/MCP-2344)

## How does this fix it?[^1]
<!-- description of how things will work after this PR -->

It was a upper case lower case comparison issue. Now we are comparing "rdr1" in the set/

## How to test this PR
- Step 1
- Step 2[^secrel]


[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
