### PR TITLE
Fix presumptive flag persistence in VRO database

### DIFF
--- a/service/provider/src/main/java/gov/va/vro/service/provider/mas/service/MasProcessingService.java
+++ b/service/provider/src/main/java/gov/va/vro/service/provider/mas/service/MasProcessingService.java
@@ -140,6 +140,7 @@ public class MasProcessingService {
         .inScope(payload.isInScope())
         .disabilityActionType(payload.getDisabilityActionType())
         .disabilityClassificationCode(payload.getDisabilityClassificationCode())
+        .presumptiveFlag(payload.isPresumptive() != null && payload.isPresumptive())
         .offRampReason(payload.getOffRampReason())
         .submissionSource(payload.getClaimDetail().getClaimSubmissionSource())
         .submissionDate(parseCustomDate(payload.getClaimDetail().getClaimSubmissionDateTime()))


### PR DESCRIPTION
## What was the problem?
Presumptive flag was always false in the database

Associated tickets or Slack threads:

- [MCP-2476](https://amida.atlassian.net/browse/MCP-2476)

## How does this fix it?
Missing processing step added

## How to test this PR
Run any end to end test where presumptive flag should be true

of note:
the payload itself can have a null return from the presumptive method. That null dictates offramp reason logic. For that reason I did not change the underlying payload and have coerced the boolean when it is turned into objects where it cannot be null. only non null and true translates to database true. 
