### PR TITLE
MCP-2580 Offramp when VRO cant retrieve MAS annotations

### DIFF
--- a/app/src/end2endTest/java/gov/va/vro/end2end/VroV2Tests.java
+++ b/app/src/end2endTest/java/gov/va/vro/end2end/VroV2Tests.java
@@ -778,7 +778,7 @@ public class VroV2Tests {
    * This is a end-to-end test for an increase case based on 375. It is used to test mas exceptions.
    */
   @Test
-  void testAutomatedClaimMasExceptikon() {
+  void testAutomatedClaimMasException() {
     AutomatedClaimTestSpec spec = specFor200("369");
     testAutomatedClaimOffRamp(spec);
   }

--- a/app/src/end2endTest/java/gov/va/vro/end2end/VroV2Tests.java
+++ b/app/src/end2endTest/java/gov/va/vro/end2end/VroV2Tests.java
@@ -773,4 +773,13 @@ public class VroV2Tests {
     testAutomatedClaimOffRamp(spec);
     testClaimSufficientStatus(collectionId, null);
   }
+
+  /**
+   * This is a end-to-end test for an increase case based on 375. It is used to test mas exceptions.
+   */
+  @Test
+  void testAutomatedClaimMasExceptikon() {
+    AutomatedClaimTestSpec spec = specFor200("369");
+    testAutomatedClaimOffRamp(spec);
+  }
 }

--- a/app/src/end2endTest/resources/test-mas/claim-369-7101.json
+++ b/app/src/end2endTest/resources/test-mas/claim-369-7101.json
@@ -1,0 +1,29 @@
+{
+  "dob": "1970-02-19",
+  "firstName": "Michael",
+  "lastName": "Masexception",
+  "gender": "male",
+  "collectionId": 369,
+  "veteranIdentifiers": {
+    "icn": "1012666073V986369",
+    "ssn": "111-11-1369",
+    "veteranFileId": "9999369",
+    "edipn": "1010234-369",
+    "participantId": "88888369"
+  },
+  "claimDetail": {
+    "benefitClaimId": "1369",
+    "claimSubmissionDateTime": "2023-01-05Z",
+    "claimSubmissionSource": "MAS",
+    "conditions": {
+      "name": "Hyperotension",
+      "diagnosticCode": "7101",
+      "disabilityActionType": "INCREASE",
+      "disabilityClassificationCode": "3460",
+      "ratedDisabilityId": "7645"
+    }
+  },
+  "veteranFlashIds": [
+    "999375"
+  ]
+}

--- a/mocks/mock-bip-claims-api/src/main/resources/mock-claims.json
+++ b/mocks/mock-bip-claims-api/src/main/resources/mock-claims.json
@@ -429,5 +429,31 @@
         ]
       }
     ]
+  },
+  {
+    "description": [
+      "for mas exception handling tests"
+    ],
+    "claimDetail": {
+      "claimId": 1369,
+      "tempStationOfJurisdiction": "398",
+      "phase": "Gathering of Evidence",
+      "claimLifecycleStatus": "Open"
+    },
+    "contentions": [
+      {
+        "contentionId": "2369",
+        "lastModified": "2023-01-25T17:32:28Z",
+        "classificationType": 1250,
+        "diagnosticTypeCode": "7101",
+        "lifecycleStatus": "Open",
+        "automationIndicator": false,
+        "specialIssueCodes": [
+          "ANOTHER",
+          "RDR1",
+          "RRD"
+        ]
+      }
+    ]
   }
 ]

--- a/mocks/mock-lighthouse-api/src/main/java/gov/va/vro/mocklh/config/AppConfig.java
+++ b/mocks/mock-lighthouse-api/src/main/java/gov/va/vro/mocklh/config/AppConfig.java
@@ -68,6 +68,9 @@ public class AppConfig {
     MockBundles mb12 = MockBundles.of("mock-bundles/mock1012666073V986386");
     store.put("mock1012666073V986386", mb12);
 
+    MockBundles mb13 = MockBundles.of("mock-bundles/mock1012666073V986369");
+    store.put("mock1012666073V986369", mb13);
+
     return store;
   }
 }

--- a/mocks/mock-lighthouse-api/src/main/resources/mock-bundles/mock1012666073V986369/Condition.json
+++ b/mocks/mock-lighthouse-api/src/main/resources/mock-bundles/mock1012666073V986369/Condition.json
@@ -1,0 +1,212 @@
+{
+  "resourceType": "Bundle",
+  "type": "searchset",
+  "total": 3,
+  "link": [
+    {
+      "relation": "first",
+      "url": "https://sandbox-api.va.gov/services/fhir/v0/r4/Condition?patient=mock1012666073V986369&_count=100&page=1"
+    },
+    {
+      "relation": "self",
+      "url": "https://sandbox-api.va.gov/services/fhir/v0/r4/Condition?patient=mock1012666073V986369&_count=100&page=1"
+    },
+    {
+      "relation": "last",
+      "url": "https://sandbox-api.va.gov/services/fhir/v0/r4/Condition?patient=mock1012666073V986369&_count=100&page=1"
+    }
+  ],
+  "entry": [
+    {
+      "fullUrl": "https://sandbox-api.va.gov/services/fhir/v0/r4/Condition/condition1",
+      "resource": {
+        "resourceType": "Condition",
+        "id": "condition1",
+        "meta": {
+          "lastUpdated": "2022-05-30T00:00:00Z"
+        },
+        "clinicalStatus": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/condition-clinical",
+              "code": "active",
+              "display": "Active"
+            }
+          ],
+          "text": "Active"
+        },
+        "verificationStatus": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/condition-ver-status",
+              "code": "confirmed",
+              "display": "Confirmed"
+            }
+          ],
+          "text": "Confirmed"
+        },
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/condition-category",
+                "code": "problem-list-item",
+                "display": "Problem List Item"
+              }
+            ],
+            "text": "Problem List Item"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "13645005",
+              "display": "Chronic obstructive lung disease"
+            }
+          ],
+          "text": "Chronic obstructive lung disease"
+        },
+        "subject": {
+          "reference": "https://sandbox-api.va.gov/services/fhir/v0/r4/Patient/mock1012666073V986369",
+          "display": "SKYSCRAPER,DAVID"
+        },
+        "onsetDateTime": "2018-12-20T04:00:00Z",
+        "recordedDate": "2018-11-20",
+        "recorder": {
+          "reference": "https://sandbox-api.va.gov/services/fhir/v0/r4/Practitioner/practitioner1",
+          "display": "PRACTITIONER, MIKE T"
+        }
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://sandbox-api.va.gov/services/fhir/v0/r4/Condition/condition2",
+      "resource": {
+        "resourceType": "Condition",
+        "id": "condition2",
+        "meta": {
+          "lastUpdated": "2022-07-05T00:00:00Z"
+        },
+        "clinicalStatus": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/condition-clinical",
+              "code": "active",
+              "display": "Active"
+            }
+          ],
+          "text": "Active"
+        },
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/condition-category",
+                "code": "encounter-diagnosis",
+                "display": "Encounter Diagnosis"
+              }
+            ],
+            "text": "Encounter Diagnosis"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://hl7.org/fhir/sid/icd-9-cm",
+              "code": "401.9",
+              "display": "UNSPECIFIED ESSENTIAL HYPERTENSION"
+            },
+            {
+              "system": "http://snomed.info/sct",
+              "code": "*Missing*",
+              "display": "Essential Hypertension"
+            }
+          ],
+          "text": "Essential Hypertension"
+        },
+        "subject": {
+          "reference": "https://sandbox-api.va.gov/services/fhir/v0/r4/Patient/mock1012666073V986369",
+          "display": "SKYSCRAPER,DAVID"
+        },
+        "encounter": {
+          "reference": "https://sandbox-api.va.gov/services/fhir/v0/r4/Encounter/encounter1"
+        },
+        "onsetDateTime": "2019-11-07T12:45:58Z",
+        "recordedDate": "2019-11-07",
+        "asserter": {
+          "reference": "https://sandbox-api.va.gov/services/fhir/v0/r4/Practitioner/practitioner1",
+          "display": "PRACTITIONER, MIKE T"
+        }
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://sandbox-api.va.gov/services/fhir/v0/r4/Condition/condition5",
+      "resource": {
+        "resourceType": "Condition",
+        "id": "condition5",
+        "meta": {
+          "lastUpdated": "2022-08-31T00:00:00Z"
+        },
+        "clinicalStatus": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/condition-clinical",
+              "code": "active",
+              "display": "Active"
+            }
+          ],
+          "text": "Active"
+        },
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/condition-category",
+                "code": "encounter-diagnosis",
+                "display": "Encounter Diagnosis"
+              }
+            ],
+            "text": "Encounter Diagnosis"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "*Missing*",
+              "display": "OTHER SPECIFIED COUNSELING"
+            },
+            {
+              "system": "http://hl7.org/fhir/sid/icd-9-cm",
+              "code": "V65.49",
+              "display": "OTHER SPECIFIED COUNSELING"
+            }
+          ],
+          "text": "OTHER SPECIFIED COUNSELING"
+        },
+        "subject": {
+          "reference": "https://sandbox-api.va.gov/services/fhir/v0/r4/Patient/mock1012666073V986369",
+          "display": "SKYSCRAPER,DAVID"
+        },
+        "encounter": {
+          "reference": "https://sandbox-api.va.gov/services/fhir/v0/r4/Encounter/encounter-no-consequence"
+        },
+        "onsetDateTime": "2023-01-16T17:00:00Z",
+        "recordedDate": "2023-01-16",
+        "asserter": {
+          "reference": "https://sandbox-api.va.gov/services/fhir/v0/r4/Practitioner/practitioner5",
+          "display": "ASSERTER, MARY Y"
+        }
+      },
+      "search": {
+        "mode": "match"
+      }
+    }
+  ]
+}

