### PR TITLE
Filter out "Missing" code for condition data from Lighthouse FHIR.

### DIFF
--- a/svc-lighthouse-api/src/main/java/gov/va/vro/abddataaccess/service/FieldExtractor.java
+++ b/svc-lighthouse-api/src/main/java/gov/va/vro/abddataaccess/service/FieldExtractor.java
@@ -64,14 +64,14 @@ public class FieldExtractor {
     if (condition.hasCode()) {
       CodeableConcept code = condition.getCode();
       if (code.hasCoding()) {
-        Coding coding = code.getCodingFirstRep();
-
-        if (coding.hasCode()) {
-          result.setCode(coding.getCode());
-        }
-
-        if (coding.hasDisplay()) {
-          result.setText(coding.getDisplay());
+        for (Coding coding : code.getCoding()) {
+          if (coding.hasCode() && !coding.getCode().equals("*Missing*")) {
+            result.setCode(coding.getCode());
+            if (coding.hasDisplay()) {
+              result.setText(coding.getDisplay());
+            }
+            break;
+          }
         }
       }
 


### PR DESCRIPTION
Filter out "Missing" code for Condition data from Lighthouse FHIR.

## What was the problem?
Lighthouse FHIR API can return code with an invalid ICD code, "*Missing*". We need to filter out this invalid code.

Associated tickets or Slack threads:
 MCP-2440

## How does this fix it?[^1]
Filter out the "Missing" code.

## How to test this PR
- Step 1. Build and launch the app
- Step 2: Test health-data-assesment with an icn that has this invalid code. (It may not exist in Lighthouse Sandbox.) If we cannot find a sample in Lighthouse FHIR sandbox, just test it with an ICN to make sure nothing broken.


[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
