### PR TITLE
SecRel 4: specify image tag when publishing

### DIFF
--- a/.github/actions/publish-images/action.yml
+++ b/.github/actions/publish-images/action.yml
@@ -8,6 +8,9 @@ inputs:
   image_prefix:
     description: 'The prefix for the image name, e.g., "dev_" or "" (no prefix)'
     default: 'dev_'
+  image_tag:
+    description: 'The tag/version for the image, e.g., first 7 of the commit hash or "release-1.2.3"'
+    required: true
   ghcr_username:
     description: 'GHCR username'
     required: true
@@ -46,22 +49,17 @@ runs:
 
     - name: "Tag and push images using commit hash and `latest`"
       shell: bash
-      env:
-        COMMIT_SHA: ${{ github.sha }}
-      run: ./scripts/tag-and-push-images.sh "${{ github.repository }}" "${COMMIT_SHA:0:7}" "${{ inputs.image_prefix }}"
+      run: ./scripts/tag-and-push-images.sh "${{ github.repository }}" "${{ inputs.image_tag }}" "${{ inputs.image_prefix }}"
 
     - name: "Published images list"
       id: published-images
       shell: bash
-      env:
-        COMMIT_SHA: ${{ github.sha }}
       run: |
         docker image list
-        IMG_TAG=${COMMIT_SHA:0:7}
         source scripts/image_vars.src
         echo "images<<EOF" >> $GITHUB_OUTPUT
         for VAR_PREFIX in ${VAR_PREFIXES_ARR[@]}; do
           IMG_NAME=${{ inputs.image_prefix }}$(getVarValue "${VAR_PREFIX}" _IMG)
-          echo "ghcr.io/${{ github.repository }}/${IMG_NAME}:${IMG_TAG}" >> $GITHUB_OUTPUT
+          echo "ghcr.io/${{ github.repository }}/${IMG_NAME}:${{ inputs.image_tag }}" >> $GITHUB_OUTPUT
         done
         echo "EOF" >> $GITHUB_OUTPUT

--- a/.github/workflows/deploy-unsigned.yml
+++ b/.github/workflows/deploy-unsigned.yml
@@ -62,6 +62,8 @@ jobs:
           IMAGE_TAG=${{ inputs.image_tag }}
           # if $IMAGE_TAG is empty, then set to first characters of GITHUB_SHA
           [ -z "$IMAGE_TAG" ] && IMAGE_TAG=${GITHUB_SHA:0:7}
+          echo "GITHUB_SHA $GITHUB_SHA"
+          echo "IMAGE_TAG  $IMAGE_TAG"
           echo "image_tag=${IMAGE_TAG}" >> $GITHUB_OUTPUT
 
   publish-images:
@@ -105,6 +107,8 @@ jobs:
           access_token: ${{ secrets.ACCESS_TOKEN_GRADLE_BUILD }}
           ghcr_username: ${{ github.actor }}
           ghcr_password: ${{ secrets.GITHUB_TOKEN }}
+          # Temp
+          run_tests: 'false'
 
       # TODO: Is this really needed?
       - name: "Remove images locally"

--- a/.github/workflows/deploy-unsigned.yml
+++ b/.github/workflows/deploy-unsigned.yml
@@ -20,6 +20,10 @@ on:
         options:
           - 'dev_'
           - ''
+      image_tag:
+        description: 'The tag/version for the image; default is the first 7 of the commit hash'
+        required: false
+        default: ${GITHUB_SHA}
 
   # Allow other workflows to call this one
   workflow_call:
@@ -30,13 +34,15 @@ on:
       image_prefix:
         required: true
         type: string
+      image_tag:
+        required: false
+        type: string
 
 # Ensures that only one deploy per env will run at a time.
 concurrency:
   group: deploy-unsigned-${{ inputs.target_env }}
 
 env:
-  COMMIT_SHA: ${{ github.sha }}
   # Id for the #benefits-vro-devops Slack channel
   SLACK_CHANNEL: C04CA47HV96
   # Default to failure messages
@@ -45,9 +51,23 @@ env:
   JOB_STATUS: 'failed'
 
 jobs:
