### PR TITLE
MCP-2472: Log all variables used in RFD logic

### DIFF
--- a/service-python/assessclaimdc7101/src/lib/main.py
+++ b/service-python/assessclaimdc7101/src/lib/main.py
@@ -72,7 +72,6 @@ def assess_sufficiency(event: Dict):
         relevant_medications = medications.filter_mas_medication(event)
         bp_display = bp_calculation["twoYearsBp"]
         conditions_display = relevant_conditions["twoYearsConditions"]
-        total_relevant_conditions = relevant_conditions["relevantConditionsLighthouseCount"]
 
         sufficient = None
         if event["disabilityActionType"] == "INCREASE":
@@ -83,7 +82,7 @@ def assess_sufficiency(event: Dict):
         if event["disabilityActionType"] == "NEW":
             bp_display = bp_calculation["allBp"]  # Include all bp readings to display
             conditions_display = relevant_conditions["conditions"]
-            if total_relevant_conditions >= 1:
+            if relevant_conditions["relevantConditionsLighthouseCount"] >= 1:
                 if bp_calculation["twoYearsBpCount"] >= 3:
                     sufficient = True
                 else:
@@ -106,6 +105,8 @@ def assess_sufficiency(event: Dict):
                 "evidenceSummary": {
                     "totalBpCount": bp_calculation["totalBpCount"],
                     "twoYearsBpCount": bp_calculation["twoYearsBpCount"],
+                    "oneYearBpCount": bp_calculation["oneYearBpCount"],
+                    "twoYearsElevatedBpCount": bp_calculation["twoYearsElevatedBpCount"],
                     "relevantConditionsLighthouseCount": relevant_conditions["relevantConditionsLighthouseCount"],
                     "totalConditionsCount": relevant_conditions["totalConditionsCount"],
                     "medicationsCount": relevant_medications["medicationsCount"]

--- a/service-python/tests/assessclaim/dc7101/main_sufficiency_test.py
+++ b/service-python/tests/assessclaim/dc7101/main_sufficiency_test.py
@@ -179,12 +179,13 @@ from assessclaimdc7101.src.lib import main
                                               'text': 'Essential (primary) hypertension'}],
                               'medications': [],
                               'documentsWithoutAnnotationsChecked': []},
-                 'evidenceSummary': {
-                                     'medicationsCount': 0,
-                                     'twoYearsBpCount': 3,
+                 'evidenceSummary': {'medicationsCount': 0,
+                                     'oneYearBpCount': 3,
                                      'relevantConditionsLighthouseCount': 1,
                                      'totalBpCount': 3,
-                                     'totalConditionsCount': 3},
+                                     'totalConditionsCount': 3,
+                                     'twoYearsBpCount': 3,
+                                     'twoYearsElevatedBpCount': 2},
                  'sufficientForFastTracking': True}
         ),
         # New claim with two twoYears BP both elevated and no condition
@@ -280,12 +281,13 @@ from assessclaimdc7101.src.lib import main
                               'conditions': [],
                               'medications': [],
                               'documentsWithoutAnnotationsChecked': []},
-                 'evidenceSummary': {
-                                     'medicationsCount': 0,
-                                     'twoYearsBpCount': 2,
+                 'evidenceSummary': {'medicationsCount': 0,
+                                     'oneYearBpCount': 0,
                                      'relevantConditionsLighthouseCount': 0,
                                      'totalBpCount': 2,
-                                     'totalConditionsCount': 0},
+                                     'totalConditionsCount': 0,
+                                     'twoYearsBpCount': 2,
+                                     'twoYearsElevatedBpCount': 2},
                  'sufficientForFastTracking': None}
         ),
         # New claim with relevant condition but no twoYears BP
@@ -404,12 +406,13 @@ from assessclaimdc7101.src.lib import main
                                                'text': 'some medication',
                                                "dataSource": "MAS"}],
                                                'documentsWithoutAnnotationsChecked': []},
-                 'evidenceSummary': {
-                                     'medicationsCount': 2,
-                                     'twoYearsBpCount': 1,
+                 'evidenceSummary': {'medicationsCount': 2,
+                                     'oneYearBpCount': 0,
                                      'relevantConditionsLighthouseCount': 1,
                                      'totalBpCount': 1,
-                                     'totalConditionsCount': 2},
+                                     'totalConditionsCount': 2,
+                                     'twoYearsBpCount': 1,
+                                     'twoYearsElevatedBpCount': 1},
                  'sufficientForFastTracking': False}
         ),
         # New claim with no condition and no twoYears BP, BP not elevated
