### PR TITLE
Correct lifecycle status end point

### DIFF
--- a/app/src/end2endTest/java/gov/va/vro/end2end/VroV2Tests.java
+++ b/app/src/end2endTest/java/gov/va/vro/end2end/VroV2Tests.java
@@ -154,7 +154,7 @@ public class VroV2Tests {
 
     boolean contentionsFound = getFoundStatus(claimId, "contentions");
     assertTrue(contentionsFound);
-    boolean lifecycleStatusFound = getFoundStatus(claimId, "lifecycle-status");
+    boolean lifecycleStatusFound = getFoundStatus(claimId, "lifecycle_status");
     assertTrue(lifecycleStatusFound);
   }
 

--- a/app/src/test/java/gov/va/vro/service/BipApiServiceTest.java
+++ b/app/src/test/java/gov/va/vro/service/BipApiServiceTest.java
@@ -47,7 +47,7 @@ public class BipApiServiceTest {
   private static final String CLAIM_RESPONSE_404 = "bip-test-data/claim_response_404.json";
   private static final String CLAIM_RESPONSE_200 = "bip-test-data/claim_response_200.json";
   private static final String CLAIM_DETAILS = "/claims/%s";
-  private static final String UPDATE_CLAIM_STATUS = "/claims/%s/lifecycle-status";
+  private static final String UPDATE_CLAIM_STATUS = "/claims/%s/lifecycle_status";
   private static final String CONTENTION = "/claims/%s/contentions";
   private static final String HTTPS = "https://";
   private static final String CLAIM_URL = "claims.bip.va.gov";

--- a/mock-bip-claims-api/src/main/java/gov/va/vro/mockbipclaims/api/LifecycleStatusesApi.java
+++ b/mock-bip-claims-api/src/main/java/gov/va/vro/mockbipclaims/api/LifecycleStatusesApi.java
@@ -31,7 +31,7 @@ import javax.validation.Valid;
 @RequestMapping("/")
 public interface LifecycleStatusesApi {
   /**
-   * PUT /claims/{claimId}/lifecycle-status : Update the lifecycle status of an existing claim
+   * PUT /claims/{claimId}/lifecycle_status : Update the lifecycle status of an existing claim
    * Update the lifecycle status of an existing claim.
    *
    * @param claimId The CorpDB BNFT_CLAIM_ID (required)
@@ -140,7 +140,7 @@ public interface LifecycleStatusesApi {
                   "https://github.ec.va.gov/EPMO/bip-vetservices-claims/blob/development/bip-vetservices-claims-docs/claim-updates.md"))
   @RequestMapping(
       method = RequestMethod.PUT,
-      value = "/claims/{claimId}/lifecycle-status",
+      value = "/claims/{claimId}/lifecycle_status",
       produces = {"application/json", "application/problem+json"},
       consumes = {"application/json"})
   ResponseEntity<UpdateClaimLifecycleStatusResponse> updateClaimLifecycleStatus(

--- a/mock-bip-claims-api/src/main/java/gov/va/vro/mockbipclaims/api/UpdatesApi.java
+++ b/mock-bip-claims-api/src/main/java/gov/va/vro/mockbipclaims/api/UpdatesApi.java
@@ -39,7 +39,7 @@ public interface UpdatesApi {
           Long claimId);
 
   /**
-   * GET /updates/{claimId}/lifecycle-status: Retrieves if the claim lifecycle status has updates.
+   * GET /updates/{claimId}/lifecycle_status: Retrieves if the claim lifecycle status has updates.
    */
   @Operation(
       operationId = "getLifecycleStatusUpdates",
@@ -57,7 +57,7 @@ public interface UpdatesApi {
       })
   @RequestMapping(
       method = RequestMethod.GET,
-      value = "/updates/{claimId}/lifecycle-status",
+      value = "/updates/{claimId}/lifecycle_status",
       produces = {"application/json"})
   ResponseEntity<UpdatesResponse> getLifecycleStatusUpdates(
       @Parameter(

--- a/mock-bip-claims-api/src/test/java/gov/va/vro/mockbipclaims/util/TestHelper.java
+++ b/mock-bip-claims-api/src/test/java/gov/va/vro/mockbipclaims/util/TestHelper.java
@@ -149,7 +149,7 @@ public class TestHelper {
 
     HttpEntity<UpdateClaimLifecycleStatusRequest> request = new HttpEntity<>(body, headers);
 
-    String url = spec.getUrl("/claims/" + claimId + "/lifecycle-status");
+    String url = spec.getUrl("/claims/" + claimId + "/lifecycle_status");
     return restTemplate.exchange(
         url, HttpMethod.PUT, request, UpdateClaimLifecycleStatusResponse.class);
   }
@@ -161,7 +161,7 @@ public class TestHelper {
    * @return is updated?
    */
   public boolean isLifecycleStatusUpdated(TestSpec spec) {
-    String url = spec.getUrl("/updates/" + spec.getClaimId() + "/lifecycle-status");
+    String url = spec.getUrl("/updates/" + spec.getClaimId() + "/lifecycle_status");
     UpdatesResponse response = restTemplate.getForObject(url, UpdatesResponse.class);
     return response.isFound();
   }

--- a/service/provider/src/main/java/gov/va/vro/service/provider/bip/service/BipApiService.java
+++ b/service/provider/src/main/java/gov/va/vro/service/provider/bip/service/BipApiService.java
@@ -50,7 +50,7 @@ import javax.crypto.spec.SecretKeySpec;
 @Slf4j
 public class BipApiService implements IBipApiService {
   private static final String CLAIM_DETAILS = "/claims/%s";
-  private static final String UPDATE_CLAIM_STATUS = "/claims/%s/lifecycle-status";
+  private static final String UPDATE_CLAIM_STATUS = "/claims/%s/lifecycle_status";
   private static final String CONTENTION = "/claims/%s/contentions";
 
   private static final String HTTPS = "https://";


### PR DESCRIPTION
<!-- Ensure the PR title reflects the feature or bug name -->

## What was the problem?
<!-- brief description of how things worked before this PR -->

We were using the wrong endpoint tio update lifecycle status *lifecycle-status"

Associated tickets or Slack threads:
<!-- replace "000" with ticket number in both places -->
- [MCP-000](https://amida.atlassian.net/browse/MCP-000)

## How does this fix it?[^1]
<!-- description of how things will work after this PR -->

## How to test this PR
- Step 1
- Step 2[^secrel]

We are using the right one now

[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
