### PR TITLE
Address latent rabbitmq bug

### DIFF
--- a/domain-xample/workflows-xample/src/main/java/gov/va/vro/routes/xample/XampleRoutes.java
+++ b/domain-xample/workflows-xample/src/main/java/gov/va/vro/routes/xample/XampleRoutes.java
@@ -99,6 +99,10 @@ public class XampleRoutes extends EndpointRouteBuilder {
   }
 
   void configureServicesRoute() {
+    final String DIRECT_TO_MQ_XAMPLE_SERVICE_J = "direct:toMq-xample--serviceJ";
+    RabbitMqCamelUtils.addToRabbitmqRoute(
+        this, DIRECT_TO_MQ_XAMPLE_SERVICE_J, "xample", "serviceJ");
+
     // Route to particular service depending on message body
     // Demonstrates different ways to trigger a service
     from(FANCY_SERVICE_ENDPOINT)
@@ -110,7 +114,7 @@ public class XampleRoutes extends EndpointRouteBuilder {
         // https://camel.apache.org/components/3.19.x/eips/bean-eip.html
         .bean(ServiceB.class)
         .otherwise()
-        .to(RabbitMqCamelUtils.rabbitmqProducerEndpoint("xample", "serviceC"))
+        .to(DIRECT_TO_MQ_XAMPLE_SERVICE_J)
         .end() // end ChoiceDefinition
         .log("Finally returning from service: ${body.getClass()}: ${body}");
 

--- a/service/provider/src/main/java/gov/va/vro/service/provider/camel/MasIntegrationRoutes.java
+++ b/service/provider/src/main/java/gov/va/vro/service/provider/camel/MasIntegrationRoutes.java
@@ -120,8 +120,11 @@ public class MasIntegrationRoutes extends RouteBuilder {
     final String MAS_NOTIFICATION_EXCHANGE = "mas-notification-exchange";
     final String MAS_NOTIFICATION_ROUTING_KEY = "mas-notification";
     RabbitMqCamelUtils.addToRabbitmqRoute(
-        this, DIRECT_TO_MQ_MAS, MAS_NOTIFICATION_EXCHANGE,
-        MAS_NOTIFICATION_ROUTING_KEY, "&requestTimeout=0");
+        this,
+        DIRECT_TO_MQ_MAS,
+        MAS_NOTIFICATION_EXCHANGE,
+        MAS_NOTIFICATION_ROUTING_KEY,
+        "&requestTimeout=0");
 
     var checkClaimRouteId = "mas-claim-notification";
     from(ENDPOINT_AUTOMATED_CLAIM)
@@ -135,8 +138,7 @@ public class MasIntegrationRoutes extends RouteBuilder {
         .to(DIRECT_TO_MQ_MAS);
 
     var processClaimRouteId = "mas-claim-processing";
-    RabbitMqCamelUtils.fromRabbitmq(this, MAS_NOTIFICATION_EXCHANGE,
-        MAS_NOTIFICATION_ROUTING_KEY)
+    RabbitMqCamelUtils.fromRabbitmq(this, MAS_NOTIFICATION_EXCHANGE, MAS_NOTIFICATION_ROUTING_KEY)
         .routeId(processClaimRouteId)
         // TODO Q: Why is unmarshal needed? Isn't the msg body already a MasAutomatedClaimPayload?
         .unmarshal(new JacksonDataFormat(MasAutomatedClaimPayload.class))

--- a/service/provider/src/main/java/gov/va/vro/service/provider/camel/PrimaryRoutes.java
+++ b/service/provider/src/main/java/gov/va/vro/service/provider/camel/PrimaryRoutes.java
@@ -92,7 +92,7 @@ public class PrimaryRoutes extends RouteBuilder {
   }
 
   private String pdfRoute(String queueName) {
-    String uri="direct:rabbitmq-"+queueName;
+    String uri = "direct:rabbitmq-" + queueName;
     RabbitMqCamelUtils.addToRabbitmqRoute(this, uri, PDF_EXCHANGE, queueName);
     return uri;
   }

--- a/service/provider/src/main/java/gov/va/vro/service/provider/camel/PrimaryRoutes.java
+++ b/service/provider/src/main/java/gov/va/vro/service/provider/camel/PrimaryRoutes.java
@@ -92,6 +92,8 @@ public class PrimaryRoutes extends RouteBuilder {
   }
 
   private String pdfRoute(String queueName) {
-    return String.format("rabbitmq:%s?routingKey=%s&queue=%s", PDF_EXCHANGE, queueName, queueName);
+    String uri="direct:rabbitmq-"+queueName;
+    RabbitMqCamelUtils.addToRabbitmqRoute(this, uri, PDF_EXCHANGE, queueName);
+    return uri;
   }
 }

--- a/shared/lib-camel-connector/src/main/java/gov/va/vro/camel/CamelEntry.java
+++ b/shared/lib-camel-connector/src/main/java/gov/va/vro/camel/CamelEntry.java
@@ -32,7 +32,7 @@ public class CamelEntry {
    */
   public <T> T inOut(String exchangeName, String entryName, Object body, Class<T> responseClass) {
     return producerTemplate.requestBody(
-        toMessageQueueUri(exchangeName, entryName), body, responseClass);
+        toMqProducerUri(exchangeName, entryName), body, responseClass);
   }
 
   /**
@@ -42,7 +42,7 @@ public class CamelEntry {
    * @param body The message payload to send
    */
   public void inOnly(String exchangeName, String entryName, Object body) {
-    producerTemplate.sendBody(toMessageQueueUri(exchangeName, entryName), body);
+    producerTemplate.sendBody(toMqProducerUri(exchangeName, entryName), body);
   }
 
   /**
@@ -61,15 +61,15 @@ public class CamelEntry {
    * @param headers
    */
   public void inOnly(String exchangeName, String entryName, Object body, Map headers) {
-    producerTemplate.sendBodyAndHeaders(toMessageQueueUri(exchangeName, entryName), body, headers);
+    producerTemplate.sendBodyAndHeaders(toMqProducerUri(exchangeName, entryName), body, headers);
   }
 
   /** Same as {@link #inOnly} except don't wait for the workflow to finish (asynchronous). */
   public void asyncInOnly(String exchangeName, String entryName, Object body) {
-    producerTemplate.asyncSendBody(toMessageQueueUri(exchangeName, entryName), body);
+    producerTemplate.asyncSendBody(toMqProducerUri(exchangeName, entryName), body);
   }
 
-  public static String toMessageQueueUri(String exchangeName, String routingKey) {
+  public static String toMqProducerUri(String exchangeName, String routingKey) {
     return RabbitMqCamelUtils.rabbitmqProducerEndpoint(exchangeName, routingKey);
   }
 }

--- a/shared/lib-camel-connector/src/main/java/gov/va/vro/camel/MessageQueueConfiguration.java
+++ b/shared/lib-camel-connector/src/main/java/gov/va/vro/camel/MessageQueueConfiguration.java
@@ -14,7 +14,7 @@ public class MessageQueueConfiguration {
 
   @Bean
   ConnectionFactory rabbitmqConnectionFactory() {
-    log.info("ConnectionFactory: connecting to {}", messageQueueProps.getHost());
+    log.info("rabbitmq ConnectionFactory: connecting to {}", messageQueueProps.getHost());
     ConnectionFactory factory = new ConnectionFactory();
     factory.setHost(messageQueueProps.getHost());
     factory.setPort(messageQueueProps.getPort());

--- a/shared/lib-camel-connector/src/main/java/gov/va/vro/camel/RabbitMqCamelUtils.java
+++ b/shared/lib-camel-connector/src/main/java/gov/va/vro/camel/RabbitMqCamelUtils.java
@@ -49,8 +49,13 @@ public class RabbitMqCamelUtils {
       RouteBuilder builder, String fromUri, String exchangeName, String routingKey) {
     return addToRabbitmqRoute(builder, fromUri, exchangeName, routingKey, "");
   }
+
   public static RouteDefinition addToRabbitmqRoute(
-    RouteBuilder builder, String fromUri, String exchangeName, String routingKey, String rabbitmqParams) {
+      RouteBuilder builder,
+      String fromUri,
+      String exchangeName,
+      String routingKey,
+      String rabbitmqParams) {
     return builder
         .from(fromUri)
         // Remove the CamelRabbitmqExchangeName and CamelRabbitmqRoutingKey so it
@@ -59,6 +64,6 @@ public class RabbitMqCamelUtils {
         // > if the source queue has a routing key set in the headers, it will pass down to
         // > the destination and not be overriden with the URI query parameters.
         .removeHeaders("CamelRabbitmq*")
-        .to(rabbitmqProducerEndpoint(exchangeName, routingKey)+rabbitmqParams);
+        .to(rabbitmqProducerEndpoint(exchangeName, routingKey) + rabbitmqParams);
   }
 }

--- a/shared/lib-camel-connector/src/main/java/gov/va/vro/camel/RabbitMqCamelUtils.java
+++ b/shared/lib-camel-connector/src/main/java/gov/va/vro/camel/RabbitMqCamelUtils.java
@@ -42,13 +42,23 @@ public class RabbitMqCamelUtils {
   public static RouteDefinition fromRabbitmq(RouteBuilder builder, String rabbitMqUri) {
     if (!rabbitMqUri.startsWith("rabbitmq:"))
       throw new IllegalArgumentException("Endpoint URI must be for RabbitMQ: " + rabbitMqUri);
+    return builder.from(rabbitMqUri);
+  }
+
+  public static RouteDefinition addToRabbitmqRoute(
+      RouteBuilder builder, String fromUri, String exchangeName, String routingKey) {
+    return addToRabbitmqRoute(builder, fromUri, exchangeName, routingKey, "");
+  }
+  public static RouteDefinition addToRabbitmqRoute(
+    RouteBuilder builder, String fromUri, String exchangeName, String routingKey, String rabbitmqParams) {
     return builder
-        .from(rabbitMqUri)
-        // Good practice to remove the CamelRabbitmqExchangeName and CamelRabbitmqRoutingKey so it
+        .from(fromUri)
+        // Remove the CamelRabbitmqExchangeName and CamelRabbitmqRoutingKey so it
         // doesn't interfere with subsequent sending to rabbitmq endpoints
         // https://camel.apache.org/components/3.19.x/rabbitmq-component.html#_troubleshooting_headers:
         // > if the source queue has a routing key set in the headers, it will pass down to
         // > the destination and not be overriden with the URI query parameters.
-        .removeHeaders("CamelRabbitmq*");
+        .removeHeaders("CamelRabbitmq*")
+        .to(rabbitmqProducerEndpoint(exchangeName, routingKey)+rabbitmqParams);
   }
 }


### PR DESCRIPTION
<!-- Ensure the PR title reflects the feature or bug name -->

## What was the problem?
<!-- brief description of how things worked before this PR -->

There's a latent Camel-rabbitmq bug addressed in #1252, but that solution prevents responses from being returned correctly b/c the `CamelCorrelationId` header was also removed.

## How does this fix it?
<!-- description of how things will work after this PR -->

Do not `removeHeaders("CamelRabbitmq*")` in `from("rabbitmq:...)` calls.
Use `RabbitMqCamelUtils.addToRabbitmqRoute()` when sending to a rabbitmq endpoint.
This utility method creates a new route that `removeHeaders("CamelRabbitmq*")` before `to("rabbitmq:...)`.