+  set-image-props:
+    outputs:
+      image-tag: ${{ steps.image-props.outputs.image_tag }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Determine image properties"
+        id: image-props
+        run: |
+          IMAGE_TAG=${{ inputs.image_tag }}
+          # if $IMAGE_TAG is empty, then set to first characters of GITHUB_SHA
+          [ -z "$IMAGE_TAG" ] && IMAGE_TAG=${GITHUB_SHA:0:7}
+          echo "image_tag=${IMAGE_TAG}" >> $GITHUB_OUTPUT
+
   publish-images:
     # Since this workflow is only designed for dev and qa, only run this job in the abd-vro repo
     if: github.repository == 'department-of-veterans-affairs/abd-vro'
+    needs: set-image-props
     outputs:
       slack-response-ts: ${{ steps.slack-thread-id.outputs.slack_thread_ts }}
       job_status: ${{ env.JOB_STATUS }}
@@ -80,7 +100,8 @@ jobs:
       - name: "Test and publish images with prefix '${{ inputs.image_prefix }}' to GHCR"
         uses: ./.github/actions/publish-images
         with:
-          image_prefix: ${{ inputs.image_prefix }}
+          image_prefix: "${{ inputs.image_prefix }}"
+          image_tag: "${{ needs.set-image-props.outputs.image-tag }}"
           access_token: ${{ secrets.ACCESS_TOKEN_GRADLE_BUILD }}
           ghcr_username: ${{ github.actor }}
           ghcr_password: ${{ secrets.GITHUB_TOKEN }}
@@ -91,8 +112,9 @@ jobs:
           source scripts/image_vars.src
           for VAR_PREFIX in ${VAR_PREFIXES_ARR[@]}; do
             IMG_NAME=${{ inputs.image_prefix }}$(getVarValue ${VAR_PREFIX} _IMG)
-            echo "Clean up image with tags '$IMG_NAME:${COMMIT_SHA:0:7}' and '${IMG_NAME}:latest'"
-            docker rmi "ghcr.io/${{ github.repository }}/${IMG_NAME}:${COMMIT_SHA:0:7}" \
+            IMG_TAG=${{ needs.set-image-props.outputs.image-tag }}
+            echo "Clean up image with tags '$IMG_NAME:$IMG_TAG' and '${IMG_NAME}:latest'"
+            docker rmi "ghcr.io/${{ github.repository }}/${IMG_NAME}:${IMG_TAG}" \
                        "ghcr.io/${{ github.repository }}/${IMG_NAME}:latest"
           done
 
@@ -101,7 +123,7 @@ jobs:
         run: echo "JOB_STATUS=cancelled" >> $GITHUB_ENV
 
   deploy-images:
-    needs: publish-images
+    needs: [set-image-props, publish-images]
     runs-on: ubuntu-latest
     outputs:
       job_status: ${{ env.JOB_STATUS }}
@@ -128,7 +150,7 @@ jobs:
         env:
           SLACK_CHANNEL: ${{ env.SLACK_CHANNEL }}
           SLACK_THREAD_TS: ${{ needs.publish-images.outputs.slack-response-ts }}
-        run: ./scripts/deploy-app.sh ${{ inputs.target_env }} ${COMMIT_SHA:0:7}
+        run: ./scripts/deploy-app.sh "${{ inputs.target_env }}" "${{ needs.set-image-props.outputs.image-tag }}"
 
       - name: "Wait for LHDI deployment"
         run: |

--- a/.github/workflows/deploy-unsigned.yml
+++ b/.github/workflows/deploy-unsigned.yml
@@ -115,7 +115,7 @@ jobs:
           for VAR_PREFIX in ${VAR_PREFIXES_ARR[@]}; do
             IMG_NAME=${{ inputs.image_prefix }}$(getVarValue ${VAR_PREFIX} _IMG)
             IMG_TAG=${{ needs.set-image-props.outputs.image-tag }}
-            echo "Clean up image with tags '$IMG_NAME:$IMG_TAG' and '${IMG_NAME}:latest'"
+            echo "Clean up image '$IMG_NAME' with tags '$IMG_TAG' and 'latest'"
             docker rmi "ghcr.io/${{ github.repository }}/${IMG_NAME}:${IMG_TAG}" \
                        "ghcr.io/${{ github.repository }}/${IMG_NAME}:latest"
           done

--- a/.github/workflows/deploy-unsigned.yml
+++ b/.github/workflows/deploy-unsigned.yml
@@ -107,8 +107,6 @@ jobs:
           access_token: ${{ secrets.ACCESS_TOKEN_GRADLE_BUILD }}
           ghcr_username: ${{ github.actor }}
           ghcr_password: ${{ secrets.GITHUB_TOKEN }}
-          # Temp
-          run_tests: 'false'
 
       # TODO: Is this really needed?
       - name: "Remove images locally"

--- a/.github/workflows/secrel4.yml
+++ b/.github/workflows/secrel4.yml
@@ -13,55 +13,59 @@ on:
   workflow_dispatch:
 
 env:
-  IMAGE_PREFIX: 'dev_'
-  RUN_TESTS: 'true'
-
   # Id for the #benefits-vro-devops Slack channel
   SLACK_CHANNEL: C04CA47HV96
 
 jobs:
-  publish-images:
+  publish-to-ghcr:
     # only run for the internal repo
     if: github.repository == 'department-of-veterans-affairs/abd-vro-internal'
     outputs:
       vro-images: ${{ steps.publish-images.outputs.images_list }}
     runs-on: ubuntu-latest
     steps:
-      - name: "Determine image prefix"
+      - name: "Determine image prefix and tag"
+        id: image-props
         run: |
           echo "ref_name: ${{ github.ref_name }}"
-          IMAGE_PREFIX=dev_
-          GRADLE_TESTS=true
+          IMG_PREFIX=dev_
+          IMG_TAG=${GITHUB_SHA:0:7}
+          RUN_GRADLE_TESTS=true
           case "${{ github.ref_name }}" in
-            main)      IMAGE_PREFIX="";;
-            release-*) IMAGE_PREFIX="";;
-            develop)   GRADLE_TESTS=false;;
+            main)      IMG_PREFIX="";;
+            release-*) IMG_PREFIX=""
+              IMG_TAG="${{ github.ref_name }}"
+              ;;
+            develop)   RUN_GRADLE_TESTS=false;;
           esac
