### PR TITLE
MCP-2598 Add Slack notifications when Lighthouse doesn't give data

### DIFF
--- a/app/src/test/java/gov/va/vro/controller/MasControllerTest.java
+++ b/app/src/test/java/gov/va/vro/controller/MasControllerTest.java
@@ -42,7 +42,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 public class MasControllerTest extends BaseControllerTest {
 
-  @EndpointInject("mock:mas-offramp")
+  @EndpointInject("mock:vro-notify")
   private MockEndpoint mockMasOfframpEndpoint;
 
   @EndpointInject("mock:mas-complete")
@@ -92,10 +92,10 @@ public class MasControllerTest extends BaseControllerTest {
     var offrampCalled = new AtomicBoolean(false);
     adviceWith(
             camelContext,
-            "mas-offramp",
+            "vro-notify",
             route ->
                 route
-                    .interceptSendToEndpoint(MasIntegrationRoutes.ENDPOINT_OFFRAMP)
+                    .interceptSendToEndpoint(MasIntegrationRoutes.ENDPOINT_NOTIFY_AUDIT)
                     .skipSendToOriginalEndpoint()
                     .to(mockMasOfframpEndpoint))
         .end();

--- a/service/provider/src/main/java/gov/va/vro/service/provider/CamelEntrance.java
+++ b/service/provider/src/main/java/gov/va/vro/service/provider/CamelEntrance.java
@@ -100,6 +100,6 @@ public class CamelEntrance {
    * @param auditEvent the event to broadcast
    */
   public void offrampClaim(AuditEvent auditEvent) {
-    producerTemplate.sendBody(MasIntegrationRoutes.ENDPOINT_OFFRAMP, auditEvent);
+    producerTemplate.sendBody(MasIntegrationRoutes.ENDPOINT_NOTIFY_AUDIT, auditEvent);
   }
 }

--- a/service/provider/src/main/java/gov/va/vro/service/provider/camel/MasIntegrationProcessors.java
+++ b/service/provider/src/main/java/gov/va/vro/service/provider/camel/MasIntegrationProcessors.java
@@ -152,6 +152,16 @@ public class MasIntegrationProcessors {
     };
   }
 
+
+  // Used for inline grabbing of errors that need to go to audit and slack, but the MasProcessingObject was stored
+  // not in the body at that point in the code.
+  public static Processor auditPropertyProcessor(String routeId, String message, String exchangeProperty){
+    return exchange -> {
+      var auditable = exchange.getProperty(exchangeProperty, Auditable.class);
+      exchange.getIn().setBody(AuditEvent.fromAuditable(auditable, routeId, message));
+    };
+  }
+
   /**
    * This sets up a skeleton lighthouse HealthDataAsessment object in the event of a timeout from
    * lighthouse. We know the fields we MUST have for evidence merge from the properties we saved on

--- a/service/provider/src/main/java/gov/va/vro/service/provider/camel/MasIntegrationProcessors.java
+++ b/service/provider/src/main/java/gov/va/vro/service/provider/camel/MasIntegrationProcessors.java
@@ -152,10 +152,11 @@ public class MasIntegrationProcessors {
     };
   }
 
-
-  // Used for inline grabbing of errors that need to go to audit and slack, but the MasProcessingObject was stored
+  // Used for inline grabbing of errors that need to go to audit and slack, but the
+  // MasProcessingObject was stored
   // not in the body at that point in the code.
-  public static Processor auditPropertyProcessor(String routeId, String message, String exchangeProperty){
+  public static Processor auditPropertyProcessor(
+      String routeId, String message, String exchangeProperty) {
     return exchange -> {
       var auditable = exchange.getProperty(exchangeProperty, Auditable.class);
       exchange.getIn().setBody(AuditEvent.fromAuditable(auditable, routeId, message));

--- a/service/provider/src/main/java/gov/va/vro/service/provider/camel/MasIntegrationRoutes.java
+++ b/service/provider/src/main/java/gov/va/vro/service/provider/camel/MasIntegrationRoutes.java
@@ -242,13 +242,16 @@ public class MasIntegrationRoutes extends RouteBuilder {
         .to(lighthouseRetryRoute)
         // Handle the errors to permit processing to continue
         .onException(
-            ExchangeTimedOutException
-                .class, ExternalCallException.class) // But do handle the errors to permit processing to continue
+            ExchangeTimedOutException.class,
+            ExternalCallException
+                .class) // But do handle the errors to permit processing to continue
         .handled(true)
-        .wireTap(ENDPOINT_NOTIFY_AUDIT) //Send error notification to slack
-        .onPrepare(auditPropertyProcessor(lighthouseRoute, "Lighthouse health data not retrieved.", "payload"))
-        .process(lighthouseContinueProcessor()) //But keep processing
-        .end(); //End of onException
+        .wireTap(ENDPOINT_NOTIFY_AUDIT) // Send error notification to slack
+        .onPrepare(
+            auditPropertyProcessor(
+                lighthouseRoute, "Lighthouse health data not retrieved.", "payload"))
+        .process(lighthouseContinueProcessor()) // But keep processing
+        .end(); // End of onException
 
     from(lighthouseRetryRoute)
         .doTry()
@@ -330,15 +333,17 @@ public class MasIntegrationRoutes extends RouteBuilder {
         .to(ENDPOINT_AUDIT_EVENT);
   }
 
-  private void configureNotify(){
-    // This exists exclusively to not change the route id from the offramp one. which may change in the future or is misnamed but already externally exposed.
-    // Not all Slack notifications that also need audit logging *are* offramping, and having that routeId exposed (sent to slack and audit) is only going to create confusion.
+  private void configureNotify() {
+    // This exists exclusively to not change the route id from the offramp one. which may change in
+    // the future or is misnamed but already externally exposed.
+    // Not all Slack notifications that also need audit logging *are* offramping, and having that
+    // routeId exposed (sent to slack and audit) is only going to create confusion.
     from(ENDPOINT_NOTIFY_AUDIT)
-            .routeId("vro-error-notify")
-            .multicast()
-            .to(ENDPOINT_SLACK_EVENT)
-            .to(ENDPOINT_AUDIT_EVENT);
-}
+        .routeId("vro-error-notify")
+        .multicast()
+        .to(ENDPOINT_SLACK_EVENT)
+        .to(ENDPOINT_AUDIT_EVENT);
+  }
 
   /** Configure auditing. */
   public void configureAuditing() {

--- a/service/provider/src/main/java/gov/va/vro/service/provider/camel/MasIntegrationRoutes.java
+++ b/service/provider/src/main/java/gov/va/vro/service/provider/camel/MasIntegrationRoutes.java
@@ -238,10 +238,7 @@ public class MasIntegrationRoutes extends RouteBuilder {
         .process(payloadToClaimProcessor())
         .to(lighthouseRetryRoute)
         // Handle the errors to permit processing to continue
-        .onException(
-            ExchangeTimedOutException.class,
-            ExternalCallException
-                .class) // But do handle the errors to permit processing to continue
+        .onException(ExchangeTimedOutException.class, ExternalCallException.class)
         .handled(true)
         .wireTap(ENDPOINT_NOTIFY_AUDIT) // Send error notification to slack
         .onPrepare(

--- a/service/provider/src/main/java/gov/va/vro/service/provider/camel/MasIntegrationRoutes.java
+++ b/service/provider/src/main/java/gov/va/vro/service/provider/camel/MasIntegrationRoutes.java
@@ -1,7 +1,6 @@
 package gov.va.vro.service.provider.camel;
 
 import static gov.va.vro.service.provider.camel.MasIntegrationProcessors.auditProcessor;
-import static gov.va.vro.service.provider.camel.MasIntegrationProcessors.auditPropertyProcessor;
 import static gov.va.vro.service.provider.camel.MasIntegrationProcessors.combineExchangesProcessor;
 import static gov.va.vro.service.provider.camel.MasIntegrationProcessors.convertToMasProcessingObject;
 import static gov.va.vro.service.provider.camel.MasIntegrationProcessors.convertToPdfResponse;
@@ -9,6 +8,7 @@ import static gov.va.vro.service.provider.camel.MasIntegrationProcessors.generat
 import static gov.va.vro.service.provider.camel.MasIntegrationProcessors.lighthouseContinueProcessor;
 import static gov.va.vro.service.provider.camel.MasIntegrationProcessors.payloadToClaimProcessor;
 import static gov.va.vro.service.provider.camel.MasIntegrationProcessors.slackEventProcessor;
+import static gov.va.vro.service.provider.camel.MasIntegrationProcessors.slackEventPropertyProcessor;
 
 import gov.va.vro.camel.FunctionProcessor;
 import gov.va.vro.camel.RabbitMqCamelUtils;
@@ -245,7 +245,7 @@ public class MasIntegrationRoutes extends RouteBuilder {
         .handled(true)
         .wireTap(ENDPOINT_NOTIFY_AUDIT) // Send error notification to slack
         .onPrepare(
-            auditPropertyProcessor(
+            slackEventPropertyProcessor(
                 lighthouseRoute, "Lighthouse health data not retrieved.", "payload"))
         .process(lighthouseContinueProcessor()) // But keep processing
         .end(); // End of onException


### PR DESCRIPTION

## What was the problem?
The remaining part of the VA ask about lighthouse documented in https://github.com/department-of-veterans-affairs/abd-vro/issues/1314 (not other cases, not included here)

Associated tickets or Slack threads:

- [MCP-2521](https://amida.atlassian.net/browse/MCP-2521)
- [MCP-2598](https://amida.atlassian.net/browse/MCP-2598)
- 
## How does this fix it?
Now sends to slack in all cases. Did minor refactoring on Warren's code to attempt to be more DRY about it. 

## How to test this PR
Oh this one is a doozy. Automated tests need to be created in this area but for deadline reasons are not in this PR.

For local developers:
Edit your end to end test .yml with the slack information from the application-nonprod.yml This will stand up all the mocks and hook you into the right slack channel for testing. (which is the non prod one)
Set your env end2end-test
Source the script but DO NOT use the special end to end test script that @yoomlam  wrote. We dont want the slack override.
Load up docker with this code.
*STOP* svc-lighthouse container. This will force timeouts to occur.

Run *any* normally successful end to end test that goes all the way through. 375 is a good collection ID for this but a number of them will work.

Watch the slack channel, and see the message go through.

Proof of work here
<img width="601" alt="Screen Shot 2023-03-23 at 4 46 03 PM" src="https://user-images.githubusercontent.com/57402207/227354649-5cd7a11d-6eb5-4f71-afdd-7931ce896046.png">

