### PR TITLE
Exam Order Response mapping - Fix

### DIFF
--- a/service/provider/src/main/java/gov/va/vro/service/provider/MasOrderExamProcessor.java
+++ b/service/provider/src/main/java/gov/va/vro/service/provider/MasOrderExamProcessor.java
@@ -38,7 +38,8 @@ public class MasOrderExamProcessor implements Processor {
       MasOrderExamConditions masOrderExamConditions = new MasOrderExamConditions();
       masOrderExamConditions.setConditionCode(
           MAS_CONDITION_CODES.getOrDefault(claimPayload.getDiagnosticCode(), "NA"));
-      masOrderExamConditions.setContentionText("HYPERTENSION");
+      masOrderExamConditions.setContentionText(
+          MAS_CONDITION_CODES.getOrDefault(claimPayload.getDiagnosticCode(), "NA"));
       masOrderExamRequest.setConditions(List.of(masOrderExamConditions));
       var response = masApiService.orderExam(masOrderExamRequest);
       log.info("Order Exam Response :  " + response);

--- a/service/provider/src/main/java/gov/va/vro/service/provider/mas/service/MasApiService.java
+++ b/service/provider/src/main/java/gov/va/vro/service/provider/mas/service/MasApiService.java
@@ -1,8 +1,11 @@
 package gov.va.vro.service.provider.mas.service;
 
+import static java.util.Objects.isNull;
+
 import com.fasterxml.jackson.core.JsonGenerationException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import gov.va.vro.model.mas.MasCollectionAnnotation;
 import gov.va.vro.model.mas.MasCollectionStatus;
@@ -120,8 +123,14 @@ public class MasApiService implements IMasApiService {
 
       ResponseEntity<String> masResponse =
           restTemplate.exchange(url, HttpMethod.POST, httpEntity, String.class);
-      return mapper.readValue(masResponse.getBody(), new TypeReference<>() {});
 
+      JsonNode masResponseJson = new ObjectMapper().readTree(String.valueOf(masResponse.getBody()));
+
+      String examOrderRespStatus = "success";
+      if ((isNull(masResponseJson.get("success")))) {
+        examOrderRespStatus = "failed";
+      }
+      return examOrderRespStatus;
     } catch (RestClientException | IOException e) {
       log.error("Failed to order exam", e);
       // TODO: REPLACE WHEN FIXED

--- a/service/provider/src/main/java/gov/va/vro/service/provider/mas/service/MasCollectionService.java
+++ b/service/provider/src/main/java/gov/va/vro/service/provider/mas/service/MasCollectionService.java
@@ -114,8 +114,10 @@ public class MasCollectionService {
         HealthAssessmentSource.MAS == assessment1.getSource() ? assessment1 : assessment2;
     var lighthouseAssessment =
         HealthAssessmentSource.LIGHTHOUSE == assessment1.getSource() ? assessment1 : assessment2;
-    AbdEvidence lighthouseEvidence = masAssessment.getEvidence();
-    AbdEvidence masApiEvidence = lighthouseAssessment.getEvidence();
+
+    AbdEvidence masApiEvidence = masAssessment.getEvidence();
+    AbdEvidence lighthouseEvidence = lighthouseAssessment.getEvidence();
+
     // for now, we just add up the lists
     log.info("combineEvidence >> LH  : " + ((lighthouseEvidence != null) ? "not null" : "null"));
     log.info("combineEvidence >> MAS : " + ((masApiEvidence != null) ? "not null" : "null"));


### PR DESCRIPTION
<!-- Ensure the PR title reflects the feature or bug name -->

## What was the problem?
ExamOrder response mapping fix

Associated tickets or Slack threads:
- [MCP-2373](https://amida.atlassian.net/browse/MCP-2373)

## How does this fix it?[^1]
The response of the examOrder call is mapped to get the status

## How to test this PR
- Step 1
- Step 2[^secrel]


[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
