### PR TITLE
Test off ramp End to End Testing

### DIFF
--- a/app/src/end2endTest/java/gov/va/vro/end2end/VroV2Tests.java
+++ b/app/src/end2endTest/java/gov/va/vro/end2end/VroV2Tests.java
@@ -234,7 +234,7 @@ public class VroV2Tests {
             log.error(
                 "CollectionId {} came back with more than one contention. Cannot determine which one to check",
                 collectionId);
-              break;
+            break;
           }
         }
       } catch (Exception exception) {

--- a/app/src/end2endTest/java/gov/va/vro/end2end/VroV2Tests.java
+++ b/app/src/end2endTest/java/gov/va/vro/end2end/VroV2Tests.java
@@ -396,7 +396,8 @@ public class VroV2Tests {
   @SneakyThrows
    @Test
   void testAutomatedSufficiencyIsNull() {
-    testAutomatedClaimFullPositive("500", true);
+    // Offramp claims do not go through pdf process per VRO workflow diagram.
+    testAutomatedClaimFullPositive("500", false);
     testClaimSufficientStatus("500", null);
   }
 }

--- a/controller/src/main/java/gov/va/vro/controller/ClaimMetricsController.java
+++ b/controller/src/main/java/gov/va/vro/controller/ClaimMetricsController.java
@@ -42,7 +42,7 @@ public class ClaimMetricsController implements ClaimMetricsResource {
         default -> {
           log.warn("Invalid version given to claim info. Must be v1 or v2 if given");
           String msg = HttpStatus.BAD_REQUEST.getReasonPhrase();
-          throw new ClaimProcessingException(claimSubmissionId, HttpStatus.BAD_GATEWAY, msg);
+          throw new ClaimProcessingException(claimSubmissionId, HttpStatus.BAD_REQUEST, msg);
         }
       }
     }

--- a/persistence/model/src/main/java/gov/va/vro/persistence/model/ClaimEntity.java
+++ b/persistence/model/src/main/java/gov/va/vro/persistence/model/ClaimEntity.java
@@ -2,6 +2,8 @@ package gov.va.vro.persistence.model;
 
 import lombok.Getter;
 import lombok.Setter;
