### PR TITLE
MCP-2417 Moving Unit Tests

### DIFF
--- a/service/provider/src/test/java/BaseIntegrationTest.java
+++ b/service/provider/src/test/java/BaseIntegrationTest.java
@@ -1,0 +1,32 @@
+import gov.va.vro.persistence.repository.AuditEventRepository;
+import gov.va.vro.persistence.repository.ClaimRepository;
+import gov.va.vro.persistence.repository.ClaimSubmissionRepository;
+import gov.va.vro.persistence.repository.VeteranRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@ActiveProfiles("test")
+public abstract class BaseIntegrationTest {
+
+  @Autowired protected ClaimRepository claimRepository;
+
+  @Autowired protected ClaimSubmissionRepository claimSubmissionRepository;
+
+  @Autowired protected VeteranRepository veteranRepository;
+
+  @Autowired protected AuditEventRepository auditEventRepository;
+
+  /** Delete all from repositories. */
+  @BeforeEach
+  @AfterEach
+  public void delete() {
+    claimRepository.deleteAll();
+    // Claim repository will cascade delete from claimSubmission
+    veteranRepository.deleteAll();
+    auditEventRepository.deleteAll();
+  }
+}

--- a/service/provider/src/test/java/MasProcessingServiceTest.java
+++ b/service/provider/src/test/java/MasProcessingServiceTest.java
@@ -1,0 +1,124 @@
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import gov.va.vro.model.mas.MasAutomatedClaimPayload;
+import gov.va.vro.persistence.model.ClaimEntity;
+import gov.va.vro.persistence.model.ClaimSubmissionEntity;
+import gov.va.vro.persistence.repository.ClaimSubmissionRepository;
+import gov.va.vro.service.provider.mas.service.MasProcessingService;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+
+@SpringBootTest(classes = TestConfig.class, webEnvironment = SpringBootTest.WebEnvironment.NONE)
+@Transactional
+@ActiveProfiles("test")
+@EnableJpaAuditing
+public class MasProcessingServiceTest extends BaseIntegrationTest {
+
+    @Autowired MasProcessingService masProcessingService;
+
+    @Autowired ClaimSubmissionRepository claimSubmissionRepository;
+
+    @Test
+    void testClaimPersistence() {
+        var collectionId1 = 123;
+        var claimId1 = "123";
+        var diagnosticCode1 = "71";
+        var request1 =
+                MasTestData.getMasAutomatedClaimPayload(collectionId1, diagnosticCode1, claimId1);
+        masProcessingService.processIncomingClaim(request1);
+
+        var claimEntity1 = verifyClaimPersisted(request1);
+        var contentions = claimEntity1.getContentions();
+        Assertions.assertEquals(1, contentions.size());
+        var contention = contentions.get(0);
+        assertEquals(request1.getDiagnosticCode(), contention.getDiagnosticCode());
+        // same claim, different diagnostic code
+        var diagnosticCode2 = "17";
+        var request2 =
+                MasTestData.getMasAutomatedClaimPayload(collectionId1, diagnosticCode2, claimId1);
+        masProcessingService.processIncomingClaim(request2);
+        var claimEntity2 = verifyClaimPersisted(request2);
+        contentions = claimEntity2.getContentions();
+        ClaimEntity claim = claimRepository.findByVbmsId(claimId1).orElseThrow();
+        Assertions.assertEquals(2, contentions.size());
+
+        // new claim
+        var claimId2 = "321";
+        var request3 =
+                MasTestData.getMasAutomatedClaimPayload(collectionId1, diagnosticCode1, claimId2);
+        masProcessingService.processIncomingClaim(request3);
+        verifyClaimPersisted(request3);
+    }
+
+    @Test
+    public void testNotInScope() {
+        var collectionId1 = 123;
+        var claimId1 = "123";
+        var diagnosticCode1 = "71";
+        var request1 =
+                MasTestData.getMasAutomatedClaimPayload(collectionId1, diagnosticCode1, claimId1);
+        var response1 = masProcessingService.processIncomingClaim(request1);
+        // wrong diagnostic code
+        Assertions.assertEquals(
+                "Claim with [collection id = 123], [diagnostic code = 71], and [disability action type = INCREASE] is not in scope.",
+                response1);
+
+        var request2 = MasTestData.getMasAutomatedClaimPayload(collectionId1, "7101", claimId1);
+        request2.getClaimDetail().getConditions().setDisabilityActionType("OTHER");
+        var response2 = masProcessingService.processIncomingClaim(request2);
+        // wrong disability action
+        Assertions.assertEquals(
+                "Claim with [collection id = 123], [diagnostic code = 7101], and [disability action type = OTHER] is not in scope.",
+                response2);
+    }
+
+    @Test
+    public void testInScopeButNotPresumptive() {
+        var collectionId1 = 123;
+        var claimId1 = "123";
+        var diagnosticCode1 = "7101";
+        var request1 =
+                MasTestData.getMasAutomatedClaimPayload(collectionId1, diagnosticCode1, claimId1);
+        request1.getClaimDetail().getConditions().setDisabilityActionType("NEW");
+        var response = masProcessingService.processIncomingClaim(request1);
+        Assertions.assertEquals(
+                "Claim with [collection id = 123], [diagnostic code = 7101], [disability action type = NEW] and [flashIds = null] is not presumptive.",
+                response);
+    }
+
+    @Test
+    public void testInScopeAndPresumptiveButMissingAnchors() {
+        var collectionId = 123;
+        var claimId = "123";
+        var diagnosticCode = "7101";
+        var request = MasTestData.getMasAutomatedClaimPayload(collectionId, diagnosticCode, claimId);
+        request.getClaimDetail().getConditions().setDisabilityActionType("NEW");
+        request = request.toBuilder().veteranFlashIds(List.of("123", "266")).build();
+        var response = masProcessingService.processIncomingClaim(request);
+        Assertions.assertEquals(
+                "Claim with [collection id = 123] does not qualify for automated processing because it is missing anchors.",
+                response);
+    }
+
+    private ClaimEntity verifyClaimPersisted(MasAutomatedClaimPayload request) {
+        var claim = claimRepository.findByVbmsId(request.getBenefitClaimId()).orElseThrow();
+        var claimSubmissionList =
+                claimSubmissionRepository.findByReferenceIdAndIdType(
+                        String.valueOf(request.getCollectionId()), MasAutomatedClaimPayload.CLAIM_V2_ID_TYPE);
+        Assertions.assertTrue(claimSubmissionList.size() > 0);
+        for (ClaimSubmissionEntity submission : claimSubmissionList) {
+            Assertions.assertEquals(request.getCollectionId().toString(), submission.getReferenceId());
+        }
+
+        assertEquals(request.getVeteranIcn(), claim.getVeteran().getIcn());
+        return claim;
+    }
+}

