### PR TITLE
Save assessment result for v2 MAS calls

### DIFF
--- a/service/provider/src/main/java/gov/va/vro/service/provider/camel/MasIntegrationRoutes.java
+++ b/service/provider/src/main/java/gov/va/vro/service/provider/camel/MasIntegrationRoutes.java
@@ -126,6 +126,7 @@ public class MasIntegrationRoutes extends RouteBuilder {
         .onPrepare(auditProcessor(routeId, "Started claim processing."))
         .process(convertToMasProcessingObject())
         .setProperty("diagnosticCode", simple("${body.diagnosticCode}"))
+        .setProperty("idType", simple("${body.idType}"))
         .to(ENDPOINT_COLLECT_EVIDENCE) // collect evidence from lighthouse and MAS
         // determine if evidence is sufficient
         .routingSlip(method(slipClaimSubmitRouter, "routeHealthSufficiency"))

--- a/service/provider/src/main/java/gov/va/vro/service/provider/services/MasAssessmentResultProcessor.java
+++ b/service/provider/src/main/java/gov/va/vro/service/provider/services/MasAssessmentResultProcessor.java
@@ -19,6 +19,8 @@ public class MasAssessmentResultProcessor implements Processor {
   public void process(Exchange exchange) throws Exception {
     var evidence = exchange.getMessage().getBody(AbdEvidenceWithSummary.class);
     String diagnosticCode = exchange.getProperty("diagnosticCode", String.class);
+    String idType = exchange.getProperty("idType", String.class);
+    evidence.setIdType(idType);
     if (diagnosticCode == null) {
       log.warn("Diagnostic Code was empty, exiting.");
       return;


### PR DESCRIPTION
## What was the problem?
V2 assessment_result table entries were not being created. Logs indicated this was due to not finding the claim_submission, which was caused by not having the idType at that point in the code. 

Associated tickets or Slack threads:
- [MCP-2383](https://amida.atlassian.net/browse/MCP-2383)
- [MCP-2384](https://amida.atlassian.net/browse/MCP-2384)

## How does this fix it?[^1]
the idType was getting lost along the way in the v2 processing camel routes. In the same area diagnostic code was being saved in the header and then used in the processor to solve not loosing that data. For speed and less risk, I have adopted that strategy of using the Exchange header to get the idType to the right object/location.

## How to test this PR
End to End V2 route methods will test this and ensure that assessment_result populates in all expected cases.
V1 behavior is unchanged. 