### PR TITLE
MCP-2421: Change type of "relevant" to boolean to properly display conditions on PDF

### DIFF
--- a/mock-lighthouse-api/src/main/resources/mock-bundles/mock1012666073V986297/Condition.json
+++ b/mock-lighthouse-api/src/main/resources/mock-bundles/mock1012666073V986297/Condition.json
@@ -115,14 +115,14 @@
         "code": {
           "coding": [
             {
-              "system": "http://snomed.info/sct",
-              "code": "*Missing*",
-              "display": "Essential Hypertension"
-            },
-            {
               "system": "http://hl7.org/fhir/sid/icd-9-cm",
               "code": "401.9",
               "display": "UNSPECIFIED ESSENTIAL HYPERTENSION"
+            },
+            {
+              "system": "http://snomed.info/sct",
+              "code": "*Missing*",
+              "display": "Essential Hypertension"
             }
           ],
           "text": "Essential Hypertension"

--- a/shared/domain/src/main/java/gov/va/vro/model/AbdCondition.java
+++ b/shared/domain/src/main/java/gov/va/vro/model/AbdCondition.java
@@ -20,7 +20,7 @@ public class AbdCondition implements Comparable<AbdCondition> {
   @EqualsAndHashCode.Include private String status;
   @EqualsAndHashCode.Include private String onsetDate;
   private String recordedDate;
-  private String relevant;
+  private Boolean relevant;
   private String category;
 
   @Schema(description = "Formatted date", example = "01/01/2023")


### PR DESCRIPTION
<!-- Ensure the PR title reflects the feature or bug name -->

## What was the problem?
<!-- brief description of how things worked before this PR -->
Relevant field for conditions was a string type so when the evidence was transferred from the assessment response to a PDF payload it was turned into a string. In the PDF generator only `False, false, "", 0` are considered false, which does not include a string, like "false".

Associated tickets or Slack threads:
<!-- replace "000" with ticket number in both places -->
- [MCP-2421](https://amida.atlassian.net/browse/MCP-2421)

## How does this fix it?[^1]
<!-- description of how things will work after this PR -->
Change the type of "relevant" to Boolean. 

## How to test this PR
- Step 1 Run `testAutomatedClaimPresumptive` and check results of the PDF. 
- 
- Step 2[^secrel]


[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
