### PR TITLE
MCP-2475 End to End Tests for LH only data

### DIFF
--- a/app/src/end2endTest/java/gov/va/vro/end2end/VroV2Tests.java
+++ b/app/src/end2endTest/java/gov/va/vro/end2end/VroV2Tests.java
@@ -505,6 +505,12 @@ public class VroV2Tests {
     testAutomatedClaimOrderExam("378");
   }
 
+  /** Test Case that ensures that exam order *is* called based on LH data with no MAS annotations */
+  @Test
+  void testLHDataOnlyClaimOrderExamIncreaseClaim() {
+    testAutomatedClaimOrderExam("401");
+  }
+
   @SneakyThrows
   private String resourceToString(String path) {
     var io = this.getClass().getClassLoader().getResourceAsStream(path);
@@ -565,6 +571,12 @@ public class VroV2Tests {
   @Test
   void testAutomatedClaimFullPositiveIncrease() {
     testAutomatedClaimFullPositive("375");
+  }
+
+  /** This is a full positive end-to-end test for an increase case with LightHouse data only. */
+  @Test
+  void testLHDataOnlyClaimFullPositiveIncrease() {
+    testAutomatedClaimFullPositive("401");
   }
 
   /**

--- a/app/src/end2endTest/java/gov/va/vro/end2end/VroV2Tests.java
+++ b/app/src/end2endTest/java/gov/va/vro/end2end/VroV2Tests.java
@@ -576,7 +576,7 @@ public class VroV2Tests {
   /** This is a full positive end-to-end test for an increase case with LightHouse data only. */
   @Test
   void testLHDataOnlyClaimFullPositiveIncrease() {
-    testAutomatedClaimFullPositive("401");
+    testAutomatedClaimFullPositive("400");
   }
 
   /**

--- a/app/src/end2endTest/resources/test-mas/claim-400-7101.json
+++ b/app/src/end2endTest/resources/test-mas/claim-400-7101.json
@@ -1,0 +1,29 @@
+{
+  "dob": "1970-02-19",
+  "firstName": "Janet",
+  "lastName": "NoMasOrderExam",
+  "gender": "female",
+  "collectionId": 400,
+  "veteranIdentifiers": {
+    "icn": "mock1012666073V986400",
+    "ssn": "111-11-1400",
+    "veteranFileId": "9999400",
+    "edipn": "1010234-400",
+    "participantId": "88888400"
+  },
+  "claimDetail": {
+    "benefitClaimId": "2010",
+    "claimSubmissionDateTime": "2023-02-27Z",
+    "claimSubmissionSource": "MAS",
+    "conditions": {
+      "name": "Hypertension",
+      "diagnosticCode": "7101",
+      "disabilityActionType": "INCREASE",
+      "disabilityClassificationCode": "3460",
+      "ratedDisabilityId": "7645"
+    }
+  },
+  "veteranFlashIds": [
+    "999375"
+  ]
+}

--- a/app/src/end2endTest/resources/test-mas/claim-401-7101.json
+++ b/app/src/end2endTest/resources/test-mas/claim-401-7101.json
@@ -1,0 +1,29 @@
+{
+  "dob": "1970-02-19",
+  "firstName": "Janet",
+  "lastName": "NoMasRRD",
+  "gender": "female",
+  "collectionId": 400,
+  "veteranIdentifiers": {
+    "icn": "mock1012666073V986400",
+    "ssn": "111-11-1400",
+    "veteranFileId": "9999400",
+    "edipn": "1010234-400",
+    "participantId": "88888400"
+  },
+  "claimDetail": {
+    "benefitClaimId": "2020",
+    "claimSubmissionDateTime": "2023-02-27Z",
+    "claimSubmissionSource": "MAS",
+    "conditions": {
+      "name": "Hypertension",
+      "diagnosticCode": "7101",
+      "disabilityActionType": "INCREASE",
+      "disabilityClassificationCode": "3460",
+      "ratedDisabilityId": "7645"
+    }
+  },
+  "veteranFlashIds": [
+    "999375"
+  ]
+}

--- a/app/src/end2endTest/resources/test-mas/claim-401-7101.json
+++ b/app/src/end2endTest/resources/test-mas/claim-401-7101.json
@@ -3,13 +3,13 @@
   "firstName": "Janet",
   "lastName": "NoMasRRD",
   "gender": "female",
-  "collectionId": 400,
+  "collectionId": 401,
   "veteranIdentifiers": {
-    "icn": "mock1012666073V986400",
+    "icn": "mock1012666073V986401",
     "ssn": "111-11-1400",
-    "veteranFileId": "9999400",
+    "veteranFileId": "9999401",
     "edipn": "1010234-400",
-    "participantId": "88888400"
+    "participantId": "88888401"
   },
   "claimDetail": {
     "benefitClaimId": "2020",

--- a/mocks/mock-bip-claims-api/src/main/resources/mock-claims.json
+++ b/mocks/mock-bip-claims-api/src/main/resources/mock-claims.json
@@ -140,6 +140,46 @@
     ]
   },
   {
+    "description": "for testing with no MAS annotations, only LH data. Exam Order path",
+    "claimDetail": {
+      "claimId": 2010,
+      "tempStationOfJurisdiction": "398",
+      "phase": "Gathering of Evidence"
+    },
+    "contentions": [
+      {
+        "contentionId": "2011",
+        "lastModified": "2023-01-25T17:32:28Z",
+        "classificationType": 1250,
+        "diagnosticTypeCode": "7101",
+        "specialIssueCodes": [
+          "RDR1",
+          "RRD"
+        ]
+      }
+    ]
+  },
+  {
+    "description": "for testing with no MAS annotations, only LH data. Full happy path",
+    "claimDetail": {
+      "claimId": 2020,
+      "tempStationOfJurisdiction": "398",
+      "phase": "Gathering of Evidence"
+    },
+    "contentions": [
+      {
+        "contentionId": "2021",
+        "lastModified": "2023-01-25T17:32:28Z",
+        "classificationType": 1250,
+        "diagnosticTypeCode": "7101",
+        "specialIssueCodes": [
+          "RDR1",
+          "RRD"
+        ]
+      }
+    ]
+  },
+  {
     "description": "identical to happy path except used for out of scope",
     "claimDetail": {
       "claimId": 3010,

--- a/mocks/mock-lighthouse-api/src/main/java/gov/va/vro/mocklh/config/AppConfig.java
+++ b/mocks/mock-lighthouse-api/src/main/java/gov/va/vro/mocklh/config/AppConfig.java
@@ -5,11 +5,8 @@ import gov.va.vro.mocklh.model.MockBundleStore;
 import gov.va.vro.mocklh.model.MockBundles;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.core.io.Resource;
-import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
 import org.springframework.web.client.RestTemplate;
 
-import java.io.File;
 import java.io.IOException;
 
 @Configuration
@@ -35,18 +32,26 @@ public class AppConfig {
   public MockBundleStore muckBundleStore() throws IOException {
     MockBundleStore store = new MockBundleStore();
 
-    String baseFolder = "mock-bundles";
+    MockBundles mb1 = MockBundles.of("mock-bundles/mock1012666073V986297");
+    store.put("mock1012666073V986297", mb1);
 
-    PathMatchingResourcePatternResolver r = new PathMatchingResourcePatternResolver();
-    Resource[] resources = r.getResources("/" + baseFolder + "/*");
-    for (Resource mockBundle : resources) {
-      File mockBundleDir = mockBundle.getFile();
-      if (mockBundleDir.isDirectory()) {
-        String bundlePath = baseFolder + "/" + mockBundleDir.getName();
-        MockBundles mb = MockBundles.of(bundlePath);
-        store.put(mockBundleDir.getName(), mb);
-      }
-    }
+    MockBundles mb2 = MockBundles.of("mock-bundles/mock1012666073V986377");
+    store.put("mock1012666073V986377", mb2);
+
+    MockBundles mb3 = MockBundles.of("mock-bundles/mock1012666073V986378");
+    store.put("mock1012666073V986378", mb3);
+
+    MockBundles mb4 = MockBundles.of("mock-bundles/mock1012666073V986380");
+    store.put("mock1012666073V986380", mb4);
+
+    MockBundles mb5 = MockBundles.of("mock-bundles/mock1012666073V986500");
+    store.put("mock1012666073V986500", mb5);
+
+    MockBundles mb6 = MockBundles.of("mock-bundles/mock1012666073V986400");
+    store.put("mock1012666073V986400", mb6);
+
+    MockBundles mb7 = MockBundles.of("mock-bundles/mock1012666073V986401");
+    store.put("mock1012666073V986401", mb7);
 
     return store;
   }

--- a/mocks/mock-lighthouse-api/src/main/java/gov/va/vro/mocklh/config/AppConfig.java
+++ b/mocks/mock-lighthouse-api/src/main/java/gov/va/vro/mocklh/config/AppConfig.java
@@ -5,8 +5,11 @@ import gov.va.vro.mocklh.model.MockBundleStore;
 import gov.va.vro.mocklh.model.MockBundles;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
 import org.springframework.web.client.RestTemplate;
 
+import java.io.File;
 import java.io.IOException;
 
 @Configuration
@@ -32,20 +35,18 @@ public class AppConfig {
   public MockBundleStore muckBundleStore() throws IOException {
     MockBundleStore store = new MockBundleStore();
 
-    MockBundles mb1 = MockBundles.of("mock-bundles/mock1012666073V986297");
-    store.put("mock1012666073V986297", mb1);
+    String baseFolder = "mock-bundles";
 
-    MockBundles mb2 = MockBundles.of("mock-bundles/mock1012666073V986377");
-    store.put("mock1012666073V986377", mb2);
-
-    MockBundles mb3 = MockBundles.of("mock-bundles/mock1012666073V986378");
-    store.put("mock1012666073V986378", mb3);
-
-    MockBundles mb4 = MockBundles.of("mock-bundles/mock1012666073V986380");
-    store.put("mock1012666073V986380", mb4);
-
-    MockBundles mb5 = MockBundles.of("mock-bundles/mock1012666073V986500");
-    store.put("mock1012666073V986500", mb5);
+    PathMatchingResourcePatternResolver r = new PathMatchingResourcePatternResolver();
+    Resource[] resources = r.getResources("/" + baseFolder + "/*");
+    for (Resource mockBundle : resources) {
+      File mockBundleDir = mockBundle.getFile();
+      if (mockBundleDir.isDirectory()) {
+        String bundlePath = baseFolder + "/" + mockBundleDir.getName();
+        MockBundles mb = MockBundles.of(bundlePath);
+        store.put(mockBundleDir.getName(), mb);
+      }
+    }
 
     return store;
   }

--- a/mocks/mock-lighthouse-api/src/main/resources/mock-bundles/mock1012666073V986400/Condition.json
+++ b/mocks/mock-lighthouse-api/src/main/resources/mock-bundles/mock1012666073V986400/Condition.json
@@ -1,0 +1,79 @@
+{
+  "resourceType": "Bundle",
+  "type": "searchset",
+  "total": 1,
+  "link": [
+    {
+      "relation": "first",
+      "url": "https://sandbox-api.va.gov/services/fhir/v0/r4/Condition?patient=1012666073V986400&_count=100&page=1"
+    },
+    {
+      "relation": "self",
+      "url": "https://sandbox-api.va.gov/services/fhir/v0/r4/Condition?patient=1012666073V986400&_count=100&page=1"
+    },
+    {
+      "relation": "last",
+      "url": "https://sandbox-api.va.gov/services/fhir/v0/r4/Condition?patient=1012666073V986400&_count=100&page=1"
+    }
+  ],
+  "entry": [
+    {
+      "fullUrl": "https://sandbox-api.va.gov/services/fhir/v0/r4/Condition/condition2",
+      "resource": {
+        "resourceType": "Condition",
+        "id": "condition1",
+        "meta": {
+          "lastUpdated": "2022-07-05T00:00:00Z"
+        },
+        "clinicalStatus": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/condition-clinical",
+              "code": "active",
+              "display": "Active"
+            }
+          ],
+          "text": "Active"
+        },
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/condition-category",
+                "code": "encounter-diagnosis",
+                "display": "Encounter Diagnosis"
+              }
+            ],
+            "text": "Encounter Diagnosis"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://hl7.org/fhir/sid/icd-9-cm",
+              "code": "401.9",
+              "display": "UNSPECIFIED ESSENTIAL HYPERTENSION"
+            }
+          ],
+          "text": "Essential Hypertension"
+        },
+        "subject": {
+          "reference": "https://sandbox-api.va.gov/services/fhir/v0/r4/Patient/1012666073V986400",
+          "display": "SKYSCRAPER,DAVID"
+        },
+        "encounter": {
+          "reference": "https://sandbox-api.va.gov/services/fhir/v0/r4/Encounter/encounter1"
+        },
+        "onsetDateTime": "2019-11-07T12:45:58Z",
+        "recordedDate": "2019-11-07",
+        "asserter": {
+          "reference": "https://sandbox-api.va.gov/services/fhir/v0/r4/Practitioner/practitioner1",
+          "display": "PRACTITIONER, MIKE T"
+        }
+      },
+      "search": {
+        "mode": "match"
+      }
+    }
+  ]
+}

--- a/mocks/mock-lighthouse-api/src/main/resources/mock-bundles/mock1012666073V986400/MedicationRequest.json
+++ b/mocks/mock-lighthouse-api/src/main/resources/mock-bundles/mock1012666073V986400/MedicationRequest.json
@@ -1,0 +1,20 @@
+{
+  "resourceType": "Bundle",
+  "type": "searchset",
+  "total": 0,
+  "link": [
+    {
+      "relation": "first",
+      "url": "https://sandbox-api.va.gov/services/fhir/v0/r4/MedicationRequest?patient=1012666073V986400&page=1&_count=100"
+    },
+    {
+      "relation": "self",
+      "url": "https://sandbox-api.va.gov/services/fhir/v0/r4/MedicationRequest?patient=1012666073V986400&page=1&_count=100"
+    },
+    {
+      "relation": "last",
+      "url": "https://sandbox-api.va.gov/services/fhir/v0/r4/MedicationRequest?patient=1012666073V986400&page=1&_count=100"
+    }
+  ],
+  "entry": []
+}

--- a/mocks/mock-lighthouse-api/src/main/resources/mock-bundles/mock1012666073V986400/Observation.json
+++ b/mocks/mock-lighthouse-api/src/main/resources/mock-bundles/mock1012666073V986400/Observation.json
@@ -1,0 +1,111 @@
+{
+  "resourceType": "Bundle",
+  "type": "searchset",
+  "total": 8,
+  "link": [
+    {
+      "relation": "first",
+      "url": "https://sandbox-api.va.gov/services/fhir/v0/r4/Observation?code=85354-9&patient=1012666073V986400&_count=100&page=1"
+    },
+    {
+      "relation": "self",
+      "url": "https://sandbox-api.va.gov/services/fhir/v0/r4/Observation?code=85354-9&patient=1012666073V986400&_count=100&page=1"
+    },
+    {
+      "relation": "last",
+      "url": "https://sandbox-api.va.gov/services/fhir/v0/r4/Observation?code=85354-9&patient=1012666073V986400&_count=100&page=1"
+    }
+  ],
+  "entry": [
+    {
+      "fullUrl": "https://sandbox-api.va.gov/services/fhir/v0/r4/Observation/I2-XT5YV4HFMF5JSBV2O6SYKK2J4Y6CHOAHYXGRUJAX3TL2BR6NBSOQ0000",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "I2-XT5YV4HFMF5JSBV2O6SYKK2J4Y6CHOAHYXGRUJAX3TL2BR6NBSOQ0000",
+        "meta": {
+          "lastUpdated": "2022-07-20T15:08:09Z"
+        },
+        "status": "final",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "vital-signs",
+                "display": "Vital Signs"
+              }
+            ],
+            "text": "Vital Signs"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "85354-9",
+              "display": "Blood pressure systolic and diastolic"
+            }
+          ],
+          "text": "Blood pressure systolic and diastolic"
+        },
+        "subject": {
+          "reference": "https://sandbox-api.va.gov/services/fhir/v0/r4/Patient/1012666073V986400",
+          "display": "Mr. Jesse Gray"
+        },
+        "effectiveDateTime": "2022-06-20T15:08:09Z",
+        "issued": "2022-06-20T15:08:09Z",
+        "performer": [
+          {
+            "reference": "https://sandbox-api.va.gov/services/fhir/v0/r4/Organization/I2-IW3YK3BHOKBUACF6FQKT3V7P2T6BY6GA2JUITPGQ6WYPSYYDPC3Q0000",
+            "display": "WASHINGTON VA MEDICAL CENTER"
+          },
+          {
+            "reference": "https://sandbox-api.va.gov/services/fhir/v0/r4/Practitioner/I2-QKF4GEFVEPYZLMVPM3O6A74SWWG73P5V2VLMOWCNQJJSC6I7AFJQ0000",
+            "display": "DR. JOHN248 SMITH811 MD"
+          }
+        ],
+        "component": [
+          {
+            "code": {
+              "coding": [
+                {
+                  "system": "http://loinc.org",
+                  "code": "8480-6",
+                  "display": "Systolic blood pressure"
+                }
+              ],
+              "text": "Systolic blood pressure"
+            },
+            "valueQuantity": {
+              "value": 167.0,
+              "unit": "mm[Hg]",
+              "system": "http://unitsofmeasure.org",
+              "code": "mm[Hg]"
+            }
+          },
+          {
+            "code": {
+              "coding": [
+                {
+                  "system": "http://loinc.org",
+                  "code": "8462-4",
+                  "display": "Diastolic blood pressure"
+                }
+              ],
+              "text": "Diastolic blood pressure"
+            },
+            "valueQuantity": {
+              "value": 93.0,
+              "unit": "mm[Hg]",
+              "system": "http://unitsofmeasure.org",
+              "code": "mm[Hg]"
+            }
+          }
+        ]
+      },
+      "search": {
+        "mode": "match"
+      }
+    }
+  ]
+}

--- a/mocks/mock-lighthouse-api/src/main/resources/mock-bundles/mock1012666073V986400/Observation.json
+++ b/mocks/mock-lighthouse-api/src/main/resources/mock-bundles/mock1012666073V986400/Observation.json
@@ -23,7 +23,7 @@
         "resourceType": "Observation",
         "id": "I2-XT5YV4HFMF5JSBV2O6SYKK2J4Y6CHOAHYXGRUJAX3TL2BR6NBSOQ0000",
         "meta": {
-          "lastUpdated": "2022-07-20T15:08:09Z"
+          "lastUpdated": "2023-03-01T15:08:09Z"
         },
         "status": "final",
         "category": [
@@ -52,8 +52,8 @@
           "reference": "https://sandbox-api.va.gov/services/fhir/v0/r4/Patient/1012666073V986400",
           "display": "Mr. Jesse Gray"
         },
-        "effectiveDateTime": "2022-06-20T15:08:09Z",
-        "issued": "2022-06-20T15:08:09Z",
+        "effectiveDateTime": "2023-03-01T15:08:09Z",
+        "issued": "2023-03-01T15:08:09Z",
         "performer": [
           {
             "reference": "https://sandbox-api.va.gov/services/fhir/v0/r4/Organization/I2-IW3YK3BHOKBUACF6FQKT3V7P2T6BY6GA2JUITPGQ6WYPSYYDPC3Q0000",
@@ -142,8 +142,8 @@
           "reference": "https://sandbox-api.va.gov/services/fhir/v0/r4/Patient/mock1012666073V986297",
           "display": "Mr. Jesse Gray"
         },
-        "effectiveDateTime": "2021-06-20T15:08:09Z",
-        "issued": "2021-06-20T15:08:09Z",
+        "effectiveDateTime": "2022-08-20T15:08:09Z",
+        "issued": "2022-08-20T15:08:09Z",
         "performer": [
           {
             "reference": "https://sandbox-api.va.gov/services/fhir/v0/r4/Organization/I2-IW3YK3BHOKBUACF6FQKT3V7P2T6BY6GA2JUITPGQ6WYPSYYDPC3Q0000",
@@ -232,8 +232,8 @@
           "reference": "https://sandbox-api.va.gov/services/fhir/v0/r4/Patient/mock1012666073V986297",
           "display": "Mr. Jesse Gray"
         },
-        "effectiveDateTime": "2021-05-11T15:08:09Z",
-        "issued": "2021-05-11T15:08:09Z",
+        "effectiveDateTime": "2023-01-10T15:08:09Z",
+        "issued": "2023-01-10T15:08:09Z",
         "performer": [
           {
             "reference": "https://sandbox-api.va.gov/services/fhir/v0/r4/Organization/I2-JD5EJVFSSEP6A6ZIEI55KCKEHLCZZPK44NSDYPMW2PGFV4A3D6FQ0000",

--- a/mocks/mock-lighthouse-api/src/main/resources/mock-bundles/mock1012666073V986400/Observation.json
+++ b/mocks/mock-lighthouse-api/src/main/resources/mock-bundles/mock1012666073V986400/Observation.json
@@ -106,6 +106,186 @@
       "search": {
         "mode": "match"
       }
+    },
+    {
+      "fullUrl": "https://sandbox-api.va.gov/services/fhir/v0/r4/Observation/I2-XT5YV4HFMF5JSBV2O6SYKK2J43JWGTMUIXSLF44V6G2GCC7QEGWQ0000",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "I2-XT5YV4HFMF5JSBV2O6SYKK2J43JWGTMUIXSLF44V6G2GCC7QEGWQ0000",
+        "meta": {
+          "lastUpdated": "2022-08-20T15:08:09Z"
+        },
+        "status": "final",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "vital-signs",
+                "display": "Vital Signs"
+              }
+            ],
+            "text": "Vital Signs"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "85354-9",
+              "display": "Blood pressure systolic and diastolic"
+            }
+          ],
+          "text": "Blood pressure systolic and diastolic"
+        },
+        "subject": {
+          "reference": "https://sandbox-api.va.gov/services/fhir/v0/r4/Patient/mock1012666073V986297",
+          "display": "Mr. Jesse Gray"
+        },
+        "effectiveDateTime": "2021-06-20T15:08:09Z",
+        "issued": "2021-06-20T15:08:09Z",
+        "performer": [
+          {
+            "reference": "https://sandbox-api.va.gov/services/fhir/v0/r4/Organization/I2-IW3YK3BHOKBUACF6FQKT3V7P2T6BY6GA2JUITPGQ6WYPSYYDPC3Q0000",
+            "display": "WASHINGTON VA MEDICAL CENTER"
+          },
+          {
+            "reference": "https://sandbox-api.va.gov/services/fhir/v0/r4/Practitioner/I2-QKF4GEFVEPYZLMVPM3O6A74SWWG73P5V2VLMOWCNQJJSC6I7AFJQ0000",
+            "display": "DR. JOHN248 SMITH811 MD"
+          }
+        ],
+        "component": [
+          {
+            "code": {
+              "coding": [
+                {
+                  "system": "http://loinc.org",
+                  "code": "8480-6",
+                  "display": "Systolic blood pressure"
+                }
+              ],
+              "text": "Systolic blood pressure"
+            },
+            "valueQuantity": {
+              "value": 153.0,
+              "unit": "mm[Hg]",
+              "system": "http://unitsofmeasure.org",
+              "code": "mm[Hg]"
+            }
+          },
+          {
+            "code": {
+              "coding": [
+                {
+                  "system": "http://loinc.org",
+                  "code": "8462-4",
+                  "display": "Diastolic blood pressure"
+                }
+              ],
+              "text": "Diastolic blood pressure"
+            },
+            "valueQuantity": {
+              "value": 115.0,
+              "unit": "mm[Hg]",
+              "system": "http://unitsofmeasure.org",
+              "code": "mm[Hg]"
+            }
+          }
+        ]
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://sandbox-api.va.gov/services/fhir/v0/r4/Observation/I2-XT5YV4HFMF5JSBV2O6SYKK2J4ZGLXXLCHMCXQP2PA2X5O6EH7JRA0000",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "I2-XT5YV4HFMF5JSBV2O6SYKK2J4ZGLXXLCHMCXQP2PA2X5O6EH7JRA0000",
+        "meta": {
+          "lastUpdated": "2023-01-10T15:08:09Z"
+        },
+        "status": "final",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "vital-signs",
+                "display": "Vital Signs"
+              }
+            ],
+            "text": "Vital Signs"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "85354-9",
+              "display": "Blood pressure systolic and diastolic"
+            }
+          ],
+          "text": "Blood pressure systolic and diastolic"
+        },
+        "subject": {
+          "reference": "https://sandbox-api.va.gov/services/fhir/v0/r4/Patient/mock1012666073V986297",
+          "display": "Mr. Jesse Gray"
+        },
+        "effectiveDateTime": "2021-05-11T15:08:09Z",
+        "issued": "2021-05-11T15:08:09Z",
+        "performer": [
+          {
+            "reference": "https://sandbox-api.va.gov/services/fhir/v0/r4/Organization/I2-JD5EJVFSSEP6A6ZIEI55KCKEHLCZZPK44NSDYPMW2PGFV4A3D6FQ0000",
+            "display": "LYONS VA MEDICAL CENTER"
+          },
+          {
+            "reference": "https://sandbox-api.va.gov/services/fhir/v0/r4/Practitioner/I2-QKF4GEFVEPYZLMVPM3O6A74SWWG73P5V2VLMOWCNQJJSC6I7AFJQ0000",
+            "display": "DR. JOHN248 SMITH811 MD"
+          }
+        ],
+        "component": [
+          {
+            "code": {
+              "coding": [
+                {
+                  "system": "http://loinc.org",
+                  "code": "8480-6",
+                  "display": "Systolic blood pressure"
+                }
+              ],
+              "text": "Systolic blood pressure"
+            },
+            "valueQuantity": {
+              "value": 167.0,
+              "unit": "mm[Hg]",
+              "system": "http://unitsofmeasure.org",
+              "code": "mm[Hg]"
+            }
+          },
+          {
+            "code": {
+              "coding": [
+                {
+                  "system": "http://loinc.org",
+                  "code": "8462-4",
+                  "display": "Diastolic blood pressure"
+                }
+              ],
+              "text": "Diastolic blood pressure"
+            },
+            "valueQuantity": {
+              "value": 93.0,
+              "unit": "mm[Hg]",
+              "system": "http://unitsofmeasure.org",
+              "code": "mm[Hg]"
+            }
+          }
+        ]
+      },
+      "search": {
+        "mode": "match"
+      }
     }
   ]
 }

--- a/mocks/mock-lighthouse-api/src/main/resources/mock-bundles/mock1012666073V986401/Condition.json
+++ b/mocks/mock-lighthouse-api/src/main/resources/mock-bundles/mock1012666073V986401/Condition.json
@@ -1,0 +1,79 @@
+{
+  "resourceType": "Bundle",
+  "type": "searchset",
+  "total": 1,
+  "link": [
+    {
+      "relation": "first",
+      "url": "https://sandbox-api.va.gov/services/fhir/v0/r4/Condition?patient=1012666073V986401&_count=100&page=1"
+    },
+    {
+      "relation": "self",
+      "url": "https://sandbox-api.va.gov/services/fhir/v0/r4/Condition?patient=1012666073V986401&_count=100&page=1"
+    },
+    {
+      "relation": "last",
+      "url": "https://sandbox-api.va.gov/services/fhir/v0/r4/Condition?patient=1012666073V986401&_count=100&page=1"
+    }
+  ],
+  "entry": [
+    {
+      "fullUrl": "https://sandbox-api.va.gov/services/fhir/v0/r4/Condition/condition2",
+      "resource": {
+        "resourceType": "Condition",
+        "id": "condition1",
+        "meta": {
+          "lastUpdated": "2022-07-05T00:00:00Z"
+        },
+        "clinicalStatus": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/condition-clinical",
+              "code": "active",
+              "display": "Active"
+            }
+          ],
+          "text": "Active"
+        },
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/condition-category",
+                "code": "encounter-diagnosis",
+                "display": "Encounter Diagnosis"
+              }
+            ],
+            "text": "Encounter Diagnosis"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://hl7.org/fhir/sid/icd-9-cm",
+              "code": "401.9",
+              "display": "UNSPECIFIED ESSENTIAL HYPERTENSION"
+            }
+          ],
+          "text": "Essential Hypertension"
+        },
+        "subject": {
+          "reference": "https://sandbox-api.va.gov/services/fhir/v0/r4/Patient/1012666073V986401",
+          "display": "SKYSCRAPER,DAVID"
+        },
+        "encounter": {
+          "reference": "https://sandbox-api.va.gov/services/fhir/v0/r4/Encounter/encounter1"
+        },
+        "onsetDateTime": "2019-11-07T12:45:58Z",
+        "recordedDate": "2019-11-07",
+        "asserter": {
+          "reference": "https://sandbox-api.va.gov/services/fhir/v0/r4/Practitioner/practitioner1",
+          "display": "PRACTITIONER, MIKE T"
+        }
+      },
+      "search": {
+        "mode": "match"
+      }
+    }
+  ]
+}

--- a/mocks/mock-lighthouse-api/src/main/resources/mock-bundles/mock1012666073V986401/MedicationRequest.json
+++ b/mocks/mock-lighthouse-api/src/main/resources/mock-bundles/mock1012666073V986401/MedicationRequest.json
@@ -1,0 +1,20 @@
+{
+  "resourceType": "Bundle",
+  "type": "searchset",
+  "total": 0,
+  "link": [
+    {
+      "relation": "first",
+      "url": "https://sandbox-api.va.gov/services/fhir/v0/r4/MedicationRequest?patient=1012666073V986401&page=1&_count=100"
+    },
+    {
+      "relation": "self",
+      "url": "https://sandbox-api.va.gov/services/fhir/v0/r4/MedicationRequest?patient=1012666073V986401&page=1&_count=100"
+    },
+    {
+      "relation": "last",
+      "url": "https://sandbox-api.va.gov/services/fhir/v0/r4/MedicationRequest?patient=1012666073V986401&page=1&_count=100"
+    }
+  ],
+  "entry": []
+}

--- a/mocks/mock-lighthouse-api/src/main/resources/mock-bundles/mock1012666073V986401/Observation.json
+++ b/mocks/mock-lighthouse-api/src/main/resources/mock-bundles/mock1012666073V986401/Observation.json
@@ -1,0 +1,111 @@
+{
+  "resourceType": "Bundle",
+  "type": "searchset",
+  "total": 8,
+  "link": [
+    {
+      "relation": "first",
+      "url": "https://sandbox-api.va.gov/services/fhir/v0/r4/Observation?code=85354-9&patient=1012666073V986401&_count=100&page=1"
+    },
+    {
+      "relation": "self",
+      "url": "https://sandbox-api.va.gov/services/fhir/v0/r4/Observation?code=85354-9&patient=1012666073V986401&_count=100&page=1"
+    },
+    {
+      "relation": "last",
+      "url": "https://sandbox-api.va.gov/services/fhir/v0/r4/Observation?code=85354-9&patient=1012666073V986401&_count=100&page=1"
+    }
+  ],
+  "entry": [
+    {
+      "fullUrl": "https://sandbox-api.va.gov/services/fhir/v0/r4/Observation/I2-XT5YV4HFMF5JSBV2O6SYKK2J4Y6CHOAHYXGRUJAX3TL2BR6NBSOQ0000",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "I2-XT5YV4HFMF5JSBV2O6SYKK2J4Y6CHOAHYXGRUJAX3TL2BR6NBSOQ0000",
+        "meta": {
+          "lastUpdated": "2022-07-20T15:08:09Z"
+        },
+        "status": "final",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "vital-signs",
+                "display": "Vital Signs"
+              }
+            ],
+            "text": "Vital Signs"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "85354-9",
+              "display": "Blood pressure systolic and diastolic"
+            }
+          ],
+          "text": "Blood pressure systolic and diastolic"
+        },
+        "subject": {
+          "reference": "https://sandbox-api.va.gov/services/fhir/v0/r4/Patient/1012666073V986401",
+          "display": "Mr. Jesse Gray"
+        },
+        "effectiveDateTime": "2022-06-20T15:08:09Z",
+        "issued": "2022-06-20T15:08:09Z",
+        "performer": [
+          {
+            "reference": "https://sandbox-api.va.gov/services/fhir/v0/r4/Organization/I2-IW3YK3BHOKBUACF6FQKT3V7P2T6BY6GA2JUITPGQ6WYPSYYDPC3Q0000",
+            "display": "WASHINGTON VA MEDICAL CENTER"
+          },
+          {
+            "reference": "https://sandbox-api.va.gov/services/fhir/v0/r4/Practitioner/I2-QKF4GEFVEPYZLMVPM3O6A74SWWG73P5V2VLMOWCNQJJSC6I7AFJQ0000",
+            "display": "DR. JOHN248 SMITH811 MD"
+          }
+        ],
+        "component": [
+          {
+            "code": {
+              "coding": [
+                {
+                  "system": "http://loinc.org",
+                  "code": "8480-6",
+                  "display": "Systolic blood pressure"
+                }
+              ],
+              "text": "Systolic blood pressure"
+            },
+            "valueQuantity": {
+              "value": 167.0,
+              "unit": "mm[Hg]",
+              "system": "http://unitsofmeasure.org",
+              "code": "mm[Hg]"
+            }
+          },
+          {
+            "code": {
+              "coding": [
+                {
+                  "system": "http://loinc.org",
+                  "code": "8462-4",
+                  "display": "Diastolic blood pressure"
+                }
+              ],
+              "text": "Diastolic blood pressure"
+            },
+            "valueQuantity": {
+              "value": 93.0,
+              "unit": "mm[Hg]",
+              "system": "http://unitsofmeasure.org",
+              "code": "mm[Hg]"
+            }
+          }
+        ]
+      },
+      "search": {
+        "mode": "match"
+      }
+    }
+  ]
+}

--- a/mocks/mock-mas-api/src/main/java/gov/va/vro/mockmas/config/MockMasConfig.java
+++ b/mocks/mock-mas-api/src/main/java/gov/va/vro/mockmas/config/MockMasConfig.java
@@ -33,6 +33,12 @@ public class MockMasConfig {
   @Value("classpath:annotations/collection-380.json")
   private Resource collection380Resource;
 
+  @Value("classpath:annotations/collection-400.json")
+  private Resource collection400Resource;
+
+  @Value("classpath:annotations/collection-401.json")
+  private Resource collection401Resource;
+
   @Value("classpath:annotations/collection-500.json")
   private Resource collection500Resource;
 
@@ -72,6 +78,12 @@ public class MockMasConfig {
 
     List<MasCollectionAnnotation> collection380 = readFromResource(collection380Resource);
     store.put(380, collection380);
+
+    List<MasCollectionAnnotation> collection400 = readFromResource(collection400Resource);
+    store.put(400, collection400);
+
+    List<MasCollectionAnnotation> collection401 = readFromResource(collection401Resource);
+    store.put(401, collection401);
 
     List<MasCollectionAnnotation> collection500 = readFromResource(collection500Resource);
     store.put(500, collection500);

--- a/mocks/mock-mas-api/src/main/resources/annotations/collection-400.json
+++ b/mocks/mock-mas-api/src/main/resources/annotations/collection-400.json
@@ -1,0 +1,10 @@
+[
+  {
+    "collectionsId": 400,
+    "vtrnFileId": "9999400",
+    "creationDate": "2023-02-28T12:11:53.888Z",
+    "icn": "mock1012666073V986400",
+    "documents": [],
+    "documentsWithoutAnnotationsChecked": []
+  }
+]

--- a/mocks/mock-mas-api/src/main/resources/annotations/collection-401.json
+++ b/mocks/mock-mas-api/src/main/resources/annotations/collection-401.json
@@ -1,0 +1,10 @@
+[
+  {
+    "collectionsId": 400,
+    "vtrnFileId": "9999400",
+    "creationDate": "2023-02-28T12:11:53.888Z",
+    "icn": "mock1012666073V986400",
+    "documents": [],
+    "documentsWithoutAnnotationsChecked": []
+  }
+]

--- a/mocks/mock-mas-api/src/main/resources/annotations/collection-401.json
+++ b/mocks/mock-mas-api/src/main/resources/annotations/collection-401.json
@@ -1,9 +1,9 @@
 [
   {
-    "collectionsId": 400,
+    "collectionsId": 401,
     "vtrnFileId": "9999400",
     "creationDate": "2023-02-28T12:11:53.888Z",
-    "icn": "mock1012666073V986400",
+    "icn": "mock1012666073V986401",
     "documents": [],
     "documentsWithoutAnnotationsChecked": []
   }


### PR DESCRIPTION

## What was the problem?
No end to end coverage when mas has no annotations, and LH has patient data
Associated tickets or Slack threads:

- [MCP-2475](https://amida.atlassian.net/browse/MCP-2475)

## How does this fix it?[^1]
Two new claims, collections for those claims, and tests have been added

## How to test this PR
Run End to End tests (specifically the new added ones). 