### PR TITLE
Save Exam Order Status when VRO initializes order to MAS

### DIFF
--- a/service/db/src/main/java/gov/va/vro/service/db/SaveToDbServiceImpl.java
+++ b/service/db/src/main/java/gov/va/vro/service/db/SaveToDbServiceImpl.java
@@ -373,7 +373,8 @@ public class SaveToDbServiceImpl implements SaveToDbService {
   }
 
   private ExamOrderEntity createExamOrder(ExamOrder examOrder) {
-    // Currently ExamOrders only come from MAS or after VRO successfully requests an exam order from MAS
+    // Currently ExamOrders only come from MAS or after VRO successfully requests an exam order from
+    // MAS
     Optional<ClaimSubmissionEntity> claimSubmission =
         claimSubmissionRepository.findFirstByReferenceIdAndIdTypeOrderByCreatedAtDesc(
             examOrder.getCollectionId(), examOrder.getIdType());

--- a/service/db/src/main/java/gov/va/vro/service/db/SaveToDbServiceImpl.java
+++ b/service/db/src/main/java/gov/va/vro/service/db/SaveToDbServiceImpl.java
@@ -373,7 +373,7 @@ public class SaveToDbServiceImpl implements SaveToDbService {
   }
 
   private ExamOrderEntity createExamOrder(ExamOrder examOrder) {
-    // Currently ExamOrders only come from MAS or VRO sending to MAS
+    // Currently ExamOrders only come from MAS or after VRO successfully requests an exam order from MAS
     Optional<ClaimSubmissionEntity> claimSubmission =
         claimSubmissionRepository.findFirstByReferenceIdAndIdTypeOrderByCreatedAtDesc(
             examOrder.getCollectionId(), examOrder.getIdType());

--- a/service/db/src/main/java/gov/va/vro/service/db/SaveToDbServiceImpl.java
+++ b/service/db/src/main/java/gov/va/vro/service/db/SaveToDbServiceImpl.java
@@ -373,7 +373,7 @@ public class SaveToDbServiceImpl implements SaveToDbService {
   }
 
   private ExamOrderEntity createExamOrder(ExamOrder examOrder) {
-    // Currently ExamOrders only come from MAS
+    // Currently ExamOrders only come from MAS or VRO sending to MAS
     Optional<ClaimSubmissionEntity> claimSubmission =
         claimSubmissionRepository.findFirstByReferenceIdAndIdTypeOrderByCreatedAtDesc(
             examOrder.getCollectionId(), examOrder.getIdType());

--- a/service/provider/src/main/java/gov/va/vro/service/provider/MasOrderExamProcessor.java
+++ b/service/provider/src/main/java/gov/va/vro/service/provider/MasOrderExamProcessor.java
@@ -55,7 +55,6 @@ public class MasOrderExamProcessor implements Processor {
               .collectionId(Integer.toString(claimPayload.getCollectionId()))
               .idType(MasAutomatedClaimPayload.CLAIM_V2_ID_TYPE)
               .status(SUBMITTED_STATUS)
-              .examOrderDateTime(OffsetDateTime.now())
               .build();
       saveToDbService.insertOrUpdateExamOrderingStatus(examOrder);
       exchange.setProperty("orderExamResponse", response);

--- a/service/provider/src/main/java/gov/va/vro/service/provider/MasOrderExamProcessor.java
+++ b/service/provider/src/main/java/gov/va/vro/service/provider/MasOrderExamProcessor.java
@@ -15,7 +15,6 @@ import org.apache.camel.Exchange;
 import org.apache.camel.Processor;
 import org.springframework.stereotype.Component;
 
-import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Map;
 


### PR DESCRIPTION
## What was the problem?
Previously the exam order table did not get an entry until MAS called for a status from us. 
Now VRO will put an entry into the table when we send the order to MAS.
If MAS asks us for a status we are not aware of we still save the row in the table. 

Associated tickets or Slack threads:
- [MCP-2470](https://amida.atlassian.net/browse/MCP-2470)
- https://amida.slack.com/archives/C01Q7979Z7D/p1678153769230959

## How does this fix it?
Hooked into the code where we send the order and create an object to save to the database. Requires changes only in that file as the database file can already handle this call. 

## How to test this PR
Run end to end tests for VroV2. 
Claim id 377, 378, and 350 will all land in ORDER_SUBMITTED status as we initiate the order.
This can also be verified in the vro logs as the log message has changed to indicate we are both making the order and saving to the database at that point. 