@@ -538,12 +541,13 @@ from assessclaimdc7101.src.lib import main
                                                'text': 'some medication',
                                                "dataSource": "MAS"}],
                                                'documentsWithoutAnnotationsChecked': []},
-                 'evidenceSummary': {
-                                     'medicationsCount': 1,
-                                     'twoYearsBpCount': 2,
+                 'evidenceSummary': {'medicationsCount': 1,
+                                     'oneYearBpCount': 0,
                                      'relevantConditionsLighthouseCount': 0,
                                      'totalBpCount': 3,
-                                     'totalConditionsCount': 0},
+                                     'totalConditionsCount': 0,
+                                     'twoYearsBpCount': 2,
+                                     'twoYearsElevatedBpCount': 0},
                  'sufficientForFastTracking': None}
         ),
         # Claim for increase, not enough BP readings
@@ -609,11 +613,13 @@ from assessclaimdc7101.src.lib import main
                               'conditions': [],
                               'medications': [],
                               'documentsWithoutAnnotationsChecked': ['{guid}']},
-                 'evidenceSummary': {'medicationsCount':0,
-                                     'twoYearsBpCount': 1,
+                 'evidenceSummary': {'medicationsCount': 0,
+                                     'oneYearBpCount': 0,
                                      'relevantConditionsLighthouseCount': 0,
                                      'totalBpCount': 2,
-                                     'totalConditionsCount': 0},
+                                     'totalConditionsCount': 0,
+                                     'twoYearsBpCount': 1,
+                                     'twoYearsElevatedBpCount': 1},
                  'sufficientForFastTracking': False}
         ),
         (
@@ -758,10 +764,12 @@ from assessclaimdc7101.src.lib import main
                               'medications':[],
                               'documentsWithoutAnnotationsChecked': []},
                  'evidenceSummary': {'medicationsCount': 0,
-                                     'twoYearsBpCount': 4,
+                                     'oneYearBpCount': 0,
                                      'relevantConditionsLighthouseCount': 0,
                                      'totalBpCount': 4,
-                                     'totalConditionsCount': 0},
+                                     'totalConditionsCount': 0,
+                                     'twoYearsBpCount': 4,
+                                     'twoYearsElevatedBpCount': 4},
                  'sufficientForFastTracking': False}
         ),
         # Claim for increase
@@ -908,12 +916,13 @@ from assessclaimdc7101.src.lib import main
                               'conditions': [],
                               'medications': [],
                               'documentsWithoutAnnotationsChecked': []},
-                 'evidenceSummary': {
-                                     'medicationsCount': 0,
-                                     'twoYearsBpCount': 4,
+                 'evidenceSummary': {'medicationsCount': 0,
+                                     'oneYearBpCount': 4,
                                      'relevantConditionsLighthouseCount': 0,
                                      'totalBpCount': 4,
-                                     'totalConditionsCount': 0},
+                                     'totalConditionsCount': 0,
+                                     'twoYearsBpCount': 4,
+                                     'twoYearsElevatedBpCount': 4},
                  'sufficientForFastTracking': True}
 
         ),
@@ -935,12 +944,13 @@ from assessclaimdc7101.src.lib import main
                  'claimSubmissionId': '1234',
                  'disabilityActionType': 'INCREASE',
                  'evidence': {'bp_readings': [], 'conditions': [], 'medications': [],'documentsWithoutAnnotationsChecked': []},
-                 'evidenceSummary': {
-                                     'medicationsCount': 0,
-                                     'twoYearsBpCount': 0,
+                 'evidenceSummary': {'medicationsCount': 0,
+                                     'oneYearBpCount': 0,
                                      'relevantConditionsLighthouseCount': 0,
                                      'totalBpCount': 0,
-                                     'totalConditionsCount': 0},
+                                     'totalConditionsCount': 0,
+                                     'twoYearsBpCount': 0,
+                                     'twoYearsElevatedBpCount': 0},
                  'sufficientForFastTracking': False}
         ),
         # Bad data missing action type


### PR DESCRIPTION
<!-- Ensure the PR title reflects the feature or bug name -->

## What was the problem?
<!-- brief description of how things worked before this PR -->
One year BP readings and elevated readings were not in the logs. 

Associated tickets or Slack threads:
<!-- replace "000" with ticket number in both places -->
- [MCP-2472](https://amida.atlassian.net/browse/MCP-2472)

## How does this fix it?[^1]
<!-- description of how things will work after this PR -->
Add one year BP readings and elevated readings  to the evidence summary. 

## How to test this PR
- Step 1
- Step 2[^secrel]


[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
