### PR TITLE
Bug fix/custom ibm times

### DIFF
--- a/service/provider/src/main/java/gov/va/vro/service/provider/mas/service/MasProcessingService.java
+++ b/service/provider/src/main/java/gov/va/vro/service/provider/mas/service/MasProcessingService.java
@@ -14,14 +14,22 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDate;
+import java.time.LocalTime;
 import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 @Service
 @RequiredArgsConstructor
 @Slf4j
 public class MasProcessingService {
 
+  private static final String customDateFormatRegex =
+      "^(-?(?:[1-9][0-9]*)?[0-9]{4})-(1[0-2]|0[1-9])-(3[01]|0[1-9]|[12][0-9])(Z)?$";
+  private static final Pattern customDatePattern = Pattern.compile(customDateFormatRegex);
   private final CamelEntrance camelEntrance;
 
   private final MasConfig masConfig;
@@ -136,8 +144,24 @@ public class MasProcessingService {
   private ExamOrder buildExamOrder(MasExamOrderStatusPayload payload, String claimIdType) {
     String examOrderDateTime = payload.getExamOrderDateTime();
     OffsetDateTime examDateTime = null;
-    if (examOrderDateTime != null && !examOrderDateTime.isBlank()) {
-      examDateTime = OffsetDateTime.parse(examOrderDateTime);
+    try {
+      if (examOrderDateTime != null && !examOrderDateTime.isBlank()) {
+        // Attempt to parse non-standard ISO date we may be sent of YYYY-MM-DDZ
+        Matcher customDateMatcher = customDatePattern.matcher(examOrderDateTime);
+        if (customDateMatcher.matches()) {
+          Integer year = Integer.parseInt(customDateMatcher.group(0));
+          Integer month = Integer.parseInt(customDateMatcher.group(1));
+          Integer day = Integer.parseInt(customDateMatcher.group(2));
+          LocalDate customDate = LocalDate.of(year, month, day);
+          examDateTime = OffsetDateTime.of(customDate, LocalTime.MIN, ZoneOffset.UTC);
+        } else {
+          // Fall back to ISO 8601 Date Time
+          examDateTime = OffsetDateTime.parse(examOrderDateTime);
+        }
+      }
+    } catch (Exception e) {
+      log.error(
+          "Unable to parse exam order date time. Unexpected date format {}", examOrderDateTime);
     }
     return ExamOrder.builder()
         .collectionId(Integer.toString(payload.getCollectionId()))


### PR DESCRIPTION
## What was the problem?
Code was crashing due to a custom non ISO 8601 time format sent by IBM we should handle. 

[Associated tickets or Slack threads:
(https://amida.atlassian.net/browse/MCP-000)](https://amida.slack.com/archives/C039KH7HY79/p1677077918268369)

## How does this fix it?
Attempt to identify the IBM date format. If true - setup a datetimestamp for the database.
If that doesn't work - fall back to ISO 8601 DateTime standard
Catch errors and if nothing can be parsed, log the error and continue while leaving the exam order time null. It is optional in the DB schema. 

## How to test this PR
Run e2e tests with IBM date format (YYYY-MM-DDZ) 
Even invalid dates will now log error and code should not crash here. 