-          echo "IMAGE_PREFIX=${IMAGE_PREFIX}" >> $GITHUB_ENV
-          echo "RUN_TESTS=${GRADLE_TESTS}" >> $GITHUB_ENV
+          echo "image_prefix=${IMG_PREFIX}" >> $GITHUB_OUTPUT
+          echo "image_tag=${IMG_TAG}" >> $GITHUB_OUTPUT
+          echo "run_tests=${RUN_GRADLE_TESTS}" >> $GITHUB_OUTPUT
 
-      - name: "DEBUG step"
+      - name: "DEBUG"
         run: |
-          echo "IMAGE_PREFIX: ${{ env.IMAGE_PREFIX }}"
-          echo "RUN_TESTS: ${{ env.RUN_TESTS }}"
+          echo "image_prefix: ${{ steps.image-props.outputs.image_prefix }}"
+          echo "image_tag: ${{ steps.image-props.outputs.image_tag }}"
+          echo "run_tests: ${{ steps.image-props.outputs.run_tests }}"
 
       - name: "Checkout source code"
         uses: actions/checkout@v3
 
-      - name: "Publish ${{ env.IMAGE_PREFIX }} images to GHCR"
+      - name: "Publish ${{ steps.image-props.outputs.image_prefix }} images to GHCR"
         id: publish-images
         uses: ./.github/actions/publish-images
         with:
-          image_prefix: ${{ env.IMAGE_PREFIX }}
+          image_prefix: "${{ steps.image-props.outputs.image_prefix }}"
+          image_tag: "${{ steps.image-props.outputs.image_tag }}"
           access_token: ${{ secrets.ACCESS_TOKEN_GRADLE_BUILD }}
           ghcr_username: ${{ github.actor }}
           ghcr_password: ${{ secrets.GITHUB_TOKEN }}
-          run_tests: ${{ env.RUN_TESTS }}
+          run_tests: ${{ steps.image-props.outputs.run_tests }}
 
   images-for-secrel:
     runs-on: ubuntu-latest
     needs:
-      - publish-images
+      - publish-to-ghcr
     outputs:
       all-images: ${{ steps.append-images.outputs.all-images }}
     steps:
@@ -69,7 +73,7 @@ jobs:
         id: append-images
         run: |
           echo "all-images<<EOF" >> $GITHUB_OUTPUT
-          echo "${{ needs.publish-images.outputs.vro-images }}" >> $GITHUB_OUTPUT
+          echo "${{ needs.publish-to-ghcr.outputs.vro-images }}" >> $GITHUB_OUTPUT
           MANUAL_IMGS_ARRAY=( vro-rabbitmq:latest vro-redis:latest )
           for MANUAL_IMAGE in ${MANUAL_IMGS_ARRAY[@]}; do
             # SecRel will not sign images outside the scope of the repository that's calling SecRel,