--- a/service/provider/src/test/java/MasTestData.java
+++ b/service/provider/src/test/java/MasTestData.java
@@ -1,0 +1,96 @@
+import gov.va.vro.model.mas.ClaimCondition;
+import gov.va.vro.model.mas.ClaimDetail;
+import gov.va.vro.model.mas.MasAnnotation;
+import gov.va.vro.model.mas.MasAutomatedClaimPayload;
+import gov.va.vro.model.mas.MasDocument;
+import gov.va.vro.model.mas.VeteranIdentifiers;
+import gov.va.vro.model.mas.request.MasAutomatedClaimRequest;
+
+import java.util.Collections;
+import java.util.UUID;
+
+public class MasTestData {
+
+  public static MasAutomatedClaimPayload getMasAutomatedClaimPayload() {
+    return getMasAutomatedClaimPayload(123, "7101", "999");
+  }
+
+  public static MasAutomatedClaimRequest getMasAutomatedClaimRequest() {
+    return getMasAutomatedClaimRequest(123, "1233", "999");
+  }
+
+  /**
+   * Gets the automated claim payload.
+   *
+   * @param collectionId collection ID.
+   * @param diagnosticCode diagnostic code.
+   * @param claimId claim ID.
+   * @return Claim payload.
+   */
+  public static MasAutomatedClaimPayload getMasAutomatedClaimPayload(
+      int collectionId, String diagnosticCode, String claimId) {
+    VeteranIdentifiers veteranIdentifiers = getVeteranIdentifiers();
+    ClaimDetail claimDetail = getClaimDetail(diagnosticCode, claimId);
+
+    return MasAutomatedClaimPayload.builder()
+        .dateOfBirth("2002-12-12")
+        .collectionId(collectionId)
+        .firstName("Rick")
+        .lastName("Smith")
+        .veteranIdentifiers(veteranIdentifiers)
+        .claimDetail(claimDetail)
+        .correlationId(UUID.randomUUID().toString())
+        .build();
+  }
+
+  public static MasAutomatedClaimRequest getMasAutomatedClaimRequest(
+      int collectionId, String diagnosticCode, String benefitClaimId) {
+    VeteranIdentifiers veteranIdentifiers = getVeteranIdentifiers();
+    ClaimDetail claimDetail = getClaimDetail(diagnosticCode, benefitClaimId);
+
+    return MasAutomatedClaimRequest.builder()
+        .dateOfBirth("2002-12-12")
+        .collectionId(collectionId)
+        .firstName("Rick")
+        .lastName("Smith")
+        .veteranIdentifiers(veteranIdentifiers)
+        .claimDetail(claimDetail)
+        .build();
+  }
+
+  private static ClaimDetail getClaimDetail(String diagnosticCode, String claimId) {
+    ClaimCondition conditions = new ClaimCondition();
+    conditions.setDiagnosticCode(diagnosticCode);
+    conditions.setDisabilityActionType("INCREASE");
+    ClaimDetail claimDetail = new ClaimDetail();
+    claimDetail.setClaimSubmissionDateTime("2022-02-04T17:45:59Z");
+    claimDetail.setConditions(conditions);
+    claimDetail.setBenefitClaimId(claimId);
+    return claimDetail;
+  }
+
+  private static VeteranIdentifiers getVeteranIdentifiers() {
+    VeteranIdentifiers veteranIdentifiers = new VeteranIdentifiers();
+    veteranIdentifiers.setEdipn("X");
+    veteranIdentifiers.setParticipantId("X");
+    veteranIdentifiers.setIcn("X");
+    veteranIdentifiers.setSsn("X");
+    veteranIdentifiers.setVeteranFileId("X");
+    return veteranIdentifiers;
+  }
+
+  /**
+   * Creates hypertension document.
+   *
+   * @return the document.
+   */
+  public static MasDocument createHypertensionDocument() {
+    var document = new MasDocument();
+    document.setCondition("Hypertension");
+    var annotation = new MasAnnotation();
+    annotation.setAnnotType("Medication");
+    annotation.setAnnotVal("Placebo");
+    document.setAnnotations(Collections.singletonList(annotation));
+    return document;
+  }
+}

