### PR TITLE
DB: add uploadedAt to EvidenceSummaryDocumentEntity

### DIFF
--- a/db-init/src/main/resources/database/migrations/V4.15__Add_UploadedAt_To_EvidenceSummaryDocument.sql
+++ b/db-init/src/main/resources/database/migrations/V4.15__Add_UploadedAt_To_EvidenceSummaryDocument.sql
@@ -1,0 +1,1 @@
+ALTER TABLE evidence_summary_document ADD COLUMN uploaded_at TIMESTAMP;

--- a/persistence/model/src/main/java/gov/va/vro/persistence/model/EvidenceSummaryDocumentEntity.java
+++ b/persistence/model/src/main/java/gov/va/vro/persistence/model/EvidenceSummaryDocumentEntity.java
@@ -6,6 +6,7 @@ import lombok.Setter;
 import org.hibernate.annotations.Type;
 import org.hibernate.annotations.TypeDef;
 
+import java.time.OffsetDateTime;
 import java.util.Map;
 import java.util.UUID;
 import javax.persistence.Column;
@@ -30,4 +31,6 @@ public class EvidenceSummaryDocumentEntity extends BaseEntity {
   private String documentName;
 
   private UUID folderId;
+
+  private OffsetDateTime uploadedAt;
 }

--- a/service/db/src/main/java/gov/va/vro/service/db/SaveToDbServiceImpl.java
+++ b/service/db/src/main/java/gov/va/vro/service/db/SaveToDbServiceImpl.java
@@ -26,6 +26,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
@@ -211,6 +212,7 @@ public class SaveToDbServiceImpl implements SaveToDbService {
       if (esd.isPresent()) {
         EvidenceSummaryDocumentEntity esdEntity = esd.get();
         esdEntity.setFolderId(eFolderId);
+        esdEntity.setUploadedAt(OffsetDateTime.now());
         evidenceSummaryDocumentRepository.save(esdEntity);
       } else {
         log.error(


### PR DESCRIPTION
<!-- Ensure the PR title reflects the feature or bug name -->

## What was the problem?
<!-- brief description of how things worked before this PR -->
To add a BGS note:
> "Hypertension automated review summary document uploaded MM/DD/YYYY"

we need the date but it's not currently stored in the DB.

- #1341

## How does this fix it?
<!-- description of how things will work after this PR -->

Add `uploadedAt` to `EvidenceSummaryDocumentEntity`

(I didn't see an existing unit test that updates and checks the `folderId` so I can add a check for `uploadedAt`.)