@@ -80,19 +84,19 @@ jobs:
 
   debug-job:
     runs-on: ubuntu-latest
-    needs: [publish-images, images-for-secrel]
+    needs: [publish-to-ghcr, images-for-secrel]
     steps:
       - name: show vars
         run: |
           echo "ref_name: ${{github.ref_name}}"
-          echo "publish-images: ${{ needs.publish-images.outputs.vro-images }}"
+          echo "vro-images: ${{ needs.publish-to-ghcr.outputs.vro-images }}"
           echo "all-images: ${{ needs.images-for-secrel.outputs.all-images }}"
 
   secrel:
     # only run for the internal repo -- SecRel doesn't work on public repos
     if: github.repository == 'department-of-veterans-affairs/abd-vro-internal'
     name: SecRel Pipeline
-    needs: [publish-images, images-for-secrel]
+    needs: [publish-to-ghcr, images-for-secrel]
     uses: department-of-veterans-affairs/lighthouse-tornado-secrel-pipeline/.github/workflows/pipeline.yml@v4.1.0
     with:
       config-file: .github/secrel/config4.yml

--- a/.github/workflows/secrel4.yml
+++ b/.github/workflows/secrel4.yml
@@ -67,12 +67,12 @@ jobs:
     needs:
       - publish-to-ghcr
     outputs:
-      all-images: ${{ steps.append-images.outputs.all-images }}
+      all-images: ${{ steps.append-images.outputs.all_images }}
     steps:
       - name: "Append 3rd-party images"
         id: append-images
         run: |
-          echo "all-images<<EOF" >> $GITHUB_OUTPUT
+          echo "all_images<<EOF" >> $GITHUB_OUTPUT
           echo "${{ needs.publish-to-ghcr.outputs.vro-images }}" >> $GITHUB_OUTPUT
           MANUAL_IMGS_ARRAY=( vro-rabbitmq:latest vro-redis:latest )
           for MANUAL_IMAGE in ${MANUAL_IMGS_ARRAY[@]}; do

--- a/scripts/tag-and-push-images.sh
+++ b/scripts/tag-and-push-images.sh
@@ -8,7 +8,7 @@ set -e
 
 # ${{ github.repository }}
 REPO="$1"
-# A tag label for all the images, e.g., ${COMMIT_SHA:0:7}
+# A tag label for all the images, e.g., ${GITHUB_SHA:0:7}
 # Images will also be tagged as 'latest', overriding any previous images
 IMG_TAG="$2"
 # The prefix for the image name, e.g., 'dev_' or '' (no prefix)

--- a/scripts/tag-and-push-images.sh
+++ b/scripts/tag-and-push-images.sh
@@ -20,7 +20,7 @@ for PREFIX in "${VAR_PREFIXES_ARR[@]}"; do
   GRADLE_IMG_NAME=$(getVarValue "${PREFIX}" _GRADLE_IMG)
   IMG_NAME=${IMG_NAME_PREFIX}$(getVarValue "${PREFIX}" _IMG)
 
-  echo "Tagging image '$GRADLE_IMG_NAME' as '$IMG_NAME:${IMG_TAG}' and 'latest'"
+  echo "Tagging '$GRADLE_IMG_NAME' as '$IMG_NAME:${IMG_TAG}' and '$IMG_NAME:latest'"
   docker tag "$GRADLE_IMG_NAME" "ghcr.io/${REPO}/${IMG_NAME}:${IMG_TAG}"
   docker tag "$GRADLE_IMG_NAME" "ghcr.io/${REPO}/${IMG_NAME}:latest"
 


### PR DESCRIPTION
<!-- Ensure the PR title reflects the feature or bug name -->

Follow-on to #1123

## What was the problem?
<!-- brief description of how things worked before this PR -->

Releases are not being signed by SecRel b/c our GH action workflows were not publishing them with the image tag `release-...`.

- #888

## How does this fix it?[^1]
<!-- description of how things will work after this PR -->

Update GH action workflows to publish images with the `release-...` image tag when a release is created.

## How to test this PR

Manually run modified GH actions.
- Ran [Deploy to DEV](https://github.com/department-of-veterans-affairs/abd-vro/actions/runs/4206350456)
- Ran [SecRel 4](https://github.com/department-of-veterans-affairs/abd-vro-internal/actions/runs/4206427166)

[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
