### PR TITLE
Use COMPOSE_PROFILES for v2

### DIFF
--- a/.github/workflows/end2end-test.yml
+++ b/.github/workflows/end2end-test.yml
@@ -1,4 +1,4 @@
-name: "PR: End-to-end test"
+name: "PR: End-to-end test for v2"
 
 on:
   pull_request:
@@ -41,6 +41,7 @@ jobs:
       - name: "Start the containers"
         run: |
           source scripts/setenv.sh
+          export COMPOSE_PROFILES="v2,v2-mocks,pdfgen,lh"
           export -p | sed 's/declare -x //'
           ./gradlew :app:dockerComposeUp
         env:

--- a/app/src/docker/docker-compose.yml
+++ b/app/src/docker/docker-compose.yml
@@ -223,7 +223,7 @@ services:
       - internal
 
   svc-assessor-dc6602:
-    profiles: ["all","svc","assessor"]
+    profiles: ["all","svc","assessor","v2"]
     image: va/abd_vro-assessclaimdc6602:latest
     <<: *common-security-opt
     <<: *common-sde-security

--- a/app/src/docker/docker-compose.yml
+++ b/app/src/docker/docker-compose.yml
@@ -67,6 +67,9 @@ x-python-healthcheck: &python-healthcheck
     retries: 5
 
 services:
+  # Containers with the `-service` suffix are need by the VRO app.
+  # Containers with the `svc-` prefix are microservices to support domain workflows.
+  # Containers with the `mock-` prefix are used for development and testing.
 
   rabbitmq-service:
     image: rabbitmq:3-management
@@ -191,7 +194,7 @@ services:
     image: va/abd_vro-workflows-xample:latest
     <<: *common-security-opt
     <<: *common-sde-security
-    profiles: ["xample"]
+    profiles: ["all","xample"]
     environment:
       <<: *redis-placeholder-vars
       <<: *rabbitmq-placeholder-vars
@@ -205,6 +208,7 @@ services:
       - internal
 
   svc-assessor-dc7101:
+    profiles: ["all","svc","assessor","v2"]
     image: va/abd_vro-assessclaimdc7101:latest
     <<: *common-security-opt
     <<: *common-sde-security
@@ -219,6 +223,7 @@ services:
       - internal
 
   svc-assessor-dc6602:
+    profiles: ["all","svc","assessor"]
     image: va/abd_vro-assessclaimdc6602:latest
     <<: *common-security-opt
     <<: *common-sde-security
@@ -233,6 +238,7 @@ services:
       - internal
 
   svc-assessor-dc6602v2:
+    profiles: ["all","svc","assessor","prototype"]
     image: va/abd_vro-assessclaimdc6602v2:latest
     <<: *common-security-opt
     <<: *common-sde-security
@@ -245,9 +251,9 @@ services:
         condition: service_healthy
     networks:
       - internal
-    profiles: ["prototype"]
 
   svc-assessor-cancer:
+    profiles: ["all","svc","assessor","prototype"]
     image: va/abd_vro-assessclaimcancer:latest
     <<: *common-security-opt
     <<: *common-sde-security
@@ -260,25 +266,9 @@ services:
         condition: service_healthy
     networks:
       - internal
-    profiles: [ "prototype" ]
-
-  svc-feature-toggle:
-    image: va/abd_vro-featuretoggle:latest
-    <<: *common-security-opt
-    <<: *common-sde-security
-    environment:
-      <<: *redis-placeholder-vars
-      <<: *rabbitmq-placeholder-vars
-      <<: *rabbitmq-client-vars
-    depends_on:
-      redis-service:
-        condition: service_started
-      rabbitmq-service:
-        condition: service_healthy
-    networks:
-      - internal
 
   svc-assessor-dc6510:
+    profiles: ["all","svc","assessor","prototype"]
     image: va/abd_vro-assessclaimdc6510:latest
     <<: *common-security-opt
     <<: *common-sde-security
@@ -291,9 +281,9 @@ services:
         condition: service_healthy
     networks:
       - internal
-    profiles: ["prototype"]
 
   svc-assessor-dc6522:
+    profiles: ["all","svc","assessor","prototype"]
     image: va/abd_vro-assessclaimdc6522:latest
     <<: *common-security-opt
     <<: *common-sde-security
@@ -306,9 +296,9 @@ services:
         condition: service_healthy
     networks:
       - internal
-    profiles: ["prototype"]
 
   svc-pdf-generator:
+    profiles: ["all","svc","pdfgen"]
     image: va/abd_vro-pdfgenerator:latest
     <<: *common-security-opt
     <<: *common-sde-security
@@ -326,6 +316,7 @@ services:
       - internal
 
   svc-lighthouse-api:
+    profiles: ["all","svc","lh"]
     image: va/abd_vro-service-data-access:latest
     <<: *common-security-opt
     <<: *common-sde-security
@@ -341,11 +332,28 @@ services:
     networks:
       - internal
 
+  svc-feature-toggle:
+    profiles: ["all","svc","feature-toggle"]
+    image: va/abd_vro-featuretoggle:latest
+    <<: *common-security-opt
+    <<: *common-sde-security
+    environment:
+      <<: *redis-placeholder-vars
+      <<: *rabbitmq-placeholder-vars
+      <<: *rabbitmq-client-vars
+    depends_on:
+      redis-service:
+        condition: service_started
+      rabbitmq-service:
+        condition: service_healthy
+    networks:
+      - internal
+
   console:
+    profiles: ["all","console"]
     image: va/abd_vro-console:latest
     # <<: *common-security-opt
     <<: *common-sde-security
