### PR TITLE
Last Minute Database Improvements

### DIFF
--- a/app/src/end2endTest/java/gov/va/vro/end2end/VroV2Tests.java
+++ b/app/src/end2endTest/java/gov/va/vro/end2end/VroV2Tests.java
@@ -228,7 +228,7 @@ public class VroV2Tests {
             "collectionStatus",
             "DRAFT",
             "examOrderDateTime",
-            "2022-12-08T17:45:61Z",
+            "2022-12-08T17:45:59Z",
             "eventId",
             "None");
     return objectMapper.writeValueAsString(payload);

--- a/app/src/end2endTest/resources/test-mas/claim-350-7101-outofscope.json
+++ b/app/src/end2endTest/resources/test-mas/claim-350-7101-outofscope.json
@@ -16,7 +16,7 @@
     "claimSubmissionDateTime": "2018-11-04T17:45:59Z",
     "claimSubmissionSource": "VA.GOV",
     "conditions": {
-      "name": "string",
+      "name": "blood pressure",
       "diagnosticCode": "7101",
       "disabilityActionType": "DECREASE",
       "disabilityClassificationCode": "3460",

--- a/app/src/end2endTest/resources/test-mas/claim-350-7101.json
+++ b/app/src/end2endTest/resources/test-mas/claim-350-7101.json
@@ -16,7 +16,7 @@
     "claimSubmissionDateTime": "2018-11-04T17:45:59Z",
     "claimSubmissionSource": "VA.GOV",
     "conditions": {
-      "name": "string",
+      "name": "blood pressure",
       "diagnosticCode": "7101",
       "disabilityActionType": "INCREASE",
       "disabilityClassificationCode": "3460",

--- a/app/src/end2endTest/resources/test-mas/claim-351-7101-noanchor.json
+++ b/app/src/end2endTest/resources/test-mas/claim-351-7101-noanchor.json
@@ -16,7 +16,7 @@
     "claimSubmissionDateTime": "2018-11-04T17:45:59Z",
     "claimSubmissionSource": "VA.GOV",
     "conditions": {
-      "name": "string",
+      "name": "blood pressure",
       "diagnosticCode": "7101",
       "disabilityActionType": "INCREASE",
       "disabilityClassificationCode": "3460",

--- a/db-init/src/main/resources/database/migrations/V4.13__Additional_Contention_And_Exam_Order_Fields.sql
+++ b/db-init/src/main/resources/database/migrations/V4.13__Additional_Contention_And_Exam_Order_Fields.sql
@@ -1,0 +1,3 @@
+ALTER TABLE contention ADD COLUMN condition_name VARCHAR;
+ALTER TABLE contention ADD COLUMN classification_code VARCHAR;
+ALTER TABLE exam_order ADD COLUMN ordered_at TIMESTAMP;

--- a/persistence/model/src/main/java/gov/va/vro/persistence/model/ContentionEntity.java
+++ b/persistence/model/src/main/java/gov/va/vro/persistence/model/ContentionEntity.java
@@ -39,6 +39,10 @@ public class ContentionEntity extends BaseEntity {
   @LazyCollection(LazyCollectionOption.FALSE)
   private List<EvidenceSummaryDocumentEntity> evidenceSummaryDocuments = new ArrayList<>();
 
+  private String conditionName;
+
+  private String classificationCode;
+
   /***
    * <p>Summary.</p>
    *

--- a/persistence/model/src/main/java/gov/va/vro/persistence/model/ExamOrderEntity.java
+++ b/persistence/model/src/main/java/gov/va/vro/persistence/model/ExamOrderEntity.java
@@ -3,6 +3,7 @@ package gov.va.vro.persistence.model;
 import lombok.Getter;
 import lombok.Setter;
 
+import java.time.OffsetDateTime;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.JoinColumn;
@@ -18,6 +19,8 @@ public class ExamOrderEntity extends BaseEntity {
   private String collectionId;
 
   private String status;
+
+  private OffsetDateTime orderedAt;
 
   @OneToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "claim_submission_id")

--- a/service/db/src/test/java/gov/va/vro/service/db/SaveToDbServiceImplTest.java
+++ b/service/db/src/test/java/gov/va/vro/service/db/SaveToDbServiceImplTest.java
@@ -89,6 +89,8 @@ class SaveToDbServiceImplTest {
     claim.setIdType(MasAutomatedClaimPayload.CLAIM_V2_ID_TYPE);
     claim.setVeteranIcn("v1");
     claim.setDiagnosticCode("1234");
+    claim.setConditionName("Condition1");
+    claim.setDisabilityClassificationCode("DCC1");
     var result = saveToDbService.insertClaim(claim);
     assertNotNull(result.getRecordId());
     assertEquals(claim.getBenefitClaimId(), result.getBenefitClaimId());
@@ -105,6 +107,8 @@ class SaveToDbServiceImplTest {
     assertEquals(1, claimEntity.getContentions().size());
     ContentionEntity contentionEntity = claimEntity.getContentions().get(0);
     assertEquals(claim.getDiagnosticCode(), contentionEntity.getDiagnosticCode());
+    assertEquals(claim.getConditionName(), contentionEntity.getConditionName());
+    assertEquals(claim.getDisabilityClassificationCode(), contentionEntity.getClassificationCode());
     assertEquals(1, claimEntity.getClaimSubmissions().size());
     ClaimSubmissionEntity claimSubmissionEntity =
         claimEntity.getClaimSubmissions().iterator().next();

--- a/service/provider/src/main/java/gov/va/vro/service/provider/mas/service/MasProcessingService.java
+++ b/service/provider/src/main/java/gov/va/vro/service/provider/mas/service/MasProcessingService.java
@@ -120,10 +120,12 @@ public class MasProcessingService {
         .benefitClaimId(payload.getBenefitClaimId())
         .collectionId(Integer.toString(payload.getCollectionId()))
         .idType(payload.getIdType())
+        .conditionName(payload.getConditionName())
         .diagnosticCode(payload.getDiagnosticCode())
         .veteranIcn(payload.getVeteranIcn())
         .inScope(payload.isInScope())
         .disabilityActionType(payload.getDisabilityActionType())
+        .disabilityClassificationCode(payload.getDisabilityClassificationCode())
         .offRampReason(payload.getOffRampReason())
         .submissionSource(payload.getClaimDetail().getClaimSubmissionSource())
         .submissionDate(OffsetDateTime.parse(payload.getClaimDetail().getClaimSubmissionDateTime()))
@@ -131,10 +133,16 @@ public class MasProcessingService {
   }
 
   private ExamOrder buildExamOrder(MasExamOrderStatusPayload payload, String claimIdType) {
+    String examOrderDateTime = payload.getExamOrderDateTime();
+    OffsetDateTime examDateTime = null;
+    if (examOrderDateTime != null && !examOrderDateTime.isBlank()) {
+      examDateTime = OffsetDateTime.parse(examOrderDateTime);
+    }
     return ExamOrder.builder()
         .collectionId(Integer.toString(payload.getCollectionId()))
         .idType(claimIdType)
         .status(payload.getCollectionStatus())
+        .examOrderDateTime(examDateTime)
         .build();
   }
 }

--- a/service/spi/src/main/java/gov/va/vro/service/spi/model/Claim.java
+++ b/service/spi/src/main/java/gov/va/vro/service/spi/model/Claim.java
@@ -48,11 +48,15 @@ public class Claim {
 
   @NotNull private String diagnosticCode;
 
+  private String conditionName;
+
   private Set<String> contentions;
 
   private String offRampReason;
 
   private boolean presumptiveFlag;
+
+  private String disabilityClassificationCode;
 
   private String disabilityActionType;
 

--- a/service/spi/src/main/java/gov/va/vro/service/spi/model/ExamOrder.java
+++ b/service/spi/src/main/java/gov/va/vro/service/spi/model/ExamOrder.java
@@ -9,6 +9,8 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
 
+import java.time.OffsetDateTime;
+
 @Getter
 @Setter
 @NoArgsConstructor
@@ -23,4 +25,6 @@ public class ExamOrder {
   private String idType;
 
   private String status;
+
+  private OffsetDateTime examOrderDateTime;
 }

--- a/shared/domain/src/main/java/gov/va/vro/model/mas/MasAutomatedClaimPayload.java
+++ b/shared/domain/src/main/java/gov/va/vro/model/mas/MasAutomatedClaimPayload.java
@@ -54,11 +54,27 @@ public class MasAutomatedClaimPayload implements Auditable {
   private List<String> veteranFlashIds;
 
   @JsonIgnore
+  public String getConditionName() {
+    if (claimDetail == null || claimDetail.getConditions() == null) {
+      return null;
+    }
+    return claimDetail.getConditions().getName();
+  }
+
+  @JsonIgnore
   public String getDiagnosticCode() {
     if (claimDetail == null || claimDetail.getConditions() == null) {
       return null;
     }
     return claimDetail.getConditions().getDiagnosticCode();
+  }
+
+  @JsonIgnore
+  public String getDisabilityClassificationCode() {
+    if (claimDetail == null || claimDetail.getConditions() == null) {
+      return null;
+    }
+    return claimDetail.getConditions().getDisabilityClassificationCode();
   }
 
   @JsonIgnore
@@ -115,9 +131,11 @@ public class MasAutomatedClaimPayload implements Auditable {
     Map<String, String> detailsMap = new HashMap<>();
     detailsMap.put("benefitClaimId", getBenefitClaimId());
     detailsMap.put("collectionId", Objects.toString(getCollectionId()));
+    detailsMap.put("conditionName", getConditionName());
     detailsMap.put("diagnosticCode", getDiagnosticCode());
     detailsMap.put("veteranIcn", getVeteranIcn());
     detailsMap.put("disabilityActionType", getDisabilityActionType());
+    detailsMap.put("disabilityClassificationCode", getDisabilityClassificationCode());
     detailsMap.put(
         "flashIds", getVeteranFlashIds() == null ? null : Objects.toString(getVeteranFlashIds()));
     detailsMap.put("inScope", Objects.toString(isInScope()));

--- a/shared/domain/src/main/java/gov/va/vro/model/mas/MasEventDetails.java
+++ b/shared/domain/src/main/java/gov/va/vro/model/mas/MasEventDetails.java
@@ -12,9 +12,11 @@ public class MasEventDetails {
   private String benefitClaimId;
   private String collectionId;
   private String veteranIcn;
+  private String conditionName;
   private String diagnosticCode;
   private String offRampReason;
   private String disabilityActionType;
+  private String disabilityClassificationCode;
   private Boolean presumptive;
   private boolean inScope;
   private List<String> flashIds;

--- a/shared/domain/src/main/java/gov/va/vro/model/mas/MasExamOrderStatusPayload.java
+++ b/shared/domain/src/main/java/gov/va/vro/model/mas/MasExamOrderStatusPayload.java
@@ -46,6 +46,7 @@ public class MasExamOrderStatusPayload implements Auditable {
     Map<String, String> detailsMap = new HashMap<>();
     detailsMap.put("collectionId", Integer.toString(collectionId));
     detailsMap.put("collectionStatus", collectionStatus);
+    detailsMap.put("examOrderDateTime", examOrderDateTime);
     return detailsMap;
   }
 


### PR DESCRIPTION
## What was the problem?
Yoom requested via Slack that the following items be added and it was agreed the PR would be broken out from current work to keep the size manageable.

- [x] Store the claimDetail.conditions.disabilityClassificationCode (provided in the /automatedClaim payload) in the DB as classification_code in the contention table

- [x] Store the claimDetail.conditions.name (provided in the /automatedClaim payload) in the DB as condition_name in the contention table

- [x] For the /examOrderingStatus endpoint, store examOrderDateTime field of the payload as ordered_at. This is for *all* statuses as clarified by subsequent thread discussion. 

(https://amida.slack.com/archives/C01Q7979Z7D/p1675982532875369)

## How does this fix it?
The work above is done to the spec requested. Audit details are added since we are already persisting those fields by request in the database

## How to test this PR
Run the /automatedClaim and /examOrderingStatus endpoints, validate new data is persisted in database. Claim payloads did not need modification beyond exposing fields to the rest of the package.


