### PR TITLE
PDF Template Fix - About this document ToC link

### DIFF
--- a/service-python/pdfgenerator/src/lib/templates/hypertension-v2/base_toc.xsl
+++ b/service-python/pdfgenerator/src/lib/templates/hypertension-v2/base_toc.xsl
@@ -13,7 +13,6 @@
         <!-- Bootstrap CSS -->
         <link href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.0.2/css/bootstrap.min.css"  rel="stylesheet" integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous"/>
 
-        <title>Table of Contents</title>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
         <style>
           @font-face {
@@ -200,41 +199,63 @@
               <b>Claims Processors:</b> This document summarizes data from VHA locations that use VistA/CAPRI, as well as scanned text from relevant documents in the Veteran’s eFolder on the date of claim.
             </p>
             <p class="mb-30">
-              <b>Notice(s):</b> Some relevant data may be missing and some of the same data may appear twice. Learn more in the <a href="https://www.va.gov">About this document</a> section.
+              <b>Notice(s):</b> Some relevant data may be missing and some of the same data may appear twice. Learn more in the <xsl:apply-templates select="outline:item/outline:item[starts-with(@title, 'About this document')]">
+                <xsl:with-param name="link_type" select="'hyperlink'" />
+              </xsl:apply-templates> section.
             </p>
           </div>
         </div>
         <div class="row flex">
           <div style="max-width: 470px !important; margin-top: 30px !important">
             <h2 class="margin-13">&#8204;<b>Table of contents</b></h2>
-            <ul><xsl:apply-templates select="outline:item/outline:item"/></ul>
+            <ul>
+              <xsl:apply-templates select="outline:item/outline:item[not(starts-with(@title, '&#x200c;'))]">
+                <xsl:with-param name="link_type" select="'toc'" />
+              </xsl:apply-templates>
+            </ul>
           </div>
         </div>
         <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM" crossorigin="anonymous"></script>
       </body>
     </html>
   </xsl:template>
+
   <xsl:template match="outline:item">
-    <li>
-      <xsl:if test="not(starts-with(@title, '&#x200c;'))">
-      <!-- <xsl:if test="@title!=''"> -->
-        <div>
-          <a>
-            <xsl:if test="@link">
-              <xsl:attribute name="href"><xsl:value-of select="@link"/></xsl:attribute>
-            </xsl:if>
-            <xsl:if test="@backLink">
-              <xsl:attribute name="name"><xsl:value-of select="@backLink"/></xsl:attribute>
-            </xsl:if>
-            <xsl:value-of select="@title" />
-          </a>
-          <span> <xsl:value-of select="@page" /> </span>
-        </div>
+    <xsl:param name="link_type" select="'toc'" />
+    <xsl:if test="$link_type='toc'">
+      <li>
+        <xsl:if test="not(starts-with(@title, '&#x200c;'))">
+          <div>
+            <a>
+              <xsl:if test="@link">
+                <xsl:attribute name="href"><xsl:value-of select="@link"/></xsl:attribute>
+              </xsl:if>
+              <xsl:if test="@backLink">
+                <xsl:attribute name="name"><xsl:value-of select="@backLink"/></xsl:attribute>
+              </xsl:if>
+              <xsl:value-of select="@title" />
+            </a>
+            <span> <xsl:value-of select="@page" /> </span>
+          </div>
+        </xsl:if>
+        <ul>
+          <xsl:comment>added to prevent self-closing tags in QtXmlPatterns</xsl:comment>
+          <xsl:apply-templates select="outline:item"/>
+        </ul>
+      </li>
+    </xsl:if>
+    <xsl:if test="$link_type='hyperlink'">
+      <xsl:if test="starts-with(@title, 'About this document')">
+        <a>
+          <xsl:if test="@link">
+            <xsl:attribute name="href"><xsl:value-of select="@link"/></xsl:attribute>
+          </xsl:if>
+          <xsl:if test="@backLink">
+            <xsl:attribute name="name"><xsl:value-of select="@backLink"/></xsl:attribute>
+          </xsl:if>
+          <xsl:value-of select="@title" />
+        </a>
       </xsl:if>
-      <ul>
-        <xsl:comment>added to prevent self-closing tags in QtXmlPatterns</xsl:comment>
-        <xsl:apply-templates select="outline:item"/>
-      </ul>
-    </li>
+    </xsl:if>
   </xsl:template>
 </xsl:stylesheet>


### PR DESCRIPTION
<!-- Ensure the PR title reflects the feature or bug name -->

## What was the problem?
<!-- brief description of how things worked before this PR -->
About this document on the ToC page was not linked to the proper section but instead the [va.gov](va.gov) site.

Associated tickets or Slack threads:
<!-- replace "000" with ticket number in both places -->
- [MCP-2398](https://amida.atlassian.net/browse/MCP-2398)

## How does this fix it?[^1]
<!-- description of how things will work after this PR -->
Restructure the XSLT so after going through the outline items, it allows different link types that can be used for different scenarios. There was a `mode` field that could have been used but it is a XSLT 2.0 feature and WKHTMLPDF uses 1.0 😠 

## How to test this PR
- Generate PDF, and click "About this document". It should take you to the section
- Note: This link, not the table of contents link 
<img width="810" alt="image" src="https://user-images.githubusercontent.com/13013464/221049675-041df39b-96bb-452d-afc1-ba7b74bd6291.png">



[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