+import org.hibernate.annotations.Fetch;
+import org.hibernate.annotations.FetchMode;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -30,11 +32,17 @@ public class ClaimEntity extends BaseEntity {
 
   @ManyToOne private VeteranEntity veteran;
 
+  // Multiple collections need to be eagerly fetched without causing a cartesian join product with
+  // FETCH.JOIN , or hibernates n+1 query issue by using FETCH.SELECT.
+  // FETCH.SUBSELECT keeps the number of queries down (3 total), does not cause a cartesian join,
+  // and permits eager fetching to still occur.
+
   @OneToMany(
       mappedBy = "claim",
       fetch = FetchType.EAGER,
       cascade = CascadeType.ALL,
       orphanRemoval = true)
+  @Fetch(FetchMode.SUBSELECT)
   private List<ContentionEntity> contentions = new ArrayList<>();
 
   @OneToMany(
@@ -42,6 +50,7 @@ public class ClaimEntity extends BaseEntity {
       fetch = FetchType.EAGER,
       cascade = CascadeType.ALL,
       orphanRemoval = true)
+  @Fetch(FetchMode.SUBSELECT)
   private Set<ClaimSubmissionEntity> claimSubmissions = new HashSet<>();
 
   public void addContention(ContentionEntity contention) {

--- a/persistence/model/src/main/java/gov/va/vro/persistence/model/ContentionEntity.java
+++ b/persistence/model/src/main/java/gov/va/vro/persistence/model/ContentionEntity.java
@@ -57,15 +57,13 @@ public class ContentionEntity extends BaseEntity {
   /**
    * Adds assessment result to a claim.
    *
-   * @param ar assessment result entity
+   * @param assessmentResultEntity assessment result entity
    * @return returns the assessment result
    */
-  public AssessmentResultEntity addAssessmentResult(AssessmentResultEntity ar) {
-    AssessmentResultEntity assessmentResult = new AssessmentResultEntity();
-    assessmentResult.setContention(this);
-    assessmentResult.setEvidenceCountSummary(ar.getEvidenceCountSummary());
-    assessmentResults.add(assessmentResult);
-    return assessmentResult;
+  public AssessmentResultEntity addAssessmentResult(AssessmentResultEntity assessmentResultEntity) {
+    assessmentResultEntity.setContention(this);
+    assessmentResults.add(assessmentResultEntity);
+    return assessmentResultEntity;
   }
 
   /**

--- a/persistence/model/src/test/java/gov/va/vro/persistence/repository/ClaimRepositoryTest.java
+++ b/persistence/model/src/test/java/gov/va/vro/persistence/repository/ClaimRepositoryTest.java
@@ -22,7 +22,8 @@ public class ClaimRepositoryTest {
   @Test
   void test() {
     Date icnTimestamp = new Date();
-
+    var REF_ID = "222";
+    var ID_TYPE = "TEST_TYPE";
     var veteran = TestDataSupplier.createVeteran("X", "Y", icnTimestamp);
     veteranRepository.save(veteran);
     assertNotNull(veteran.getIcn());
@@ -47,12 +48,19 @@ public class ClaimRepositoryTest {
     contention1.addAssessmentResult(assessmentResult);
     contention1.addEvidenceSummaryDocument(evidenceSummaryDocument1);
     contention1.addEvidenceSummaryDocument(evidenceSummaryDocument2);
-    var claim = TestDataSupplier.createClaim("123", veteran);
+    var claim = TestDataSupplier.createClaim("123", veteran);git st
     claim.addContention(contention1);
+    var claimSubmission = TestDataSupplier.createClaimSubmission(claim, REF_ID, ID_TYPE);
+    claim.addClaimSubmission(claimSubmission);
     claim = claimRepository.save(claim);
     assertNotNull(claim.getId());
     assertNotNull(claim.getCreatedAt());
     assertNotNull(claim.getContentions().get(0));
     assertEquals(claim.getContentions().get(0).getDiagnosticCode(), "c1");
+    assertNotNull(claim.getClaimSubmissions());
+    var savedSubmission = claim.getClaimSubmissions().iterator().next();
+    assertNotNull(savedSubmission);
+    assertEquals(REF_ID, savedSubmission.getReferenceId());
+    assertEquals(ID_TYPE, savedSubmission.getIdType());
   }
 }

--- a/persistence/model/src/test/java/gov/va/vro/persistence/repository/ClaimRepositoryTest.java
+++ b/persistence/model/src/test/java/gov/va/vro/persistence/repository/ClaimRepositoryTest.java
@@ -48,7 +48,7 @@ public class ClaimRepositoryTest {
     contention1.addAssessmentResult(assessmentResult);
     contention1.addEvidenceSummaryDocument(evidenceSummaryDocument1);
     contention1.addEvidenceSummaryDocument(evidenceSummaryDocument2);
-    var claim = TestDataSupplier.createClaim("123", veteran);git st
+    var claim = TestDataSupplier.createClaim("123", veteran);
     claim.addContention(contention1);
     var claimSubmission = TestDataSupplier.createClaimSubmission(claim, REF_ID, ID_TYPE);
     claim.addClaimSubmission(claimSubmission);

--- a/service/db/src/main/java/gov/va/vro/service/db/SaveToDbServiceImpl.java
+++ b/service/db/src/main/java/gov/va/vro/service/db/SaveToDbServiceImpl.java
@@ -141,6 +141,8 @@ public class SaveToDbServiceImpl implements SaveToDbService {
     }
     AssessmentResultEntity assessmentResultEntity = new AssessmentResultEntity();
     assessmentResultEntity.setEvidenceCountSummary(summary);
+    assessmentResultEntity.setSufficientEvidenceFlag(
+        evidenceResponse.getSufficientForFastTracking());
     ContentionEntity contention = findContention(claimEntity, diagnosticCode);
     if (contention == null) {
       log.warn("Could not match contention with diagnostic code");

--- a/service/db/src/test/java/gov/va/vro/service/db/SaveToDbServiceImplTest.java
+++ b/service/db/src/test/java/gov/va/vro/service/db/SaveToDbServiceImplTest.java
@@ -135,10 +135,8 @@ class SaveToDbServiceImplTest {
     AbdEvidenceWithSummary evidence = new AbdEvidenceWithSummary();
     evidence.setIdType(MasAutomatedClaimPayload.CLAIM_V2_ID_TYPE);
     evidence.setEvidenceSummary(evidenceMap);
-    // evidence flag is currently null
-    saveToDbService.insertAssessmentResult(claimBeforeAssessment.getId(), evidence, "7101");
     evidence.setSufficientForFastTracking(false);
-    saveToDbService.updateSufficientEvidenceFlag(evidence, "7101");
+    saveToDbService.insertAssessmentResult(claimBeforeAssessment.getId(), evidence, "7101");
     ClaimEntity result = claimRepository.findByVbmsId("1234").orElseThrow();
     assertNotNull(result);
     assertNotNull(result.getContentions().get(0).getAssessmentResults().get(0));

--- a/service/db/src/test/java/gov/va/vro/service/db/mapper/ClaimInfoResponseMapperTest.java
+++ b/service/db/src/test/java/gov/va/vro/service/db/mapper/ClaimInfoResponseMapperTest.java
@@ -43,9 +43,11 @@ public class ClaimInfoResponseMapperTest {
     ContentionEntity contentionEntity = new ContentionEntity();
     contentionEntity.setDiagnosticCode(diagnosticCode);
 
+    final Boolean sufficientEvidence = true;
     AssessmentResultEntity assessmentResultEntity = new AssessmentResultEntity();
     Map<String, String> areEvidenceInfo = ImmutableMap.of("k1", "v1", "k2", "v2");
     assessmentResultEntity.setEvidenceCountSummary(areEvidenceInfo);
+    assessmentResultEntity.setSufficientEvidenceFlag(sufficientEvidence);
     contentionEntity.addAssessmentResult(assessmentResultEntity);
 
     EvidenceSummaryDocumentEntity esdEntity = new EvidenceSummaryDocumentEntity();
@@ -81,6 +83,7 @@ public class ClaimInfoResponseMapperTest {
     assertEquals(1, assessments.size());
     AssessmentInfo assessmentInfo = assessments.get(0);
     assertEquals(areEvidenceInfo, assessmentInfo.getEvidenceInfo());
+    assertEquals(sufficientEvidence, assessmentInfo.getSufficientEvidenceFlag());
 
     List<DocumentInfo> documents = contentionInfo.getDocuments();
     assertNotNull(documents);

--- a/service/provider/src/main/java/gov/va/vro/service/provider/services/MasAssessmentResultProcessor.java
+++ b/service/provider/src/main/java/gov/va/vro/service/provider/services/MasAssessmentResultProcessor.java
@@ -26,6 +26,5 @@ public class MasAssessmentResultProcessor implements Processor {
       return;
     }
     saveToDbService.insertAssessmentResult(evidence, diagnosticCode);
-    saveToDbService.updateSufficientEvidenceFlag(evidence, diagnosticCode);
   }
 }

--- a/shared/domain/src/main/java/gov/va/vro/model/claimmetrics/AssessmentInfo.java
+++ b/shared/domain/src/main/java/gov/va/vro/model/claimmetrics/AssessmentInfo.java
@@ -17,4 +17,5 @@ import java.util.Map;
 @EqualsAndHashCode
 public class AssessmentInfo {
   private Map<String, String> evidenceInfo;
+  private Boolean sufficientEvidenceFlag;
 }


### PR DESCRIPTION
## What was the problem?
Previously, the code could not check for the assessment result sufficient flag directly to know the end of processing had occurred and check that it is correct. 

Associated tickets or Slack threads:
- [MCP-2424](https://amida.atlassian.net/browse/MCP-2424)

## How does this fix it?
Wires up end to end testing against the claim-info api. 
Exposes the sufficient flag in the claim info api
And also solves a problem that I inadvertently discovered on database reads showing more results in only *some* cases than were actually in the database itself. 

## How to test this PR
Run end to end tests.
You can also use the claim-info api for a given claimsubmissionId