--- a/mocks/mock-lighthouse-api/src/main/resources/mock-bundles/mock1012666073V986369/MedicationRequest.json
+++ b/mocks/mock-lighthouse-api/src/main/resources/mock-bundles/mock1012666073V986369/MedicationRequest.json
@@ -1,0 +1,722 @@
+{
+  "resourceType": "Bundle",
+  "type": "searchset",
+  "total": 10,
+  "link": [
+    {
+      "relation": "first",
+      "url": "https://sandbox-api.va.gov/services/fhir/v0/r4/MedicationRequest?patient=mock1012666073V986369&page=1&_count=100"
+    },
+    {
+      "relation": "self",
+      "url": "https://sandbox-api.va.gov/services/fhir/v0/r4/MedicationRequest?patient=mock1012666073V986369&page=1&_count=100"
+    },
+    {
+      "relation": "last",
+      "url": "https://sandbox-api.va.gov/services/fhir/v0/r4/MedicationRequest?patient=mock1012666073V986369&page=1&_count=100"
+    }
+  ],
+  "entry": [
+    {
+      "fullUrl": "https://sandbox-api.va.gov/services/fhir/v0/r4/MedicationRequest/I2-DG5EAFAS4H4RGLQ44WMVGVNYATHIPTD454QNU27VQ6DFZGYFPRLQ0000",
+      "resource": {
+        "resourceType": "MedicationRequest",
+        "id": "I2-DG5EAFAS4H4RGLQ44WMVGVNYATHIPTD454QNU27VQ6DFZGYFPRLQ0000",
+        "meta": {
+          "lastUpdated": "2020-08-14T08:00:00Z"
+        },
+        "status": "active",
+        "intent": "order",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/medicationrequest-category",
+                "code": "outpatient",
+                "display": "Outpatient"
+              }
+            ],
+            "text": "Outpatient"
+          }
+        ],
+        "medicationReference": {
+          "reference": "https://sandbox-api.va.gov/services/fhir/v0/r4/Medication/I2-WNE2DVN73IGHOU7MDDF6NJKQJ232Q262Q6UZXWKKXAWAIOJ65OGA0000",
+          "display": "Amlodipine 5 MG Oral Tablet"
+        },
+        "subject": {
+          "reference": "https://sandbox-api.va.gov/services/fhir/v0/r4/Patient/mock1012666073V986369",
+          "display": "Mr. Jesse Gray"
+        },
+        "authoredOn": "2020-08-14T08:00:00Z",
+        "requester": {
+          "reference": "https://sandbox-api.va.gov/services/fhir/v0/r4/Practitioner/I2-VLZYJVF7MOB2SFAKTAPNSQIBWZS22HGVT3A56E5D5PHDUWJGQIGQ0000",
+          "display": "DR. JANE460 DOE922 MD"
+        },
+        "dosageInstruction": [
+          {
+            "timing": {
+              "repeat": {
+                "boundsPeriod": {
+                  "start": "2020-08-14T08:00:00Z"
+                }
+              },
+              "code": {
+                "text": "Once Per Day"
+              }
+            },
+            "asNeededBoolean": false,
+            "route": {
+              "text": "ORAL"
+            },
+            "doseAndRate": [
+              {
+                "doseQuantity": {
+                  "value": 1.0
+                }
+              }
+            ]
+          },
+          {
+            "timing": {
+              "repeat": {
+                "boundsPeriod": {
+                  "start": "2020-08-14T08:00:00Z"
+                }
+              },
+              "code": {
+                "text": "Twice Per Day"
+              }
+            },
+            "asNeededBoolean": false,
+            "route": {
+              "text": "ORAL"
+            },
+            "doseAndRate": [
+              {
+                "doseQuantity": {
+                  "value": 1.0
+                }
+              }
+            ]
+          }
+        ],
+        "dispenseRequest": {
+          "numberOfRepeatsAllowed": 0,
+          "quantity": {
+            "value": 1.0
+          },
+          "expectedSupplyDuration": {
+            "value": 30,
+            "unit": "days",
+            "system": "http://unitsofmeasure.org",
+            "code": "d"
+          }
+        }
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://sandbox-api.va.gov/services/fhir/v0/r4/MedicationRequest/I2-DG5EAFAS4H4RGLQ44WMVGVNYAS477OC36HK4JCCUEYVN2JZULEZA0000",
+      "resource": {
+        "resourceType": "MedicationRequest",
+        "id": "I2-DG5EAFAS4H4RGLQ44WMVGVNYAS477OC36HK4JCCUEYVN2JZULEZA0000",
+        "meta": {
+          "lastUpdated": "2018-02-03T08:00:00Z"
+        },
+        "status": "active",
+        "intent": "order",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/medicationrequest-category",
+                "code": "outpatient",
+                "display": "Outpatient"
+              }
+            ],
+            "text": "Outpatient"
+          }
+        ],
+        "medicationReference": {
+          "reference": "https://sandbox-api.va.gov/services/fhir/v0/r4/Medication/I2-6TKXY4NWCNKLXGBHFWMCU736FC2CEJHDL4RL4HYDK347BPOTKT4Q0000",
+          "display": "Escitalopram 10 MG"
+        },
+        "subject": {
+          "reference": "https://sandbox-api.va.gov/services/fhir/v0/r4/Patient/mock1012666073V986369",
+          "display": "Mr. Jesse Gray"
+        },
+        "authoredOn": "2018-02-03T08:00:00Z",
+        "requester": {
+          "reference": "https://sandbox-api.va.gov/services/fhir/v0/r4/Practitioner/I2-VLZYJVF7MOB2SFAKTAPNSQIBWZS22HGVT3A56E5D5PHDUWJGQIGQ0000",
+          "display": "DR. JANE460 DOE922 MD"
+        },
+        "dosageInstruction": [
+          {
+            "timing": {
+              "repeat": {
+                "boundsPeriod": {
+                  "start": "2018-02-03T08:00:00Z"
+                }
+              },
+              "code": {
+                "text": "Once Per Day"
+              }
+            },
+            "asNeededBoolean": false,
+            "route": {
+              "text": "ORAL"
+            },
+            "doseAndRate": [
+              {
+                "doseQuantity": {
+                  "value": 1.0
+                }
+              }
+            ]
+          }
+        ],
+        "dispenseRequest": {
+          "numberOfRepeatsAllowed": 0,
+          "quantity": {
+            "value": 1.0
+          },
+          "expectedSupplyDuration": {
+            "value": 30,
+            "unit": "days",
+            "system": "http://unitsofmeasure.org",
+            "code": "d"
+          }
+        }
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://sandbox-api.va.gov/services/fhir/v0/r4/MedicationRequest/I2-DG5EAFAS4H4RGLQ44WMVGVNYAQ5XHK2OAL5WWSHAYXQDX3MDQCLA0000",
+      "resource": {
+        "resourceType": "MedicationRequest",
+        "id": "I2-DG5EAFAS4H4RGLQ44WMVGVNYAQ5XHK2OAL5WWSHAYXQDX3MDQCLA0000",
+        "meta": {
+          "lastUpdated": "2021-04-15T08:00:00Z"
+        },
+        "status": "active",
+        "intent": "order",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/medicationrequest-category",
+                "code": "outpatient",
+                "display": "Outpatient"
+              }
+            ],
+            "text": "Outpatient"
+          }
+        ],
+        "medicationReference": {
+          "reference": "https://sandbox-api.va.gov/services/fhir/v0/r4/Medication/I2-6TKXY4NWCNKLXGBHFWMCU736FC5CYFVETDH5ODDXPDHLPXNXZ6EQ0000",
+          "display": "Omeprazole 10 MG"
+        },
+        "subject": {
+          "reference": "https://sandbox-api.va.gov/services/fhir/v0/r4/Patient/mock1012666073V986369",
+          "display": "Mr. Jesse Gray"
+        },
+        "authoredOn": "2021-04-15T08:00:00Z",
+        "requester": {
+          "reference": "https://sandbox-api.va.gov/services/fhir/v0/r4/Practitioner/I2-VLZYJVF7MOB2SFAKTAPNSQIBWZS22HGVT3A56E5D5PHDUWJGQIGQ0000",
+          "display": "DR. JANE460 DOE922 MD"
+        },
+        "dispenseRequest": {
+          "numberOfRepeatsAllowed": 0,
+          "quantity": {
+            "value": 1.0
+          },
+          "expectedSupplyDuration": {
+            "value": 30,
+            "unit": "days",
+            "system": "http://unitsofmeasure.org",
+            "code": "d"
+          }
+        }
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://sandbox-api.va.gov/services/fhir/v0/r4/MedicationRequest/I2-DG5EAFAS4H4RGLQ44WMVGVNYATAHNQWZMLO5WCISRYSFP43KTKEQ0000",
+      "resource": {
+        "resourceType": "MedicationRequest",
+        "id": "I2-DG5EAFAS4H4RGLQ44WMVGVNYATAHNQWZMLO5WCISRYSFP43KTKEQ0000",
+        "meta": {
+          "lastUpdated": "2018-02-14T08:00:00Z"
+        },
+        "status": "completed",
+        "intent": "order",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/medicationrequest-category",
+                "code": "outpatient",
+                "display": "Outpatient"
+              }
+            ],
+            "text": "Outpatient"
+          }
+        ],
+        "medicationReference": {
+          "reference": "https://sandbox-api.va.gov/services/fhir/v0/r4/Medication/I2-6TKXY4NWCNKLXGBHFWMCU736FBVIYI7OSPGY5FZ3TREPGSBCVARQ0000",
+          "display": "Hydrocortisone 10 MG/ML Topical Cream"
+        },
+        "subject": {
+          "reference": "https://sandbox-api.va.gov/services/fhir/v0/r4/Patient/mock1012666073V986369",
+          "display": "Mr. Jesse Gray"
+        },
+        "authoredOn": "2018-02-14T08:00:00Z",
+        "requester": {
+          "reference": "https://sandbox-api.va.gov/services/fhir/v0/r4/Practitioner/I2-VLZYJVF7MOB2SFAKTAPNSQIBWZS22HGVT3A56E5D5PHDUWJGQIGQ0000",
+          "display": "DR. JANE460 DOE922 MD"
+        },
+        "dosageInstruction": [
+          {
+            "timing": {
+              "repeat": {
+                "boundsPeriod": {
+                  "start": "2018-02-14T08:00:00Z"
+                }
+              },
+              "code": {
+                "text": "Once Per Day"
+              }
+            },
+            "asNeededBoolean": false,
+            "doseAndRate": [
+              {
+                "doseQuantity": {
+                  "value": 1.0
+                }
+              }
+            ]
+          }
+        ],
+        "dispenseRequest": {
+          "numberOfRepeatsAllowed": 0,
+          "expectedSupplyDuration": {
+            "value": 30,
+            "unit": "days",
+            "system": "http://unitsofmeasure.org",
+            "code": "d"
+          }
+        }
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://sandbox-api.va.gov/services/fhir/v0/r4/MedicationRequest/I2-DG5EAFAS4H4RGLQ44WMVGVNYATLO6VB7KKLYT3RPU2HVS4M4P5MQ0000",
+      "resource": {
+        "resourceType": "MedicationRequest",
+        "id": "I2-DG5EAFAS4H4RGLQ44WMVGVNYATLO6VB7KKLYT3RPU2HVS4M4P5MQ0000",
+        "meta": {
+          "lastUpdated": "2021-07-06T01:43:31Z"
+        },
+        "status": "completed",
+        "intent": "order",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/medicationrequest-category",
+                "code": "outpatient",
+                "display": "Outpatient"
+              }
+            ],
+            "text": "Outpatient"
+          }
+        ],
+        "medicationReference": {
+          "reference": "https://sandbox-api.va.gov/services/fhir/v0/r4/Medication/I2-XRKHNR2H3CNP37MJQEFNGLIVMYDFMV2QSIN3WZBFBUSTPDA555HA0000",
+          "display": "IBUPROFEN 800MG TAB"
+        },
+        "subject": {
+          "reference": "https://sandbox-api.va.gov/services/fhir/v0/r4/Patient/mock1012666073V986369",
+          "display": "Mr. Jesse Gray"
+        },
+        "authoredOn": "2021-07-06T01:43:31Z",
+        "_requester": {
+          "extension": [
+            {
+              "url": "https://hl7.org/fhir/extension-data-absent-reason.html",
+              "valueCode": "unknown"
+            }
+          ]
+        },
+        "dosageInstruction": [
+          {
+            "text": "TAKE ONE TABLET BY MOUTH EVERY 8 HOURS AS NEEDED -TAKE WITH FOOD",
+            "timing": {
+              "repeat": {
+                "boundsPeriod": {
+                  "start": "2021-07-06T01:43:31Z"
+                }
+              },
+              "code": {
+                "text": "As directed by physician."
+              }
+            },
+            "asNeededBoolean": false,
+            "route": {
+              "text": "ORAL"
+            }
+          }
+        ],
+        "dispenseRequest": {
+          "numberOfRepeatsAllowed": 1,
+          "expectedSupplyDuration": {
+            "value": 15,
+            "unit": "days",
+            "system": "http://unitsofmeasure.org",
+            "code": "d"
+          }
+        }
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://sandbox-api.va.gov/services/fhir/v0/r4/MedicationRequest/I2-DG5EAFAS4H4RGLQ44WMVGVNYAQHKCMB2GEQTWOZBQI3FLMSOIQKQ0000",
+      "resource": {
+        "resourceType": "MedicationRequest",
+        "id": "I2-DG5EAFAS4H4RGLQ44WMVGVNYAQHKCMB2GEQTWOZBQI3FLMSOIQKQ0000",
+        "meta": {
+          "lastUpdated": "2022-03-23T01:43:31Z"
+        },
+        "status": "active",
+        "intent": "order",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/medicationrequest-category",
+                "code": "outpatient",
+                "display": "Outpatient"
+              }
+            ],
+            "text": "Outpatient"
+          }
+        ],
+        "medicationReference": {
+          "reference": "https://sandbox-api.va.gov/services/fhir/v0/r4/Medication/I2-EK3ARQ73OVGMYQTC3HNYBBKVD5ISZAUX3TSAWCZHKCEYA6BHZG2A0000",
+          "display": "ALBUTEROL SO4 90MCG/ACTUAT (CFC-F) INHL,ORAL,6.7GM"
+        },
+        "subject": {
+          "reference": "https://sandbox-api.va.gov/services/fhir/v0/r4/Patient/mock1012666073V986369",
+          "display": "Mr. Jesse Gray"
+        },
+        "authoredOn": "2022-03-23T01:43:31Z",
+        "_requester": {
+          "extension": [
+            {
+              "url": "https://hl7.org/fhir/extension-data-absent-reason.html",
+              "valueCode": "unknown"
+            }
+          ]
+        },
+        "dosageInstruction": [
+          {
+            "text": "INHALE 2 PUFFS BY INHALATION FOUR TIMES A DAY AS NEEDED FOR SHORTNESS OF BREATH OR WHEEZING",
+            "timing": {
+              "repeat": {
+                "boundsPeriod": {
+                  "start": "2022-03-23T01:43:31Z"
+                }
+              },
+              "code": {
+                "text": "As directed by physician."
+              }
+            },
+            "asNeededBoolean": false
+          }
+        ],
+        "dispenseRequest": {
+          "numberOfRepeatsAllowed": 0,
+          "expectedSupplyDuration": {
+            "value": 30,
+            "unit": "days",
+            "system": "http://unitsofmeasure.org",
+            "code": "d"
+          }
+        }
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://sandbox-api.va.gov/services/fhir/v0/r4/MedicationRequest/I2-DG5EAFAS4H4RGLQ44WMVGVNYASLWJ7GNZ36UEOF5DCTZ6EOIECIA0000",
+      "resource": {
+        "resourceType": "MedicationRequest",
+        "id": "I2-DG5EAFAS4H4RGLQ44WMVGVNYASLWJ7GNZ36UEOF5DCTZ6EOIECIA0000",
+        "meta": {
+          "lastUpdated": "2021-09-09T01:43:31Z"
+        },
+        "status": "on-hold",
+        "intent": "order",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/medicationrequest-category",
+                "code": "outpatient",
+                "display": "Outpatient"
+              }
+            ],
+            "text": "Outpatient"
+          }
+        ],
+        "medicationReference": {
+          "reference": "https://sandbox-api.va.gov/services/fhir/v0/r4/Medication/I2-X2QZH3IXBDIJ2OFUZZ2A3NMNSCBQLZ7GO4TXONPVQRDA3GF2NODQ0000",
+          "display": "LEVALBUTEROL 45MCG/SPRAY INHL,ORAL,15GM"
+        },
+        "subject": {
+          "reference": "https://sandbox-api.va.gov/services/fhir/v0/r4/Patient/mock1012666073V986369",
+          "display": "Mr. Jesse Gray"
+        },
+        "authoredOn": "2021-09-09T01:43:31Z",
+        "_requester": {
+          "extension": [
+            {
+              "url": "https://hl7.org/fhir/extension-data-absent-reason.html",
+              "valueCode": "unknown"
+            }
+          ]
+        },
+        "dosageInstruction": [
+          {
+            "text": "INHALE 2 PUFFS BY MOUTH DAILY USE AT THE SAME TIME EACH DAY",
+            "timing": {
+              "repeat": {
+                "boundsPeriod": {
+                  "start": "2021-09-09T01:43:31Z"
+                }
+              },
+              "code": {
+                "text": "As directed by physician."
+              }
+            },
+            "asNeededBoolean": false
+          }
+        ],
+        "dispenseRequest": {
+          "numberOfRepeatsAllowed": 0,
+          "expectedSupplyDuration": {
+            "unit": "days",
+            "system": "http://unitsofmeasure.org",
+            "code": "d"
+          }
+        }
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://sandbox-api.va.gov/services/fhir/v0/r4/MedicationRequest/I2-DG5EAFAS4H4RGLQ44WMVGVNYAQX5SDUMC6UAQQZJ5M3ALPPL7C7Q0000",
+      "resource": {
+        "resourceType": "MedicationRequest",
+        "id": "I2-DG5EAFAS4H4RGLQ44WMVGVNYAQX5SDUMC6UAQQZJ5M3ALPPL7C7Q0000",
+        "meta": {
+          "lastUpdated": "2020-03-23T01:43:31Z"
+        },
+        "status": "active",
+        "intent": "order",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/medicationrequest-category",
+                "code": "outpatient",
+                "display": "Outpatient"
+              }
+            ],
+            "text": "Outpatient"
+          }
+        ],
+        "medicationReference": {
+          "reference": "https://sandbox-api.va.gov/services/fhir/v0/r4/Medication/I2-KXRMLYFVSCXW4CRPQQHAOCQA2ZBKTKC5ZHK7EGBCY27OYWNELZ6Q0000",
+          "display": "MOMETASONE FUROATE 200MCG/ACTUAT INHL,ORAL,120D,13GM"
+        },
+        "subject": {
+          "reference": "https://sandbox-api.va.gov/services/fhir/v0/r4/Patient/mock1012666073V986369",
+          "display": "Mr. Jesse Gray"
+        },
+        "authoredOn": "2020-03-23T01:43:31Z",
+        "_requester": {
+          "extension": [
+            {
+              "url": "https://hl7.org/fhir/extension-data-absent-reason.html",
+              "valueCode": "unknown"
+            }
+          ]
+        },
+        "dosageInstruction": [
+          {
+            "asNeededBoolean": false,
+            "route": {
+              "text": "INHALATION"
+            }
+          }
+        ],
+        "dispenseRequest": {
+          "numberOfRepeatsAllowed": 0,
+          "expectedSupplyDuration": {
+            "value": 30,
+            "unit": "days",
+            "system": "http://unitsofmeasure.org",
+            "code": "d"
+          }
+        }
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://sandbox-api.va.gov/services/fhir/v0/r4/MedicationRequest/I2-DG5EAFAS4H4RGLQ44WMVGVNYASPOW4MMBYKCEVHPZKRMVR33KMZA0000",
+      "resource": {
+        "resourceType": "MedicationRequest",
+        "id": "I2-DG5EAFAS4H4RGLQ44WMVGVNYASPOW4MMBYKCEVHPZKRMVR33KMZA0000",
+        "meta": {
+          "lastUpdated": "2022-03-06T01:43:31Z"
+        },
+        "status": "active",
+        "intent": "order",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/medicationrequest-category",
+                "code": "outpatient",
+                "display": "Outpatient"
+              }
+            ],
+            "text": "Outpatient"
+          }
+        ],
+        "medicationReference": {
+          "reference": "https://sandbox-api.va.gov/services/fhir/v0/r4/Medication/I2-3M52HHQDA7AUNFPFDOC37I6352677IDWKV3MUBOSP5MGLNJMDG4A0000",
+          "display": "MIRTAZAPINE 15MG TAB"
+        },
+        "subject": {
+          "reference": "https://sandbox-api.va.gov/services/fhir/v0/r4/Patient/mock1012666073V986369",
+          "display": "Mr. Jesse Gray"
+        },
+        "authoredOn": "2022-03-06T01:43:31Z",
+        "_requester": {
+          "extension": [
+            {
+              "url": "https://hl7.org/fhir/extension-data-absent-reason.html",
+              "valueCode": "unknown"
+            }
+          ]
+        },
+        "dosageInstruction": [
+          {
+            "text": "TAKE ONE TABLET BY MOUTH AT BEDTIME AS NEEDED FOR SLEEP",
+            "timing": {
+              "repeat": {
+                "boundsPeriod": {
+                  "start": "2022-03-06T01:43:31Z"
+                }
+              },
+              "code": {
+                "text": "As directed by physician."
+              }
+            },
+            "asNeededBoolean": false,
+            "route": {
+              "text": "ORAL"
+            }
+          }
+        ],
+        "dispenseRequest": {
+          "numberOfRepeatsAllowed": 2,
+          "expectedSupplyDuration": {
+            "unit": "days",
+            "system": "http://unitsofmeasure.org",
+            "code": "d"
+          }
+        }
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://sandbox-api.va.gov/services/fhir/v0/r4/MedicationRequest/I2-DG5EAFAS4H4RGLQ44WMVGVNYAQNCI3CWFC3ZPLJP72VV5ISYVBPA0000",
+      "resource": {
+        "resourceType": "MedicationRequest",
+        "id": "I2-DG5EAFAS4H4RGLQ44WMVGVNYAQNCI3CWFC3ZPLJP72VV5ISYVBPA0000",
+        "meta": {
+          "lastUpdated": "2022-03-06T01:43:31Z"
+        },
+        "status": "active",
+        "intent": "order",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/medicationrequest-category",
+                "code": "outpatient",
+                "display": "Outpatient"
+              }
+            ],
+            "text": "Outpatient"
+          }
+        ],
+        "medicationReference": {
+          "reference": "https://sandbox-api.va.gov/services/fhir/v0/r4/Medication/I2-UMATUHWC7KYV4IJ6TH4WBLIQ2UTOCOXNOM6MKWRSW7RBTT4WCOYA0000",
+          "display": "SERTRALINE HCL 100MG TA"
+        },
+        "subject": {
+          "reference": "https://sandbox-api.va.gov/services/fhir/v0/r4/Patient/mock1012666073V986369",
+          "display": "Mr. Jesse Gray"
+        },
+        "authoredOn": "2022-03-06T01:43:31Z",
+        "_requester": {
+          "extension": [
+            {
+              "url": "https://hl7.org/fhir/extension-data-absent-reason.html",
+              "valueCode": "unknown"
+            }
+          ]
+        },
+        "dosageInstruction": [
+          {
+            "text": "TAKE ONE TABLET BY MOUTH DAILY FOR ANXIETY, MOOD, AND SLEEP",
+            "timing": {
+              "repeat": {
+                "boundsPeriod": {
+                  "start": "2022-03-06T01:43:31Z"
+                }
+              },
+              "code": {
+                "text": "As directed by physician."
+              }
+            },
+            "asNeededBoolean": false
+          }
+        ]
+      },
+      "search": {
+        "mode": "match"
+      }
+    }
+  ]
+}

