### PR TITLE
Gradle: remove org.springdoc as a default dependency

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -5,6 +5,7 @@ plugins {
 dependencies {
   implementation project(':shared:domain')
 
+  implementation "org.springdoc:springdoc-openapi-webmvc-core"
   implementation 'io.micrometer:micrometer-core'
   implementation 'gov.va.starter:exceptions'
 }

--- a/buildSrc/src/main/groovy/local.std.java.application-conventions.gradle
+++ b/buildSrc/src/main/groovy/local.std.java.application-conventions.gradle
@@ -37,6 +37,12 @@ plugins {
 }
 
 dependencies {
+    implementation "org.zalando:problem-spring-web"
+    implementation "org.springdoc:springdoc-openapi-ui"
+    implementation "org.springdoc:springdoc-openapi-webmvc-core"
+    //implementation "org.springdoc:springdoc-openapi-security"
+    implementation "org.springdoc:springdoc-openapi-data-rest"
+
     testImplementation 'org.mock-server:mockserver-netty'
     // open tracing testing/mock support
     testImplementation 'io.opentracing:opentracing-mock'

--- a/buildSrc/src/main/groovy/starter.java.deps-build-conventions.gradle
+++ b/buildSrc/src/main/groovy/starter.java.deps-build-conventions.gradle
@@ -8,13 +8,6 @@ dependencies {
 
     implementation 'javax.validation:validation-api'
 
-    // aren't needed for all subprojects:
-    // implementation "org.zalando:problem-spring-web"
-    // implementation "org.springdoc:springdoc-openapi-ui"
-    // implementation "org.springdoc:springdoc-openapi-webmvc-core"
-    // //implementation "org.springdoc:springdoc-openapi-security"
-    // implementation "org.springdoc:springdoc-openapi-data-rest"
-
     implementation 'org.mapstruct:mapstruct'
 
     compileOnly 'org.projectlombok:lombok'

--- a/buildSrc/src/main/groovy/starter.java.deps-build-conventions.gradle
+++ b/buildSrc/src/main/groovy/starter.java.deps-build-conventions.gradle
@@ -3,16 +3,18 @@
  * Includes proper dependencies for lombok and mapstruct annotation processing.
  */
 
-// starter.java.build-javatarget-conventions
-
 dependencies {
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
 
-    implementation "org.zalando:problem-spring-web"
-    implementation "org.springdoc:springdoc-openapi-ui"
-    implementation "org.springdoc:springdoc-openapi-webmvc-core"
-    //implementation "org.springdoc:springdoc-openapi-security"
-    implementation "org.springdoc:springdoc-openapi-data-rest"
+    implementation 'javax.validation:validation-api'
+
+    // aren't needed for all subprojects:
+    // implementation "org.zalando:problem-spring-web"
+    // implementation "org.springdoc:springdoc-openapi-ui"
+    // implementation "org.springdoc:springdoc-openapi-webmvc-core"
+    // //implementation "org.springdoc:springdoc-openapi-security"
+    // implementation "org.springdoc:springdoc-openapi-data-rest"
+
     implementation 'org.mapstruct:mapstruct'
 
     compileOnly 'org.projectlombok:lombok'

--- a/console/src/main/groovy/gov/va/vro/consolegroovy/ConsoleGroovyApplication.groovy
+++ b/console/src/main/groovy/gov/va/vro/consolegroovy/ConsoleGroovyApplication.groovy
@@ -1,13 +1,10 @@
 package gov.va.vro.consolegroovy
 
-import org.springdoc.hateoas.SpringDocHateoasConfiguration
 import org.springframework.boot.SpringApplication
 import org.springframework.boot.autoconfigure.SpringBootApplication
 
 @SpringBootApplication(
-scanBasePackages = ["gov.va.vro.consolegroovy", "gov.va.vro.camel"],
-// Exclude to avoid error "org.springdoc.hateoas.SpringDocHateoasConfiguration required a bean ..."
-exclude = [SpringDocHateoasConfiguration.class]
+scanBasePackages = ["gov.va.vro.consolegroovy", "gov.va.vro.camel"]
 )
 class ConsoleGroovyApplication {
   static void main(String[] args) {

--- a/controller/build.gradle
+++ b/controller/build.gradle
@@ -9,7 +9,6 @@ dependencies {
   implementation project(':service:provider')
   implementation project(':service:spi')
 
-  implementation "org.zalando:problem-spring-web"
   implementation "org.springdoc:springdoc-openapi-webmvc-core"
 
   implementation "gov.va.starter:exceptions"

--- a/controller/build.gradle
+++ b/controller/build.gradle
@@ -9,6 +9,9 @@ dependencies {
   implementation project(':service:provider')
   implementation project(':service:spi')
 
+  implementation "org.zalando:problem-spring-web"
+  implementation "org.springdoc:springdoc-openapi-webmvc-core"
+
   implementation "gov.va.starter:exceptions"
 
   // https://mvnrepository.com/artifact/javax.servlet/javax.servlet-api

--- a/domain-xample/api-controller/build.gradle
+++ b/domain-xample/api-controller/build.gradle
@@ -14,4 +14,7 @@ dependencies {
   implementation project(':domain-xample:shared')
   // api project(':shared:lib-camel-connector')
   implementation project(':shared:lib-camel-connector')
+
+  implementation "org.zalando:problem-spring-web"
+  implementation "org.springdoc:springdoc-openapi-webmvc-core"
 }

--- a/domain-xample/api-controller/build.gradle
+++ b/domain-xample/api-controller/build.gradle
@@ -15,6 +15,5 @@ dependencies {
   // api project(':shared:lib-camel-connector')
   implementation project(':shared:lib-camel-connector')
 
-  implementation "org.zalando:problem-spring-web"
   implementation "org.springdoc:springdoc-openapi-webmvc-core"
 }

--- a/domain-xample/workflows-xample/build.gradle
+++ b/domain-xample/workflows-xample/build.gradle
@@ -2,6 +2,8 @@
 plugins {
   id 'local.java.container-spring-conventions'
   id 'starter.std.java.library-spring-conventions'
+//    id 'java'
+//    id 'org.springframework.boot'
 }
 
 dependencies {

--- a/domain-xample/workflows-xample/build.gradle
+++ b/domain-xample/workflows-xample/build.gradle
@@ -2,8 +2,8 @@
 plugins {
   id 'local.java.container-spring-conventions'
   id 'starter.std.java.library-spring-conventions'
-//    id 'java'
-//    id 'org.springframework.boot'
+  //    id 'java'
+  //    id 'org.springframework.boot'
 }
 
 dependencies {

--- a/domain-xample/workflows-xample/build.gradle
+++ b/domain-xample/workflows-xample/build.gradle
@@ -2,8 +2,6 @@
 plugins {
   id 'local.java.container-spring-conventions'
   id 'starter.std.java.library-spring-conventions'
-  //    id 'java'
-  //    id 'org.springframework.boot'
 }
 
 dependencies {

--- a/domain-xample/workflows-xample/src/main/java/gov/va/vro/routes/xample/XampleWorkflowsApplication.java
+++ b/domain-xample/workflows-xample/src/main/java/gov/va/vro/routes/xample/XampleWorkflowsApplication.java
@@ -6,10 +6,7 @@ import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
-@SpringBootApplication(
-    scanBasePackages = {"gov.va.vro.routes.xample", "gov.va.vro.camel"}
-    // Add DataSourceAutoConfiguration.class if no Spring DataSources are set up.
-    )
+@SpringBootApplication(scanBasePackages = {"gov.va.vro.routes.xample", "gov.va.vro.camel"})
 // Needed to interface with the DB
 @EnableJpaRepositories("gov.va.vro.persistence.repository")
 @EntityScan("gov.va.vro.persistence.model")

--- a/domain-xample/workflows-xample/src/main/java/gov/va/vro/routes/xample/XampleWorkflowsApplication.java
+++ b/domain-xample/workflows-xample/src/main/java/gov/va/vro/routes/xample/XampleWorkflowsApplication.java
@@ -8,11 +8,8 @@ import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
 @SpringBootApplication(
     scanBasePackages = {"gov.va.vro.routes.xample", "gov.va.vro.camel"}
-    // Exclude to avoid error "org.springdoc.hateoas.SpringDocHateoasConfiguration required a bean
-    // ..."
     // Add DataSourceAutoConfiguration.class if no Spring DataSources are set up.
-    // exclude = {SpringDocHateoasConfiguration.class}
-)
+    )
 // Needed to interface with the DB
 @EnableJpaRepositories("gov.va.vro.persistence.repository")
 @EntityScan("gov.va.vro.persistence.model")

--- a/domain-xample/workflows-xample/src/main/java/gov/va/vro/routes/xample/XampleWorkflowsApplication.java
+++ b/domain-xample/workflows-xample/src/main/java/gov/va/vro/routes/xample/XampleWorkflowsApplication.java
@@ -1,6 +1,5 @@
 package gov.va.vro.routes.xample;
 
-import org.springdoc.hateoas.SpringDocHateoasConfiguration;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
@@ -8,11 +7,12 @@ import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
 @SpringBootApplication(
-    scanBasePackages = {"gov.va.vro.routes.xample", "gov.va.vro.camel"},
+    scanBasePackages = {"gov.va.vro.routes.xample", "gov.va.vro.camel"}
     // Exclude to avoid error "org.springdoc.hateoas.SpringDocHateoasConfiguration required a bean
     // ..."
     // Add DataSourceAutoConfiguration.class if no Spring DataSources are set up.
-    exclude = {SpringDocHateoasConfiguration.class})
+    // exclude = {SpringDocHateoasConfiguration.class}
+)
 // Needed to interface with the DB
 @EnableJpaRepositories("gov.va.vro.persistence.repository")
 @EntityScan("gov.va.vro.persistence.model")

--- a/mocks/mock-bip-ce-api/build.gradle
+++ b/mocks/mock-bip-ce-api/build.gradle
@@ -24,7 +24,6 @@ dependencies {
   implementation "com.fasterxml.jackson.core:jackson-core:${jackson_version}"
   implementation 'org.springframework.boot:spring-boot-starter-web'
   implementation 'org.springframework.boot:spring-boot-starter-actuator'
-  implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
   implementation 'org.springframework.boot:spring-boot-starter-security'
   implementation 'org.springframework:spring-web:5.3.23'
 

--- a/mocks/mock-bip-ce-api/build.gradle
+++ b/mocks/mock-bip-ce-api/build.gradle
@@ -28,6 +28,8 @@ dependencies {
   implementation 'org.springframework.boot:spring-boot-starter-security'
   implementation 'org.springframework:spring-web:5.3.23'
 
+  implementation "org.springdoc:springdoc-openapi-webmvc-core"
+
   implementation 'org.bouncycastle:bcprov-jdk15on:1.70'
   implementation 'org.apache.commons:commons-lang3:3.12.0'
   implementation "io.jsonwebtoken:jjwt:${io_jsonwebtoken_version}"

--- a/mocks/mock-bip-ce-api/src/main/java/gov/va/vro/mockbipce/Application.java
+++ b/mocks/mock-bip-ce-api/src/main/java/gov/va/vro/mockbipce/Application.java
@@ -7,7 +7,6 @@ import org.springframework.context.annotation.ComponentScan;
 
 @SpringBootApplication(
     exclude = {
-      org.springdoc.hateoas.SpringDocHateoasConfiguration.class,
       DataSourceAutoConfiguration.class
     })
 @ComponentScan(basePackages = {"gov.va.vro.mockbipce", "gov.va.vro.mockshared"})

--- a/mocks/mock-bip-ce-api/src/main/java/gov/va/vro/mockbipce/Application.java
+++ b/mocks/mock-bip-ce-api/src/main/java/gov/va/vro/mockbipce/Application.java
@@ -2,10 +2,9 @@ package gov.va.vro.mockbipce;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 import org.springframework.context.annotation.ComponentScan;
 
-@SpringBootApplication(exclude = {DataSourceAutoConfiguration.class})
+@SpringBootApplication
 @ComponentScan(basePackages = {"gov.va.vro.mockbipce", "gov.va.vro.mockshared"})
 public class Application {
   public static void main(String[] args) {

--- a/mocks/mock-bip-ce-api/src/main/java/gov/va/vro/mockbipce/Application.java
+++ b/mocks/mock-bip-ce-api/src/main/java/gov/va/vro/mockbipce/Application.java
@@ -5,10 +5,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 import org.springframework.context.annotation.ComponentScan;
 
-@SpringBootApplication(
-    exclude = {
-      DataSourceAutoConfiguration.class
-    })
+@SpringBootApplication(exclude = {DataSourceAutoConfiguration.class})
 @ComponentScan(basePackages = {"gov.va.vro.mockbipce", "gov.va.vro.mockshared"})
 public class Application {
   public static void main(String[] args) {

--- a/mocks/mock-bip-claims-api/build.gradle
+++ b/mocks/mock-bip-claims-api/build.gradle
@@ -26,7 +26,6 @@ dependencies {
 
   implementation 'org.springframework.boot:spring-boot-starter-web'
   implementation 'org.springframework.boot:spring-boot-starter-actuator'
-  implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
   implementation 'org.springframework.boot:spring-boot-starter-security'
   implementation 'org.springframework:spring-web:5.3.23'
 

--- a/mocks/mock-bip-claims-api/build.gradle
+++ b/mocks/mock-bip-claims-api/build.gradle
@@ -30,6 +30,8 @@ dependencies {
   implementation 'org.springframework.boot:spring-boot-starter-security'
   implementation 'org.springframework:spring-web:5.3.23'
 
+  implementation "org.springdoc:springdoc-openapi-webmvc-core"
+
   implementation 'org.bouncycastle:bcprov-jdk15on:1.70'
   implementation 'org.apache.commons:commons-lang3:3.12.0'
   implementation "io.jsonwebtoken:jjwt:${io_jsonwebtoken_version}"

--- a/mocks/mock-bip-claims-api/src/main/java/gov/va/vro/mockbipclaims/MockBipClaimsApplication.java
+++ b/mocks/mock-bip-claims-api/src/main/java/gov/va/vro/mockbipclaims/MockBipClaimsApplication.java
@@ -7,7 +7,6 @@ import org.springframework.context.annotation.ComponentScan;
 
 @SpringBootApplication(
     exclude = {
-      org.springdoc.hateoas.SpringDocHateoasConfiguration.class,
       DataSourceAutoConfiguration.class
     })
 @ComponentScan(basePackages = {"gov.va.vro.mockbipclaims", "gov.va.vro.mockshared"})

--- a/mocks/mock-bip-claims-api/src/main/java/gov/va/vro/mockbipclaims/MockBipClaimsApplication.java
+++ b/mocks/mock-bip-claims-api/src/main/java/gov/va/vro/mockbipclaims/MockBipClaimsApplication.java
@@ -2,10 +2,9 @@ package gov.va.vro.mockbipclaims;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 import org.springframework.context.annotation.ComponentScan;
 
-@SpringBootApplication(exclude = {DataSourceAutoConfiguration.class})
+@SpringBootApplication
 @ComponentScan(basePackages = {"gov.va.vro.mockbipclaims", "gov.va.vro.mockshared"})
 public class MockBipClaimsApplication {
 

--- a/mocks/mock-bip-claims-api/src/main/java/gov/va/vro/mockbipclaims/MockBipClaimsApplication.java
+++ b/mocks/mock-bip-claims-api/src/main/java/gov/va/vro/mockbipclaims/MockBipClaimsApplication.java
@@ -5,10 +5,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 import org.springframework.context.annotation.ComponentScan;
 
-@SpringBootApplication(
-    exclude = {
-      DataSourceAutoConfiguration.class
-    })
+@SpringBootApplication(exclude = {DataSourceAutoConfiguration.class})
 @ComponentScan(basePackages = {"gov.va.vro.mockbipclaims", "gov.va.vro.mockshared"})
 public class MockBipClaimsApplication {
 

--- a/mocks/mock-lighthouse-api/build.gradle
+++ b/mocks/mock-lighthouse-api/build.gradle
@@ -26,7 +26,6 @@ dependencies {
 
   implementation 'org.springframework.boot:spring-boot-starter-web'
   implementation 'org.springframework.boot:spring-boot-starter-actuator'
-  implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 
   implementation "org.springdoc:springdoc-openapi-webmvc-core"
 

--- a/mocks/mock-lighthouse-api/build.gradle
+++ b/mocks/mock-lighthouse-api/build.gradle
@@ -28,6 +28,8 @@ dependencies {
   implementation 'org.springframework.boot:spring-boot-starter-actuator'
   implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 
+  implementation "org.springdoc:springdoc-openapi-webmvc-core"
+
   implementation 'org.bouncycastle:bcprov-jdk15on:1.70'
   implementation 'org.projectlombok:lombok:1.18.26'
   implementation 'org.apache.commons:commons-lang3:3.12.0'

--- a/mocks/mock-lighthouse-api/src/main/java/gov/va/vro/mocklh/MockLhApplication.java
+++ b/mocks/mock-lighthouse-api/src/main/java/gov/va/vro/mocklh/MockLhApplication.java
@@ -6,10 +6,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 
-@SpringBootApplication(
-    exclude = {
-      DataSourceAutoConfiguration.class
-    })
+@SpringBootApplication(exclude = {DataSourceAutoConfiguration.class})
 @EnableConfigurationProperties({LhApiProperties.class})
 public class MockLhApplication {
 

--- a/mocks/mock-lighthouse-api/src/main/java/gov/va/vro/mocklh/MockLhApplication.java
+++ b/mocks/mock-lighthouse-api/src/main/java/gov/va/vro/mocklh/MockLhApplication.java
@@ -3,10 +3,9 @@ package gov.va.vro.mocklh;
 import gov.va.vro.mocklh.config.LhApiProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 
-@SpringBootApplication(exclude = {DataSourceAutoConfiguration.class})
+@SpringBootApplication
 @EnableConfigurationProperties({LhApiProperties.class})
 public class MockLhApplication {
 

--- a/mocks/mock-lighthouse-api/src/main/java/gov/va/vro/mocklh/MockLhApplication.java
+++ b/mocks/mock-lighthouse-api/src/main/java/gov/va/vro/mocklh/MockLhApplication.java
@@ -8,7 +8,6 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 
 @SpringBootApplication(
     exclude = {
-      org.springdoc.hateoas.SpringDocHateoasConfiguration.class,
       DataSourceAutoConfiguration.class
     })
 @EnableConfigurationProperties({LhApiProperties.class})

--- a/mocks/mock-mas-api/build.gradle
+++ b/mocks/mock-mas-api/build.gradle
@@ -26,7 +26,7 @@ dependencies {
 
   implementation 'org.springframework.boot:spring-boot-starter-web'
   implementation 'org.springframework.boot:spring-boot-starter-actuator'
-  implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+  // implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 
   implementation "org.springdoc:springdoc-openapi-webmvc-core"
 

--- a/mocks/mock-mas-api/build.gradle
+++ b/mocks/mock-mas-api/build.gradle
@@ -28,5 +28,7 @@ dependencies {
   implementation 'org.springframework.boot:spring-boot-starter-actuator'
   implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 
+  implementation "org.springdoc:springdoc-openapi-webmvc-core"
+
   testImplementation "org.junit.jupiter:junit-jupiter-api:${junit_jupiter_version}"
 }

--- a/mocks/mock-mas-api/src/main/java/gov/va/vro/mockmas/MockMasApplication.java
+++ b/mocks/mock-mas-api/src/main/java/gov/va/vro/mockmas/MockMasApplication.java
@@ -6,10 +6,7 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 
-@SpringBootApplication(
-    exclude = {
-      // DataSourceAutoConfiguration.class
-    })
+@SpringBootApplication
 @EnableConfigurationProperties({MasApiProperties.class, MasOauth2Properties.class})
 public class MockMasApplication {
 

--- a/mocks/mock-mas-api/src/main/java/gov/va/vro/mockmas/MockMasApplication.java
+++ b/mocks/mock-mas-api/src/main/java/gov/va/vro/mockmas/MockMasApplication.java
@@ -9,7 +9,6 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 
 @SpringBootApplication(
     exclude = {
-      org.springdoc.hateoas.SpringDocHateoasConfiguration.class,
       DataSourceAutoConfiguration.class
     })
 @EnableConfigurationProperties({MasApiProperties.class, MasOauth2Properties.class})

--- a/mocks/mock-mas-api/src/main/java/gov/va/vro/mockmas/MockMasApplication.java
+++ b/mocks/mock-mas-api/src/main/java/gov/va/vro/mockmas/MockMasApplication.java
@@ -4,12 +4,11 @@ import gov.va.vro.mockmas.config.MasApiProperties;
 import gov.va.vro.mockmas.config.MasOauth2Properties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 
 @SpringBootApplication(
     exclude = {
-      DataSourceAutoConfiguration.class
+      // DataSourceAutoConfiguration.class
     })
 @EnableConfigurationProperties({MasApiProperties.class, MasOauth2Properties.class})
 public class MockMasApplication {

--- a/service/db/build.gradle
+++ b/service/db/build.gradle
@@ -16,6 +16,7 @@ dependencies {
   // implementation "gov.va.starter:exceptions"
 
   implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+  implementation 'org.apache.commons:commons-lang3:3.12.0'
 
   testRuntimeOnly "com.h2database:h2:${h2_version}"
 }

--- a/service/db/src/test/java/gov/va/vro/service/db/TestConfig.java
+++ b/service/db/src/test/java/gov/va/vro/service/db/TestConfig.java
@@ -1,14 +1,10 @@
 package gov.va.vro.service.db;
 
-import org.springdoc.hateoas.SpringDocHateoasConfiguration;
-import org.springdoc.webmvc.ui.SwaggerConfig;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
-@SpringBootApplication(
-    scanBasePackages = {"gov.va.vro.service.db"},
-    exclude = {SpringDocHateoasConfiguration.class, SwaggerConfig.class})
+@SpringBootApplication(scanBasePackages = {"gov.va.vro.service.db"})
 @EnableJpaRepositories("gov.va.vro.persistence.repository")
 @EntityScan("gov.va.vro.persistence.model")
 public class TestConfig {}

--- a/service/provider/build.gradle
+++ b/service/provider/build.gradle
@@ -12,6 +12,7 @@ dependencies {
   // implementation "gov.va.starter:exceptions"
   // implementation 'gov.va.starter:test-data'
 
+  implementation 'org.apache.commons:commons-lang3:3.12.0'
   implementation 'com.google.guava:guava:31.1-jre'
   implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 

--- a/service/spi/build.gradle
+++ b/service/spi/build.gradle
@@ -4,5 +4,6 @@ plugins {
 
 dependencies {
   implementation project(':shared:domain')
+
   // implementation "gov.va.starter:exceptions"
 }

--- a/shared/domain/build.gradle
+++ b/shared/domain/build.gradle
@@ -1,3 +1,7 @@
 plugins {
   id 'starter.std.java.library-conventions'
 }
+
+dependencies {
+  implementation "org.springdoc:springdoc-openapi-webmvc-core"
+}

--- a/svc-lighthouse-api/src/main/java/gov/va/vro/abddataaccess/AbdApplication.java
+++ b/svc-lighthouse-api/src/main/java/gov/va/vro/abddataaccess/AbdApplication.java
@@ -1,10 +1,9 @@
 package gov.va.vro.abddataaccess;
 
-import org.springdoc.hateoas.SpringDocHateoasConfiguration;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
-@SpringBootApplication(exclude = {SpringDocHateoasConfiguration.class})
+@SpringBootApplication
 public class AbdApplication {
   public static void main(String[] args) {
     SpringApplication.run(AbdApplication.class, args);


### PR DESCRIPTION
<!-- Ensure the PR title reflects the feature or bug name -->

## What was the problem?
<!-- brief description of how things worked before this PR -->

New Java-based containers has to exclude `SpringDocHateoasConfiguration` b/c the Spring libraries are included be default.

## How does this fix it?
<!-- description of how things will work after this PR -->

Remove `org.springdoc:*` as a default dependency. It's only needed in the main app.

Similarly, remove `spring-boot-starter-data-jpa` from mocks so that `DataSourceAutoConfiguration` doesn't need to be excluded.

