### PR TITLE
MCP-2557 PDF Generator Table Break Logic

### DIFF
--- a/service-python/pdfgenerator/src/lib/templates/hypertension-v2-breakpoint.html
+++ b/service-python/pdfgenerator/src/lib/templates/hypertension-v2-breakpoint.html
@@ -469,5 +469,26 @@
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js"
     integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM"
     crossorigin="anonymous"></script>
+  <script>
+    window.onload = function() {
+      const tables = document.querySelectorAll('table');
+
+      for (let i = 0; i < tables.length; i++) {
+        const currentHeight = tables[i].offsetHeight;
+
+        let followingHeight = 0;
+        if (i < tables.length - 1) {
+          followingHeight = tables[i + 1].offsetHeight;
+        }
+
+        if (currentHeight + followingHeight < 550) {
+          const parentRow = tables[i].closest('.row');
+          const pagebreak = document.createElement('div');
+          pagebreak.classList.add('pagebreak');
+          parentRow.insertAdjacentElement('beforeend', pagebreak);
+        }
+      }
+    };
+  </script>
 </body>
 </html>

--- a/service-python/pdfgenerator/src/lib/templates/hypertension-v2-breakpoint.html
+++ b/service-python/pdfgenerator/src/lib/templates/hypertension-v2-breakpoint.html
@@ -207,7 +207,6 @@
       </table>
     </div>
   </div>
-  <div class="pagebreak"> </div>
   <!-- Condition History -->
   <div class="row">
     <div class="col">
@@ -242,7 +241,6 @@
         interaction with the patient, such as during an appointment or in-patient treatment. It may be a preliminary assessment.</i></p>
     </div>
   </div>
-  <div class="pagebreak"> </div>
   {% endif %}
   <!-- Hypertension -->
   <div class="row">
@@ -301,7 +299,6 @@
       </table>
     </div>
   </div>
-  <div class="pagebreak"> </div>
   <!-- Schedular evidence -->
   <div class="row">
     <div class="col">
@@ -357,7 +354,6 @@
       </table>
     </div>
   </div>
-  <div class="pagebreak"> </div>
   <!-- Other medical evidence -->
   <div class="row">
     <div class="col">
@@ -481,7 +477,7 @@
           followingHeight = tables[i + 1].offsetHeight;
         }
 
-        if (currentHeight + followingHeight < 550) {
+        if (currentHeight + followingHeight > 550) {
           const parentRow = tables[i].closest('.row');
           const pagebreak = document.createElement('div');
           pagebreak.classList.add('pagebreak');


### PR DESCRIPTION
<!-- Ensure the PR title reflects the feature or bug name -->

## What was the problem?
<!-- brief description of how things worked before this PR -->
Currently, the template has breakpoints after each table is defined regardless of its size. The design team asked if it would be possible to keep multiple tables on 1 page if they fit properly without any overflow.

Associated tickets or Slack threads:
<!-- replace "000" with ticket number in both places -->
- [MCP-2557](https://amida.atlassian.net/browse/MCP-2557)

## How does this fix it?[^1]
<!-- description of how things will work after this PR -->
Remove all the manual breakpoints and then iterate over each table and compare the heights of them to see if they fit together or not. If they don't then we add the breakpoint

## How to test this PR
- Generate a PDF using the template `hypertension-v2-breakpoint`
- When generating the PDF, modify the amount of data in each table to see the different scenarios

[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