-    profiles: ["debug"]
     # stdin and tty are needed for user interaction
     stdin_open: true
     tty: true
@@ -369,6 +377,7 @@ services:
       - internal
 
   mock-bip-ce-api:
+    profiles: ["all","mock","bip","v2-mocks"]
     image: va/abd_vro-mock-bip-ce-api:latest
     <<: *common-security-opt
     <<: *common-sde-security
@@ -389,6 +398,7 @@ services:
       - internal
 
   mock-bip-claims-api:
+    profiles: ["all","mock","bip","v2-mocks"]
     image: va/abd_vro-mock-bip-claims-api:latest
     <<: *common-security-opt
     <<: *common-sde-security
@@ -409,6 +419,7 @@ services:
       - internal
 
   mock-mas-api:
+    profiles: ["all","mock","mas","v2-mocks"]
     image: va/abd_vro-mock-mas-api:latest
     <<: *common-security-opt
     <<: *common-sde-security
@@ -430,6 +441,7 @@ services:
       - internal
 
   mock-lighthouse-api:
+    profiles: ["all","mock","lh","v2-mocks"]
     image: va/abd_vro-mock-lighthouse-api:latest
     <<: *common-security-opt
     <<: *common-sde-security

--- a/scripts/setenv.sh
+++ b/scripts/setenv.sh
@@ -76,8 +76,22 @@ exportFile(){
 # Set the prefix for container names used by docker-compose
 # Not necessary, but it shortens the default prefix `abd-vro`
 export COMPOSE_PROJECT_NAME=vro
-# Determines which containers are started by docker-compose
-export COMPOSE_PROFILES=assessors,feat-toggle,pdf-gen
+
+# COMPOSE_PROFILES determines which containers are started by docker-compose.
+# This allows developers to start only the containers they need for their current work.
+# See https://docs.docker.com/compose/profiles/
+# Refer to the src/docker/docker-compose.yml file for profile names.
+# For the iMVP, set to "v2,v2-mocks,pdfgen,lh"
+# - "v2" = all service for v2
+# - "v2-mocks" = all mocks for v2
+# - "pdfgen" = pdf generator microservice
+# - "lh" = Lighthouse API client microservice and the mock LH API
+# For minimal VRO, set to "" (empty string). This starts the app and required application services.
+# To start all containers, set to "all".
+# To start a specific container (along with containers it depends_on), run:
+#   cd app/src/docker
+#   docker-compose up $CONTAINER_NAME
+export COMPOSE_PROFILES="v2,v2-mocks,pdfgen,lh"
 
 ###
 ### Credentials for VRO internal services ###

--- a/scripts/setenv.sh
+++ b/scripts/setenv.sh
@@ -59,9 +59,18 @@ getSecret(){
 exportSecretIfUnset(){
   local VAR_VALUE=$(eval echo "\$$1")
   if [ "${VAR_VALUE}" ]; then
-    >&2 echo "$1 already set -- not overriding."
+    >&2 echo "Not overriding: $1 already set."
   else
     eval "export $1=\$(getSecret $1)"
+  fi
+}
+
+exportIfUnset(){
+  local VAR_VALUE=$(eval echo "\$$1")
+  if [ "${VAR_VALUE}" ]; then
+    >&2 echo "Not overriding: $1 already set to: '${VAR_VALUE}'"
+  else
+    eval "export $1=$2"
   fi
 }
 
@@ -86,12 +95,14 @@ export COMPOSE_PROJECT_NAME=vro
 # - "v2-mocks" = all mocks for v2
 # - "pdfgen" = pdf generator microservice
 # - "lh" = Lighthouse API client microservice and the mock LH API
-# For minimal VRO, set to "" (empty string). This starts the app and required application services.
+# For minimal VRO, set to " " (space). This starts the app and required application services.
+#   (A space is used to distinguish it from an empty string, which is interpreted as
+#   being unset by function exportIfUnset.)
 # To start all containers, set to "all".
 # To start a specific container (along with containers it depends_on), run:
 #   cd app/src/docker
 #   docker-compose up $CONTAINER_NAME
-export COMPOSE_PROFILES="v2,v2-mocks,pdfgen,lh"
+exportIfUnset COMPOSE_PROFILES "v2,v2-mocks,pdfgen,lh"
 
 ###
 ### Credentials for VRO internal services ###


### PR DESCRIPTION
<!-- Ensure the PR title reflects the feature or bug name -->

## What was the problem?
<!-- brief description of how things worked before this PR -->

We now have many Docker containers starting by default, which consumes lots of memory. Depending on the thing be developed, not all containers need to be started.

## How does this fix it?
<!-- description of how things will work after this PR -->

Set docker compose profiles to each container, so that only desired containers are started when running `./gradlew :app:dockerComposeUp`. The desired containers are determined by setting env variable `COMPOSE_PROFILES`.

For running the entire iMVP, set to "v2,v2-mocks,pdfgen,lh" (`export COMPOSE_PROFILES="v2,v2-mocks,pdfgen,lh"`)
- "v2" = all service for v2
- "v2-mocks" = all mocks for v2
- "pdfgen" = pdf generator microservice
- "lh" = Lighthouse API client microservice and the mock LH API

Additional instructions are in the `setenv.sh` file.

## How to test this PR
In a new console/terminal, Run and test VRO locally using docker compose:
```
unset COMPOSE_PROFILES
source scripts/setenv.sh
./gradlew :app:dockerComposeUp
```

Try `export COMPOSE_PROFILES=' '` to run a minimal VRO.