### PR TITLE
correct container for slack

### DIFF
--- a/helm-app/templates/api/deployment.yaml
+++ b/helm-app/templates/api/deployment.yaml
@@ -229,6 +229,16 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.name }}
                   key: {{ .Values.dataservice.lhApiAuthUrl }}
+            - name: SLACK_EXCEPTION_CHANNEL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.name }}
+                  key: {{ .Values.dataservice.slackExceptionChannel }}
+            - name: SLACK_EXCEPTION_WEBHOOK
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.name }}
+                  key: {{ .Values.dataservice.slackExceptionWebhook }}
             - name: VRO_AUD_URL
               valueFrom:
                 secretKeyRef:
@@ -529,16 +539,6 @@ spec:
                   key: {{ .Values.dataservice.lhAssertionUrl }}
             # Setting these secrets are only needed for the prod cluster
             # For the nonprod cluster, these settings are set directly in application-*.yml files
-            - name: SLACK_EXCEPTION_CHANNEL
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.name }}
-                  key: {{ .Values.dataservice.slackExceptionChannel }}
-            - name: SLACK_EXCEPTION_WEBHOOK
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.name }}
-                  key: {{ .Values.dataservice.slackExceptionWebhook }}
             - name: LH_TOKEN_URL
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
<!-- Ensure the PR title reflects the feature or bug name -->

## What was the problem?
<!-- brief description of how things worked before this PR -->

Slack channel settings were in the wrong container in HELM

Associated tickets or Slack threads:
<!-- replace "000" with ticket number in both places -->
- [MCP-000](https://amida.atlassian.net/browse/MCP-000)

## How does this fix it?[^1]
<!-- description of how things will work after this PR -->

Moves setting from svc_lighthouse to api

## How to test this PR
- Step 1
- Step 2[^secrel]


[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
