### PR TITLE
Add logs to count the number of entries pulled from LH FHIR

### DIFF
--- a/.github/workflows/update-deployment.yml
+++ b/.github/workflows/update-deployment.yml
@@ -140,7 +140,7 @@ jobs:
           chmod go-rwx ~/.kube/config
 
           echo "==================================="
-          if helm list -n va-abd-rrd-dev | grep ${{ env.RELEASE_NAME }}; then
+          if helm list -n va-abd-rrd-${{ inputs.target_env }} | grep "^${{ env.RELEASE_NAME }} "; then
             helm get values ${{ env.RELEASE_NAME }} -n va-abd-rrd-${{ inputs.target_env }}
             kubectl -n va-abd-rrd-${{ inputs.target_env }} get pods --show-labels
 
@@ -151,7 +151,9 @@ jobs:
 
             echo "helm_values=$(helm get values ${{ env.RELEASE_NAME }} -n va-abd-rrd-${{ inputs.target_env }} -o json)" >> $GITHUB_OUTPUT
           else
-            echo "No existing release; creating a new release: ${{ env.RELEASE_NAME }}"
+            echo "No existing Helm release; creating a new Helm release: ${{ env.RELEASE_NAME }}"
+            # Set helm_values so that subsequent steps that access it don't fail
+            echo 'helm_values={ "postgres": { "enabled": false } }' >> $GITHUB_OUTPUT
           fi
 
       - name: "Checkout source code"

--- a/app/src/main/resources/application.yml
+++ b/app/src/main/resources/application.yml
@@ -82,7 +82,7 @@ server:
     timeout: 60000
   servlet:
     session:
-      timeout: 60000
+      timeout: 120000
 
 log4j2:
   formatMsgNoLookups: true
@@ -114,7 +114,7 @@ spring:
       maxRequestSize: 25MB
       enabled: true
     session:
-      timeout: 60000
+      timeout: 120000
   resources:
     add-mappings: false
   mvc:

--- a/app/src/test/java/gov/va/vro/controller/VroControllerTest.java
+++ b/app/src/test/java/gov/va/vro/controller/VroControllerTest.java
@@ -50,6 +50,8 @@ import java.util.function.Function;
 @CamelSpringBootTest
 class VroControllerTest extends BaseControllerTest {
 
+  private static final int TIME_OUT = 120000;
+
   @Autowired private AppTestUtil util;
 
   @Autowired protected CamelContext camelContext;
@@ -80,7 +82,8 @@ class VroControllerTest extends BaseControllerTest {
                 .interceptSendToEndpoint(
                     "rabbitmq:claim-submit-exchange"
                         + "?queue=claim-submit"
-                        + "&routingKey=code.hypertension&requestTimeout=60000")
+                        + "&routingKey=code.hypertension&requestTimeout="
+                        + TIME_OUT)
                 .skipSendToOriginalEndpoint()
                 .to("mock:claim-submit"));
     // Mock secondary process endpoint
@@ -91,7 +94,8 @@ class VroControllerTest extends BaseControllerTest {
             route
                 .interceptSendToEndpoint(
                     "rabbitmq:health-assess-exchange"
-                        + "?routingKey=health-assess.hypertension&requestTimeout=60000")
+                        + "?routingKey=health-assess.hypertension&requestTimeout="
+                        + TIME_OUT)
                 .skipSendToOriginalEndpoint()
                 .to("mock:claim-submit-full"));
     // The mock endpoint returns a valid response
@@ -141,7 +145,8 @@ class VroControllerTest extends BaseControllerTest {
                 .interceptSendToEndpoint(
                     "rabbitmq:claim-submit-exchange"
                         + "?queue=claim-submit"
-                        + "&routingKey=code.hypertension&requestTimeout=60000")
+                        + "&routingKey=code.hypertension&requestTimeout="
+                        + TIME_OUT)
                 .skipSendToOriginalEndpoint()
                 .to("mock:claim-submit"));
     // Mock secondary process endpoint
@@ -152,7 +157,8 @@ class VroControllerTest extends BaseControllerTest {
             route
                 .interceptSendToEndpoint(
                     "rabbitmq:health-assess-exchange"
-                        + "?routingKey=health-assess.hypertension&requestTimeout=60000")
+                        + "?routingKey=health-assess.hypertension&requestTimeout="
+                        + TIME_OUT)
                 .skipSendToOriginalEndpoint()
                 .to("mock:claim-submit-full"));
 

