### PR TITLE
Identify correct evidence source

### DIFF
--- a/app/src/test/java/gov/va/vro/service/MasCollectionServiceTest.java
+++ b/app/src/test/java/gov/va/vro/service/MasCollectionServiceTest.java
@@ -3,10 +3,7 @@ package gov.va.vro.service;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import gov.va.vro.model.AbdCondition;
-import gov.va.vro.model.AbdEvidence;
-import gov.va.vro.model.AbdMedication;
-import gov.va.vro.model.HealthDataAssessment;
+import gov.va.vro.model.*;
 import gov.va.vro.service.provider.mas.service.MasCollectionService;
 import org.junit.jupiter.api.Test;
 
@@ -18,13 +15,15 @@ public class MasCollectionServiceTest {
 
   @Test
   void combineEvidence() {
-    var lighthouseAssessment = createAssessment(null);
-    lighthouseAssessment.setDisabilityActionType("INCREASE");
+    var lighthouseAssessment = createAssessment("123");
+    lighthouseAssessment.setSource(HealthAssessmentSource.LIGHTHOUSE);
     lighthouseAssessment.setEvidence(
         createEvidence(
             Arrays.asList(createMedication("med1"), createMedication("med2")),
             Collections.singletonList(createCondition("cond2"))));
-    var masAssessment = createAssessment("123");
+    var masAssessment = createAssessment(null);
+    masAssessment.setSource(HealthAssessmentSource.MAS);
+    masAssessment.setDisabilityActionType("INCREASE");
     masAssessment.setEvidence(
         createEvidence(
             Collections.singletonList(createMedication("med1")),

--- a/shared/domain/src/main/java/gov/va/vro/model/HealthAssessmentSource.java
+++ b/shared/domain/src/main/java/gov/va/vro/model/HealthAssessmentSource.java
@@ -1,0 +1,6 @@
+package gov.va.vro.model;
+
+public enum HealthAssessmentSource {
+  LIGHTHOUSE,
+  MAS
+}

--- a/shared/domain/src/main/java/gov/va/vro/model/HealthDataAssessment.java
+++ b/shared/domain/src/main/java/gov/va/vro/model/HealthDataAssessment.java
@@ -1,5 +1,6 @@
 package gov.va.vro.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
@@ -36,4 +37,6 @@ public class HealthDataAssessment {
 
   @Schema(description = "date of the Claim")
   private String claimSubmissionDateTime;
+
+  @JsonIgnore private HealthAssessmentSource source = HealthAssessmentSource.LIGHTHOUSE;
 }


### PR DESCRIPTION
<!-- Ensure the PR title reflects the feature or bug name -->

## What was the problem?

We retrieve health assessments from Lighthouse and MAS and combine them. When we combine them we do not know which evidence came from which service.

Associated tickets or Slack threads:

- [MCP-2350](https://amida.atlassian.net/browse/MCP-2350)

## How does this fix it?[^1]
- Introduce a new field in HealthDataAssessment to store the source of the assessment.


## How to test this PR
- N/A


[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
