### PR TITLE
Change secrel version to v4, remove minor and patch numbers

### DIFF
--- a/.github/workflows/secrel.yml
+++ b/.github/workflows/secrel.yml
@@ -136,8 +136,8 @@ jobs:
     if: github.repository == 'department-of-veterans-affairs/abd-vro-internal' && needs.publish-to-ghcr.outputs.run-secrel == 'true'
     name: SecRel Pipeline
     needs: publish-to-ghcr
-    # https://psychic-disco-c1251ea1.pages.github.io/pipeline/release_notes/v4.1.0/
-    uses: department-of-veterans-affairs/lighthouse-tornado-secrel-pipeline/.github/workflows/pipeline.yml@v4.2.0
+    # https://psychic-disco-c1251ea1.pages.github.io/pipeline/release_notes/v4.2.0/
+    uses: department-of-veterans-affairs/lighthouse-tornado-secrel-pipeline/.github/workflows/pipeline.yml@v4
     with:
       config-file: .github/secrel/config.yml
       images: ${{ needs.publish-to-ghcr.outputs.vro-images }}


### PR DESCRIPTION
This PR changes the version number of secrel from v4.2.0 to v4 to auto-inherit minor and patch changes

## What was the problem?
Teams would incur additional upgrade effort for each change that is released.

Associated tickets or Slack threads:
(https://dsva.slack.com/archives/C03UA9MV1EH/p1679333284422229)

[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