--- a/app/src/test/java/gov/va/vro/routes/MasIntegrationRoutesTest.java
+++ b/app/src/test/java/gov/va/vro/routes/MasIntegrationRoutesTest.java
@@ -35,6 +35,8 @@ import java.util.Collections;
 
 public class MasIntegrationRoutesTest extends BaseIntegrationTest {
 
+  private static final long DEFAULT_REQUEST_TIMEOUT = 120000;
+
   @Autowired CamelEntrance camelEntrance;
 
   @MockBean IMasApiService masApiService;
@@ -96,7 +98,9 @@ public class MasIntegrationRoutesTest extends BaseIntegrationTest {
     replaceEndpoint(
         "claim-submit",
         "rabbitmq://claim-submit-exchange?queue=claim-submit&"
-            + "requestTimeout=60000&routingKey=code.hypertension",
+            + "requestTimeout="
+            + DEFAULT_REQUEST_TIMEOUT
+            + "&routingKey=code.hypertension",
         "mock:claim-submit");
 
     mockClaimSubmit.whenAnyExchangeReceived(
@@ -110,7 +114,8 @@ public class MasIntegrationRoutesTest extends BaseIntegrationTest {
     replaceEndpoint(
         "mas-processing",
         "rabbitmq:health-assess-exchange?routingKey=health-sufficiency-assess.hypertension&"
-            + "requestTimeout=60000",
+            + "requestTimeout="
+            + DEFAULT_REQUEST_TIMEOUT,
         "mock:sufficiency-assess");
 
     mockSufficiencyAssess.whenAnyExchangeReceived(

--- a/service/provider/src/main/java/gov/va/vro/service/provider/camel/SlipClaimSubmitRouter.java
+++ b/service/provider/src/main/java/gov/va/vro/service/provider/camel/SlipClaimSubmitRouter.java
@@ -17,7 +17,7 @@ import java.util.Map;
 @Component
 public class SlipClaimSubmitRouter {
 
-  private static final long DEFAULT_REQUEST_TIMEOUT = 60000;
+  private static final long DEFAULT_REQUEST_TIMEOUT = 120000;
   public static final String NO_DIAGNOSTIC_CODE_ERROR = "No diagnostic code in properties.";
 
   /**

--- a/shared/domain/src/main/java/gov/va/vro/model/event/AuditEvent.java
+++ b/shared/domain/src/main/java/gov/va/vro/model/event/AuditEvent.java
@@ -93,8 +93,11 @@ public class AuditEvent {
         + '\''
         + ", payloadType="
         + payloadType
+        + ", eventId="
+        + eventId
         + ", message='"
         + message
+        + '\''
         + '}';
   }
 }

--- a/svc-lighthouse-api/src/main/java/gov/va/vro/abddataaccess/service/FhirClient.java
+++ b/svc-lighthouse-api/src/main/java/gov/va/vro/abddataaccess/service/FhirClient.java
@@ -165,6 +165,7 @@ public class FhirClient {
   }
 
   private List<AbdCondition> getPatientConditions(List<BundleEntryComponent> entries) {
+    log.info("Extract patient condition entries. number of entries: {}", entries.size());
     List<AbdCondition> result = new ArrayList<>();
     for (BundleEntryComponent entry : entries) {
       Condition resource = (Condition) entry.getResource();
@@ -188,6 +189,7 @@ public class FhirClient {
   }
 
   private List<AbdProcedure> getPatientProcedures(List<BundleEntryComponent> entries) {
+    log.info("Extract patient procedure entries. number of entries: {}", entries.size());
     List<AbdProcedure> result = new ArrayList<>();
     for (BundleEntryComponent entry : entries) {
       Procedure resource = (Procedure) entry.getResource();


### PR DESCRIPTION
Add logs to count the number of entries from LH for condition and procedure. In addition, add collection ID to slack message

## What was the problem?

1. Add additional logs for debugging purpose. MCP-2478
2. The slack message for OffRamp doesn't have information to identify the collection/claim. MCP-2479
3. Increase timeout value. See MCP-2471

Associated tickets or Slack threads:
 MCP-2478, MCP-2479, MCP-2471

## How does this fix it?[^1]
1. Add additional logs.
2. Output eventId which is collection ID to the message to slack.

## How to test this PR
- Step 1. Build and launch the app.
- Step 2. Open log window to see svs-lighthouse-api.
- Step 3. Test health-data-assessment endpoint. Checking log window, should see something like the followings.
     abddataaccess.service.FhirClient   : Extract patient medication entries. number of entries: 11
     abddataaccess.service.FhirClient   : Extract patient condition entries. number of entries: 38
Note: I have some difficult to test 2 (for MCP-2479), as it needs to make a case and check the slack channel. It is difficult for me to do it in my local environment. The slack message for OffRamp should have something looks like "AuditEvent{routeId='assessorError', payloadType=Automated Claim, eventId=3424, message='Sufficiency cannot be determined}"


[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
