### PR TITLE
Add Claim Submission to Exam Order table

### DIFF
--- a/db-init/src/main/resources/database/migrations/V4.9__Reference_Claim_Submission_In_Exam_Order.sql
+++ b/db-init/src/main/resources/database/migrations/V4.9__Reference_Claim_Submission_In_Exam_Order.sql
@@ -1,0 +1,5 @@
+ALTER TABLE exam_order
+    ADD COLUMN IF NOT EXISTS claim_submission_id UUID;
+
+ALTER TABLE exam_order
+    ADD CONSTRAINT fk_claim_submission_id FOREIGN KEY (claim_submission_id) REFERENCES claim_submission (id);

--- a/persistence/model/src/main/java/gov/va/vro/persistence/model/ExamOrderEntity.java
+++ b/persistence/model/src/main/java/gov/va/vro/persistence/model/ExamOrderEntity.java
@@ -3,8 +3,7 @@ package gov.va.vro.persistence.model;
 import lombok.Getter;
 import lombok.Setter;
 
-import javax.persistence.Entity;
-import javax.persistence.Table;
+import javax.persistence.*;
 
 @Entity
 @Getter
@@ -15,4 +14,8 @@ public class ExamOrderEntity extends BaseEntity {
   private String collectionId;
 
   private String status;
+
+  @OneToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "claim_submission_id")
+  private ClaimSubmissionEntity claimSubmission;
 }

--- a/persistence/model/src/main/java/gov/va/vro/persistence/repository/ClaimSubmissionRepository.java
+++ b/persistence/model/src/main/java/gov/va/vro/persistence/repository/ClaimSubmissionRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 @Repository
@@ -12,6 +13,6 @@ public interface ClaimSubmissionRepository extends JpaRepository<ClaimSubmission
 
   List<ClaimSubmissionEntity> findByReferenceIdAndIdType(String referenceId, String idType);
 
-  List<ClaimSubmissionEntity> findByReferenceIdAndIdTypeOrderByCreatedAtDesc(
+  Optional<ClaimSubmissionEntity> findFirstByReferenceIdAndIdTypeOrderByCreatedAtDesc(
       String referenceId, String idType);
 }

--- a/persistence/model/src/test/java/gov/va/vro/persistence/repository/TestDataSupplier.java
+++ b/persistence/model/src/test/java/gov/va/vro/persistence/repository/TestDataSupplier.java
@@ -41,6 +41,14 @@ public class TestDataSupplier {
     return claim;
   }
 
+  /**
+   * Create a Claim Submission
+   *
+   * @param claim
+   * @param reference_id
+   * @param id_type
+   * @return
+   */
   public static ClaimSubmissionEntity createClaimSubmission(
       ClaimEntity claim, String reference_id, String id_type) {
     ClaimSubmissionEntity claimSubmission = new ClaimSubmissionEntity();

--- a/service/db/src/main/java/gov/va/vro/service/db/SaveToDbServiceImpl.java
+++ b/service/db/src/main/java/gov/va/vro/service/db/SaveToDbServiceImpl.java
@@ -23,7 +23,12 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
 import javax.transaction.Transactional;
 
 @Service
@@ -114,11 +119,10 @@ public class SaveToDbServiceImpl implements SaveToDbService {
 
   @Override
   public void setOffRampReason(Claim claimWithOffRamp) {
-    List<ClaimSubmissionEntity> claimSubmissionList =
-        claimSubmissionRepository.findByReferenceIdAndIdType(
+    Optional<ClaimSubmissionEntity> claimSubmission =
+        claimSubmissionRepository.findFirstByReferenceIdAndIdTypeOrderByCreatedAtDesc(
             String.valueOf(claimWithOffRamp.getCollectionId()), DEFAULT_ID_TYPE);
-    Collections.reverse(claimSubmissionList);
-    ClaimSubmissionEntity claimSubmissionEntity = claimSubmissionList.get(0);
+    ClaimSubmissionEntity claimSubmissionEntity = claimSubmission.get();
     claimSubmissionEntity.setOffRampReason(claimWithOffRamp.getOffRampReason());
     claimSubmissionRepository.save(claimSubmissionEntity);
   }

--- a/service/db/src/test/java/gov/va/vro/service/db/SaveToDbServiceImplTest.java
+++ b/service/db/src/test/java/gov/va/vro/service/db/SaveToDbServiceImplTest.java
@@ -156,6 +156,14 @@ class SaveToDbServiceImplTest {
 
   @Test
   void persistExamOrder() {
+    Claim claim = new Claim();
+    claim.setClaimSubmissionId("1234");
+    claim.setVeteranIcn("v1");
+    claim.setDiagnosticCode("7101");
+    claim.setVbmsId("vbms1");
+    claim.setCollectionId("collection1");
+    claim.setIdType(Claim.DEFAULT_ID_TYPE);
+    saveToDbService.insertClaim(claim);
     ExamOrder examOrder1 = new ExamOrder();
     examOrder1.setCollectionId("collection1");
     examOrder1.setStatus("status1");


### PR DESCRIPTION
<!-- Ensure the PR title reflects the feature or bug name -->

## What was the problem?
Exam order needs a foreign key to the claim submission table as documented here. https://github.com/department-of-veterans-affairs/abd-vro/pull/1060
Additionally changed the claim submission repository to do a findFirst to make prior commits to that PR more efficient with a limit statement under the hood. 

Associated tickets or Slack threads:
<!-- replace "000" with ticket number in both places -->
- [MCP-2303](https://amida.atlassian.net/browse/MCP-2303)

## How does this fix it?[^1]
Exam order now looks up the claim submission entry by the collectionid=>refId key and assumes the default MCP order type as that is the only one that can submit to the exam order endpoint. 

## How to test this PR
Automated unit tests are created for this new code
Swagger endpoint for an exam order after a claim has been created will also take that same code flow. 