### PR TITLE
MCP-2649 Fixing claim metrics claimSubmissionId bug

### DIFF
--- a/service/db/src/main/java/gov/va/vro/service/db/ClaimMetricsServiceImpl.java
+++ b/service/db/src/main/java/gov/va/vro/service/db/ClaimMetricsServiceImpl.java
@@ -69,10 +69,16 @@ public class ClaimMetricsServiceImpl implements ClaimMetricsService {
     if (claimSubmission != null) {
       claim = claimSubmission.getClaim();
     }
-
     if (claim == null) {
-      log.warn("Could not find claim with the claimSubmissionId: {}", claimSubmissionId);
-      return null;
+      log.warn("Could not find claim with the claimSubmissionId: {}, retrying.", claimSubmissionId);
+      ClaimEntity claimEntity = claimRepository.findByVbmsId(claimSubmissionId).orElse(null);
+      if (claimEntity == null) {
+        log.warn(
+            "Could not find claim with claimSubmissionId: {}, return null.", claimSubmissionId);
+        return null;
+      } else {
+        return claimInfoResponseMapper.toClaimInfoResponse(claimEntity);
+      }
     }
     return claimInfoResponseMapper.toClaimInfoResponse(claim);
   }

--- a/service/db/src/main/java/gov/va/vro/service/db/mapper/ClaimInfoResponseMapper.java
+++ b/service/db/src/main/java/gov/va/vro/service/db/mapper/ClaimInfoResponseMapper.java
@@ -32,7 +32,7 @@ public interface ClaimInfoResponseMapper {
   // equal to claimSubmissionId to external systems.
   default String claimSubmissionsEntitySetToClaimSubmissionId(
       Iterable<ClaimSubmissionEntity> claimSubmissionEntities) {
-    return claimSubmissionEntities.iterator().next().getReferenceId();
+    return claimSubmissionEntities.iterator().next().getClaim().getVbmsId();
   }
 
   default String claimSubmissionsEntitySetToIdType(


### PR DESCRIPTION
<!-- Ensure the PR title reflects the feature or bug name -->

## What was the problem?
The claimSubmissionId field was being populated by the collectionId instead of the expected benefitClaimId. 

Associated tickets or Slack threads:
<!-- replace "000" with ticket number in both places -->
- [MCP-2649](https://amida.atlassian.net/browse/MCP-2649)

## How does this fix it?[^1]
benefitClaimId now populates the claimSubmissionId field.

## How to test this PR
- Step 1
- Step 2[^secrel]


[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