--- a/service/provider/src/test/java/TestConfig.java
+++ b/service/provider/src/test/java/TestConfig.java
@@ -1,0 +1,8 @@
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+
+@SpringBootApplication(scanBasePackages = {"gov.va.vro.service.db"})
+@EnableJpaRepositories("gov.va.vro.persistence.repository")
+@EntityScan("gov.va.vro.persistence.model")
+public class TestConfig {}

--- a/service/provider/src/test/resources/application-test.yml
+++ b/service/provider/src/test/resources/application-test.yml
@@ -1,0 +1,38 @@
+# This file is loaded when a test is annotated with @ActiveProfiles("test")
+# Spring will load main/resources/application.yml, followed by this file.
+# Since we want tests to be as close as possible to the deployed app, don't create test/resources/application.yml.
+# If test/resources/application.yml exists, it will override main/resources/application.yml.
+
+# Since this is for tests, override some main/resources/application.yml Spring settings
+
+spring:
+  datasource:
+    url: jdbc:h2:mem:testdb;MODE=PostgreSQL;INIT=CREATE SCHEMA IF NOT EXISTS example\;SET SCHEMA example;
+    hikari:
+      jdbc-url: jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;MODE=PostgreSQL;INIT=RUNSCRIPT FROM 'classpath:init.sql'
+      username: sa
+      password: sap
+  jpa:
+    show-sql: false
+    generate-ddl: true
+    hibernate:
+      ddl-auto: create-drop
+      naming:
+        physical-strategy: org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
+    database-platform: org.hibernate.dialect.PostgreSQL95Dialect
+    properties:
+      hibernate:
+        generate_statistics: false
+        jdbc:
+          lob:
+            non_contextual_creation=true:
+
+logging:
+  register-shutdown-hook: true
+  level:
+    org.springframework.jdbc.core: INFO # DEBUG
+    org.springframework.jdbc.core.JdbcTemplate: INFO # DEBUG
+    org.springframework.jdbc.core.StatementCreatorUtils: INFO # TRACE
+    org.hibernate.SQL: INFO # DEBUG
+    org.type.descriptor.sql.BasicBinder: INFO # TRACE
+    org.hibernate.type.descriptor.sql.BasicBinder: INFO # TRACE


### PR DESCRIPTION
<!-- Ensure the PR title reflects the feature or bug name -->

## What was the problem?
All of our unit tests are in one spot under the app folder, when really they should be under their respective sub-folders like 'controller' and 'service'.

Associated tickets or Slack threads:
<!-- replace "000" with ticket number in both places -->
- [MCP-2417](https://amida.atlassian.net/browse/MCP-2417)

## How does this fix it?[^1]
Moves tests to their appropriate folder to make them easier to find and make the folder structure of the project make sense.

## How to test this PR
No testing necessary by QA


[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