--- a/mocks/mock-lighthouse-api/src/main/resources/mock-bundles/mock1012666073V986369/Observation.json
+++ b/mocks/mock-lighthouse-api/src/main/resources/mock-bundles/mock1012666073V986369/Observation.json
@@ -1,0 +1,793 @@
+{
+  "resourceType": "Bundle",
+  "type": "searchset",
+  "total": 9,
+  "link": [
+    {
+      "relation": "first",
+      "url": "https://sandbox-api.va.gov/services/fhir/v0/r4/Observation?code=85354-9&patient=mock1012666073V986369&_count=100&page=1"
+    },
+    {
+      "relation": "self",
+      "url": "https://sandbox-api.va.gov/services/fhir/v0/r4/Observation?code=85354-9&patient=mock1012666073V986369&_count=100&page=1"
+    },
+    {
+      "relation": "last",
+      "url": "https://sandbox-api.va.gov/services/fhir/v0/r4/Observation?code=85354-9&patient=mock1012666073V986369&_count=100&page=1"
+    }
+  ],
+  "entry": [
+    {
+      "fullUrl": "https://sandbox-api.va.gov/services/fhir/v0/r4/Observation/I2-XT5YV4HFMF5JSBV2O6SYKK2J43JWGTMUIXSLF44V6G2GCC7QEGWQ0000",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "I2-XT5YV4HFMF5JSBV2O6SYKK2J43JWGTMUIXSLF44V6G2GCC7QEGWQ0000",
+        "meta": {
+          "lastUpdated": "2021-07-20T15:08:09Z"
+        },
+        "status": "final",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "vital-signs",
+                "display": "Vital Signs"
+              }
+            ],
+            "text": "Vital Signs"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "85354-9",
+              "display": "Blood pressure systolic and diastolic"
+            }
+          ],
+          "text": "Blood pressure systolic and diastolic"
+        },
+        "subject": {
+          "reference": "https://sandbox-api.va.gov/services/fhir/v0/r4/Patient/mock1012666073V986369",
+          "display": "Mr. Jesse Gray"
+        },
+        "effectiveDateTime": "2021-06-20T15:08:09Z",
+        "issued": "2021-06-20T15:08:09Z",
+        "performer": [
+          {
+            "reference": "https://sandbox-api.va.gov/services/fhir/v0/r4/Organization/I2-IW3YK3BHOKBUACF6FQKT3V7P2T6BY6GA2JUITPGQ6WYPSYYDPC3Q0000",
+            "display": "WASHINGTON VA MEDICAL CENTER"
+          },
+          {
+            "reference": "https://sandbox-api.va.gov/services/fhir/v0/r4/Practitioner/I2-QKF4GEFVEPYZLMVPM3O6A74SWWG73P5V2VLMOWCNQJJSC6I7AFJQ0000",
+            "display": "DR. JOHN248 SMITH811 MD"
+          }
+        ],
+        "component": [
+          {
+            "code": {
+              "coding": [
+                {
+                  "system": "http://loinc.org",
+                  "code": "8480-6",
+                  "display": "Systolic blood pressure"
+                }
+              ],
+              "text": "Systolic blood pressure"
+            },
+            "valueQuantity": {
+              "value": 153.0,
+              "unit": "mm[Hg]",
+              "system": "http://unitsofmeasure.org",
+              "code": "mm[Hg]"
+            }
+          },
+          {
+            "code": {
+              "coding": [
+                {
+                  "system": "http://loinc.org",
+                  "code": "8462-4",
+                  "display": "Diastolic blood pressure"
+                }
+              ],
+              "text": "Diastolic blood pressure"
+            },
+            "valueQuantity": {
+              "value": 115.0,
+              "unit": "mm[Hg]",
+              "system": "http://unitsofmeasure.org",
+              "code": "mm[Hg]"
+            }
+          }
+        ]
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://sandbox-api.va.gov/services/fhir/v0/r4/Observation/I2-XT5YV4HFMF5JSBV2O6SYKK2J4ZGLXXLCHMCXQP2PA2X5O6EH7JRA0000",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "I2-XT5YV4HFMF5JSBV2O6SYKK2J4ZGLXXLCHMCXQP2PA2X5O6EH7JRA0000",
+        "meta": {
+          "lastUpdated": "2021-06-10T15:08:09Z"
+        },
+        "status": "final",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "vital-signs",
+                "display": "Vital Signs"
+              }
+            ],
+            "text": "Vital Signs"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "85354-9",
+              "display": "Blood pressure systolic and diastolic"
+            }
+          ],
+          "text": "Blood pressure systolic and diastolic"
+        },
+        "subject": {
+          "reference": "https://sandbox-api.va.gov/services/fhir/v0/r4/Patient/mock1012666073V986369",
+          "display": "Mr. Jesse Gray"
+        },
+        "effectiveDateTime": "2021-05-11T15:08:09Z",
+        "issued": "2021-05-11T15:08:09Z",
+        "performer": [
+          {
+            "reference": "https://sandbox-api.va.gov/services/fhir/v0/r4/Organization/I2-JD5EJVFSSEP6A6ZIEI55KCKEHLCZZPK44NSDYPMW2PGFV4A3D6FQ0000",
+            "display": "LYONS VA MEDICAL CENTER"
+          },
+          {
+            "reference": "https://sandbox-api.va.gov/services/fhir/v0/r4/Practitioner/I2-QKF4GEFVEPYZLMVPM3O6A74SWWG73P5V2VLMOWCNQJJSC6I7AFJQ0000",
+            "display": "DR. JOHN248 SMITH811 MD"
+          }
+        ],
+        "component": [
+          {
+            "code": {
+              "coding": [
+                {
+                  "system": "http://loinc.org",
+                  "code": "8480-6",
+                  "display": "Systolic blood pressure"
+                }
+              ],
+              "text": "Systolic blood pressure"
+            },
+            "valueQuantity": {
+              "value": 167.0,
+              "unit": "mm[Hg]",
+              "system": "http://unitsofmeasure.org",
+              "code": "mm[Hg]"
+            }
+          },
+          {
+            "code": {
+              "coding": [
+                {
+                  "system": "http://loinc.org",
+                  "code": "8462-4",
+                  "display": "Diastolic blood pressure"
+                }
+              ],
+              "text": "Diastolic blood pressure"
+            },
+            "valueQuantity": {
+              "value": 93.0,
+              "unit": "mm[Hg]",
+              "system": "http://unitsofmeasure.org",
+              "code": "mm[Hg]"
+            }
+          }
+        ]
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://sandbox-api.va.gov/services/fhir/v0/r4/Observation/I2-XT5YV4HFMF5JSBV2O6SYKK2J4Z4CCVGVDJH2EQRNFGN5XRM7XZXA0000",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "I2-XT5YV4HFMF5JSBV2O6SYKK2J4Z4CCVGVDJH2EQRNFGN5XRM7XZXA0000",
+        "meta": {
+          "lastUpdated": "2021-06-10T15:08:09Z"
+        },
+        "status": "final",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "vital-signs",
+                "display": "Vital Signs"
+              }
+            ],
+            "text": "Vital Signs"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "85354-9",
+              "display": "Blood pressure systolic and diastolic"
+            }
+          ],
+          "text": "Blood pressure systolic and diastolic"
+        },
+        "subject": {
+          "reference": "https://sandbox-api.va.gov/services/fhir/v0/r4/Patient/mock1012666073V986369",
+          "display": "Mr. Jesse Gray"
+        },
+        "effectiveDateTime": "2021-05-11T15:08:09Z",
+        "issued": "2021-05-11T15:08:09Z",
+        "component": [
+          {
+            "code": {
+              "coding": [
+                {
+                  "system": "http://loinc.org",
+                  "code": "8480-6",
+                  "display": "Systolic blood pressure"
+                }
+              ],
+              "text": "Systolic blood pressure"
+            },
+            "valueQuantity": {
+              "value": 167.0,
+              "unit": "mm[Hg]",
+              "system": "http://unitsofmeasure.org",
+              "code": "mm[Hg]"
+            }
+          },
+          {
+            "code": {
+              "coding": [
+                {
+                  "system": "http://loinc.org",
+                  "code": "8462-4",
+                  "display": "Diastolic blood pressure"
+                }
+              ],
+              "text": "Diastolic blood pressure"
+            },
+            "valueQuantity": {
+              "value": 93.0,
+              "unit": "mm[Hg]",
+              "system": "http://unitsofmeasure.org",
+              "code": "mm[Hg]"
+            }
+          }
+        ]
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://sandbox-api.va.gov/services/fhir/v0/r4/Observation/I2-XT5YV4HFMF5JSBV2O6SYKK2J4YRZD5J4XP7L4NBN5SLA7VKIGD7A0000",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "I2-XT5YV4HFMF5JSBV2O6SYKK2J4YRZD5J4XP7L4NBN5SLA7VKIGD7A0000",
+        "meta": {
+          "lastUpdated": "2019-05-30T15:08:09Z"
+        },
+        "status": "final",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "vital-signs",
+                "display": "Vital Signs"
+              }
+            ],
+            "text": "Vital Signs"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "85354-9",
+              "display": "Blood pressure systolic and diastolic"
+            }
+          ],
+          "text": "Blood pressure systolic and diastolic"
+        },
+        "subject": {
+          "reference": "https://sandbox-api.va.gov/services/fhir/v0/r4/Patient/mock1012666073V986369",
+          "display": "Mr. Jesse Gray"
+        },
+        "effectiveDateTime": "2019-04-30T15:08:09Z",
+        "issued": "2019-04-30T15:08:09Z",
+        "performer": [
+          {
+            "reference": "https://sandbox-api.va.gov/services/fhir/v0/r4/Organization/I2-IW3YK3BHOKBUACF6FQKT3V7P2T6BY6GA2JUITPGQ6WYPSYYDPC3Q0000",
+            "display": "WASHINGTON VA MEDICAL CENTER"
+          },
+          {
+            "reference": "https://sandbox-api.va.gov/services/fhir/v0/r4/Practitioner/I2-QKF4GEFVEPYZLMVPM3O6A74SWWG73P5V2VLMOWCNQJJSC6I7AFJQ0000",
+            "display": "DR. JOHN248 SMITH811 MD"
+          }
+        ],
+        "component": [
+          {
+            "code": {
+              "coding": [
+                {
+                  "system": "http://loinc.org",
+                  "code": "8480-6",
+                  "display": "Systolic blood pressure"
+                }
+              ],
+              "text": "Systolic blood pressure"
+            },
+            "valueQuantity": {
+              "value": 190.0,
+              "unit": "mm[Hg]",
+              "system": "http://unitsofmeasure.org",
+              "code": "mm[Hg]"
+            }
+          },
+          {
+            "code": {
+              "coding": [
+                {
+                  "system": "http://loinc.org",
+                  "code": "8462-4",
+                  "display": "Diastolic blood pressure"
+                }
+              ],
+              "text": "Diastolic blood pressure"
+            },
+            "valueQuantity": {
+              "value": 104.0,
+              "unit": "mm[Hg]",
+              "system": "http://unitsofmeasure.org",
+              "code": "mm[Hg]"
+            }
+          }
+        ]
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://sandbox-api.va.gov/services/fhir/v0/r4/Observation/I2-XT5YV4HFMF5JSBV2O6SYKK2J4YW2OIUPJ46FMYBRBBGLJS4QUTUA0000",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "I2-XT5YV4HFMF5JSBV2O6SYKK2J4YW2OIUPJ46FMYBRBBGLJS4QUTUA0000",
+        "meta": {
+          "lastUpdated": "1987-05-30T15:08:09Z"
+        },
+        "status": "final",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "vital-signs",
+                "display": "Vital Signs"
+              }
+            ],
+            "text": "Vital Signs"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "85354-9",
+              "display": "Blood pressure systolic and diastolic"
+            }
+          ],
+          "text": "Blood pressure systolic and diastolic"
+        },
+        "subject": {
+          "reference": "https://sandbox-api.va.gov/services/fhir/v0/r4/Patient/mock1012666073V986369",
+          "display": "Mr. Jesse Gray"
+        },
+        "effectiveDateTime": "1987-04-30T15:08:09Z",
+        "issued": "1987-04-30T15:08:09Z",
+        "performer": [
+          {
+            "reference": "https://sandbox-api.va.gov/services/fhir/v0/r4/Organization/I2-IW3YK3BHOKBUACF6FQKT3V7P2T6BY6GA2JUITPGQ6WYPSYYDPC3Q0000",
+            "display": "WASHINGTON VA MEDICAL CENTER"
+          },
+          {
+            "reference": "https://sandbox-api.va.gov/services/fhir/v0/r4/Practitioner/I2-QKF4GEFVEPYZLMVPM3O6A74SWWG73P5V2VLMOWCNQJJSC6I7AFJQ0000",
+            "display": "DR. JOHN248 SMITH811 MD"
+          }
+        ],
+        "component": [
+          {
+            "code": {
+              "coding": [
+                {
+                  "system": "http://loinc.org",
+                  "code": "8480-6",
+                  "display": "Systolic blood pressure"
+                }
+              ],
+              "text": "Systolic blood pressure"
+            },
+            "valueQuantity": {
+              "value": 192.0,
+              "unit": "mm[Hg]",
+              "system": "http://unitsofmeasure.org",
+              "code": "mm[Hg]"
+            }
+          },
+          {
+            "code": {
+              "coding": [
+                {
+                  "system": "http://loinc.org",
+                  "code": "8462-4",
+                  "display": "Diastolic blood pressure"
+                }
+              ],
+              "text": "Diastolic blood pressure"
+            },
+            "valueQuantity": {
+              "value": 100.0,
+              "unit": "mm[Hg]",
+              "system": "http://unitsofmeasure.org",
+              "code": "mm[Hg]"
+            }
+          }
+        ]
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://sandbox-api.va.gov/services/fhir/v0/r4/Observation/I2-XT5YV4HFMF5JSBV2O6SYKK2J4YV7WALUHYLIJ4ZWOOBHLY2QDBLA0000",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "I2-XT5YV4HFMF5JSBV2O6SYKK2J4YV7WALUHYLIJ4ZWOOBHLY2QDBLA0000",
+        "meta": {
+          "lastUpdated": "2022-08-19T15:08:09Z"
+        },
+        "status": "final",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "vital-signs",
+                "display": "Vital Signs"
+              }
+            ],
+            "text": "Vital Signs"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "85354-9",
+              "display": "Blood pressure systolic and diastolic"
+            }
+          ],
+          "text": "Blood pressure systolic and diastolic"
+        },
+        "subject": {
+          "reference": "https://sandbox-api.va.gov/services/fhir/v0/r4/Patient/mock1012666073V986369",
+          "display": "Mr. Jesse Gray"
+        },
+        "effectiveDateTime": "2022-07-20T15:08:09Z",
+        "issued": "2022-07-20T15:08:09Z",
+        "performer": [
+          {
+            "reference": "https://sandbox-api.va.gov/services/fhir/v0/r4/Organization/I2-IW3YK3BHOKBUACF6FQKT3V7P2T6BY6GA2JUITPGQ6WYPSYYDPC3Q0000",
+            "display": "WASHINGTON VA MEDICAL CENTER"
+          },
+          {
+            "reference": "https://sandbox-api.va.gov/services/fhir/v0/r4/Practitioner/I2-QKF4GEFVEPYZLMVPM3O6A74SWWG73P5V2VLMOWCNQJJSC6I7AFJQ0000",
+            "display": "DR. JOHN248 SMITH811 MD"
+          }
+        ],
+        "component": [
+          {
+            "code": {
+              "coding": [
+                {
+                  "system": "http://loinc.org",
+                  "code": "8480-6",
+                  "display": "Systolic blood pressure"
+                }
+              ],
+              "text": "Systolic blood pressure"
+            },
+            "valueQuantity": {
+              "value": 167.0,
+              "unit": "mm[Hg]",
+              "system": "http://unitsofmeasure.org",
+              "code": "mm[Hg]"
+            }
+          },
+          {
+            "code": {
+              "coding": [
+                {
+                  "system": "http://loinc.org",
+                  "code": "8462-4",
+                  "display": "Diastolic blood pressure"
+                }
+              ],
+              "text": "Diastolic blood pressure"
+            },
+            "valueQuantity": {
+              "value": 93.0,
+              "unit": "mm[Hg]",
+              "system": "http://unitsofmeasure.org",
+              "code": "mm[Hg]"
+            }
+          }
+        ]
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://sandbox-api.va.gov/services/fhir/v0/r4/Observation/I2-XT5YV4HFMF5JSBV2O6SYKK2J4Y6CHOAHYXGRUJAX3TL2BR6NBSOQ0000",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "I2-XT5YV4HFMF5JSBV2O6SYKK2J4Y6CHOAHYXGRUJAX3TL2BR6NBSOQ0000",
+        "meta": {
+          "lastUpdated": "2022-07-20T15:08:09Z"
+        },
+        "status": "final",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "vital-signs",
+                "display": "Vital Signs"
+              }
+            ],
+            "text": "Vital Signs"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "85354-9",
+              "display": "Blood pressure systolic and diastolic"
+            }
+          ],
+          "text": "Blood pressure systolic and diastolic"
+        },
+        "subject": {
+          "reference": "https://sandbox-api.va.gov/services/fhir/v0/r4/Patient/mock1012666073V986369",
+          "display": "Mr. Jesse Gray"
+        },
+        "effectiveDateTime": "2022-06-20T15:08:09Z",
+        "issued": "2022-06-20T15:08:09Z",
+        "performer": [
+          {
+            "reference": "https://sandbox-api.va.gov/services/fhir/v0/r4/Organization/I2-IW3YK3BHOKBUACF6FQKT3V7P2T6BY6GA2JUITPGQ6WYPSYYDPC3Q0000",
+            "display": "WASHINGTON VA MEDICAL CENTER"
+          },
+          {
+            "reference": "https://sandbox-api.va.gov/services/fhir/v0/r4/Practitioner/I2-QKF4GEFVEPYZLMVPM3O6A74SWWG73P5V2VLMOWCNQJJSC6I7AFJQ0000",
+            "display": "DR. JOHN248 SMITH811 MD"
+          }
+        ],
+        "component": [
+          {
+            "code": {
+              "coding": [
+                {
+                  "system": "http://loinc.org",
+                  "code": "8480-6",
+                  "display": "Systolic blood pressure"
+                }
+              ],
+              "text": "Systolic blood pressure"
+            },
+            "valueQuantity": {
+              "value": 167.0,
+              "unit": "mm[Hg]",
+              "system": "http://unitsofmeasure.org",
+              "code": "mm[Hg]"
+            }
+          },
+          {
+            "code": {
+              "coding": [
+                {
+                  "system": "http://loinc.org",
+                  "code": "8462-4",
+                  "display": "Diastolic blood pressure"
+                }
+              ],
+              "text": "Diastolic blood pressure"
+            },
+            "valueQuantity": {
+              "value": 93.0,
+              "unit": "mm[Hg]",
+              "system": "http://unitsofmeasure.org",
+              "code": "mm[Hg]"
+            }
+          }
+        ]
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://sandbox-api.va.gov/services/fhir/v0/r4/Observation/I2-XT5YV4HFMF5JSBV2O6SYKK2J437XFDXR3MBFUS7NJU4RRPI5RUDA0000",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "I2-XT5YV4HFMF5JSBV2O6SYKK2J437XFDXR3MBFUS7NJU4RRPI5RUDA0000",
+        "meta": {
+          "lastUpdated": "2022-06-19T15:08:09Z"
+        },
+        "status": "final",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "vital-signs",
+                "display": "Vital Signs"
+              }
+            ],
+            "text": "Vital Signs"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "85354-9",
+              "display": "Blood pressure systolic and diastolic"
+            }
+          ],
+          "text": "Blood pressure systolic and diastolic"
+        },
+        "subject": {
+          "reference": "https://sandbox-api.va.gov/services/fhir/v0/r4/Patient/mock1012666073V986369",
+          "display": "Mr. Jesse Gray"
+        },
+        "effectiveDateTime": "2022-05-20T15:08:09Z",
+        "issued": "2022-05-20T15:08:09Z",
+        "performer": [
+          {
+            "reference": "https://sandbox-api.va.gov/services/fhir/v0/r4/Organization/I2-IW3YK3BHOKBUACF6FQKT3V7P2T6BY6GA2JUITPGQ6WYPSYYDPC3Q0000",
+            "display": "WASHINGTON VA MEDICAL CENTER"
+          },
+          {
+            "reference": "https://sandbox-api.va.gov/services/fhir/v0/r4/Practitioner/I2-QKF4GEFVEPYZLMVPM3O6A74SWWG73P5V2VLMOWCNQJJSC6I7AFJQ0000",
+            "display": "DR. JOHN248 SMITH811 MD"
+          }
+        ],
+        "component": [
+          {
+            "code": {
+              "coding": [
+                {
+                  "system": "http://loinc.org",
+                  "code": "8480-6",
+                  "display": "Systolic blood pressure"
+                }
+              ],
+              "text": "Systolic blood pressure"
+            },
+            "valueQuantity": {
+              "value": 190.0,
+              "unit": "mm[Hg]",
+              "system": "http://unitsofmeasure.org",
+              "code": "mm[Hg]"
+            }
+          },
+          {
+            "code": {
+              "coding": [
+                {
+                  "system": "http://loinc.org",
+                  "code": "8462-4",
+                  "display": "Diastolic blood pressure"
+                }
+              ],
+              "text": "Diastolic blood pressure"
+            },
+            "valueQuantity": {
+              "value": 104.0,
+              "unit": "mm[Hg]",
+              "system": "http://unitsofmeasure.org",
+              "code": "mm[Hg]"
+            }
+          }
+        ]
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://sandbox-api.va.gov/services/fhir/v0/r4/Observation/12345",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "12345",
+        "meta": {
+          "lastUpdated": "2021-10-02T00:00:00Z"
+        },
+        "status": "final",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "vital-signs",
+                "display": "Vital Signs"
+              }
+            ],
+            "text": "Vital Signs"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "85354-9",
+              "display": "Blood pressure systolic and diastolic"
+            }
+          ],
+          "text": "Blood pressure systolic and diastolic"
+        },
+        "subject": {
+          "reference": "https://api.va.gov/services/fhir/v0/r4/Patient/999999999",
+          "display": "PATIENT, THE"
+        },
+        "effectiveDateTime": "2020-03-04T18:17:26Z",
+        "issued": "2020-08-08T15:27:47Z",
+        "performer": [
+          {
+            "reference": "https://api.va.gov/services/fhir/v0/r4/Practitioner/746637388444",
+            "display": "PRACTITIONER, PERFORMER"
+          },
+          {
+            "reference": "https://api.va.gov/services/fhir/v0/r4/Organization/985888885",
+            "display": "WASHINGTON VA MEDICAL CENTER"
+          }
+        ],
+        "dataAbsentReason": {
+          "coding": [
+            {
+              "system": "http://hl7.org/fhir/data-absent-reason",
+              "code": "unknown",
+              "display": "Unknown"
+            }
+          ],
+          "text": "Unknown"
+        }
+      },
+      "search": {
+        "mode": "match"
+      }
+    }
+  ]
+}

--- a/mocks/mock-mas-api/src/main/java/gov/va/vro/mockmas/controller/MockMasController.java
+++ b/mocks/mock-mas-api/src/main/java/gov/va/vro/mockmas/controller/MockMasController.java
@@ -56,6 +56,10 @@ public class MockMasController {
       return new ResponseEntity<>(collection, HttpStatus.OK);
     }
 
+    if (collectionId == 369) { // Used to test mas exceptions
+      throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Mas exception testing");
+    }
+
     List<MasCollectionAnnotation> collection = store.get(collectionId);
     if (collection == null) {
       String reason = "No claim found for id: " + collectionId;

--- a/service/provider/src/main/java/gov/va/vro/service/provider/camel/MasIntegrationProcessors.java
+++ b/service/provider/src/main/java/gov/va/vro/service/provider/camel/MasIntegrationProcessors.java
@@ -44,7 +44,6 @@ public class MasIntegrationProcessors {
 
   private static Function<List<Exchange>, HealthDataAssessment> combineExchangesFunction() {
     return exchanges -> {
-      log.error("I hit this code, no bueno.");
       for (Exchange exchange : exchanges) {
         if (exchange.isFailed()) {
           throw new MasException(

--- a/service/provider/src/main/java/gov/va/vro/service/provider/camel/MasIntegrationProcessors.java
+++ b/service/provider/src/main/java/gov/va/vro/service/provider/camel/MasIntegrationProcessors.java
@@ -44,6 +44,7 @@ public class MasIntegrationProcessors {
 
   private static Function<List<Exchange>, HealthDataAssessment> combineExchangesFunction() {
     return exchanges -> {
+      log.error("I hit this code, no bueno.");
       for (Exchange exchange : exchanges) {
         if (exchange.isFailed()) {
           throw new MasException(

--- a/service/provider/src/main/java/gov/va/vro/service/provider/camel/MasIntegrationRoutes.java
+++ b/service/provider/src/main/java/gov/va/vro/service/provider/camel/MasIntegrationRoutes.java
@@ -248,12 +248,17 @@ public class MasIntegrationRoutes extends RouteBuilder {
 
     String routeId = "mas-collect-evidence";
     from(ENDPOINT_COLLECT_EVIDENCE)
+        .onException(
+            MasException
+                .class) // Do not go to the main error processor. Mas complete route handles.
+        .handled(true)
+        .end() // End Exception
         .routeId(routeId)
         .wireTap(ENDPOINT_AUDIT_WIRETAP)
         .onPrepare(auditProcessor(routeId, "Collecting evidence"))
         .setProperty("payload", simple("${body}"))
         .multicast(new GroupedExchangeAggregationStrategy())
-        .stopOnException()
+        .stopOnException() // Stop does not handle the exception.
         .doTry()
         .process(
             FunctionProcessor.fromFunction(masCollectionService::collectAnnotations)) // call MAS


### PR DESCRIPTION
<!-- Ensure the PR title reflects the feature or bug name -->

## What was the problem?
User Story

As a VRO stakeholder, I want to have confidence that when claims cannot complete processing in VRO due to errors, the claims are appropriately offramped so that they will be processed manually by claim adjudicators.

Error Scenario

VRO cannot successfully retrieve annotation data via the MAS endpoint

Logs should record offramp reason: annotationDataRequestFailed

Associated tickets or Slack threads:
<!-- replace "000" with ticket number in both places -->
- [MCP-2580](https://amida.atlassian.net/browse/MCP-2580)

## How does this fix it?[^1]
We introduced error handling into the multicast of Camel for when there is no response from MAS annotations.  If there is no response from MAS annotations, we offramp the claim with the message "annotationDataRequestFailed", and do NOT continue the processing with getting LH data etc.

## How to test this PR
- Bring up containers
- test automatedClaim endpoint with collection id: 369 and benefit claim id: 1369
- verify in app container logs that we offramp the claim after not receiving MAS annotations


[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
