### PR TITLE
Use MasProcessingObject.sufficientForFastTracking instead of Camel property

### DIFF
--- a/app/src/test/java/gov/va/vro/architecture/NamingConventionTest.java
+++ b/app/src/test/java/gov/va/vro/architecture/NamingConventionTest.java
@@ -115,7 +115,7 @@ public class NamingConventionTest {
         .or()
         .haveSimpleNameEndingWith("Response")
         .should()
-        .resideInAnyPackage("..api..", "..model..request..", "..model..response..")
+        .resideInAnyPackage("..api..", "..model..")
         .check(classes);
   }
 

--- a/service/db/src/main/java/gov/va/vro/service/db/SaveToDbServiceImpl.java
+++ b/service/db/src/main/java/gov/va/vro/service/db/SaveToDbServiceImpl.java
@@ -221,6 +221,8 @@ public class SaveToDbServiceImpl implements SaveToDbService {
         esdEntity.setFolderId(eFolderId);
         esdEntity.setUploadedAt(OffsetDateTime.now());
         evidenceSummaryDocumentRepository.save(esdEntity);
+
+        payload.setEvidenceSummaryDocumentId(esdEntity.getId());
       } else {
         log.error(
             "Could not find evidence summary document by contentionId: "

--- a/service/provider/src/main/java/gov/va/vro/service/provider/camel/MasIntegrationProcessors.java
+++ b/service/provider/src/main/java/gov/va/vro/service/provider/camel/MasIntegrationProcessors.java
@@ -160,8 +160,8 @@ public class MasIntegrationProcessors {
       BipClaimService bipClaimService, MasProcessingService masProcessingService) {
     return exchange -> {
       MasProcessingObject payload = exchange.getIn().getBody(MasProcessingObject.class);
+
       MasCamelStage origin = payload.getOrigin();
-      Boolean sufficient = exchange.getProperty("sufficientForFastTracking", Boolean.class);
       String offRampErrorPayload = payload.getOffRampReason();
 
       // Update our database with offramp reason.
@@ -170,8 +170,8 @@ public class MasIntegrationProcessors {
         exchange.setProperty("completionSlackMessage", offRampErrorPayload);
       }
       MasCompletionStatus completionStatus =
-          MasCompletionStatus.of(origin, sufficient, offRampErrorPayload);
-
+          MasCompletionStatus.of(
+              origin, payload.getSufficientForFastTracking(), offRampErrorPayload);
       try {
         BipUpdateClaimResult result = bipClaimService.updateClaim(payload, completionStatus);
         if (result.hasMessage()) {

--- a/service/provider/src/main/java/gov/va/vro/service/provider/camel/MasIntegrationRoutes.java
+++ b/service/provider/src/main/java/gov/va/vro/service/provider/camel/MasIntegrationRoutes.java
@@ -14,7 +14,6 @@ import static gov.va.vro.service.provider.camel.MasIntegrationProcessors.slackEv
 import gov.va.vro.camel.FunctionProcessor;
 import gov.va.vro.camel.RabbitMqCamelUtils;
 import gov.va.vro.camel.ToRabbitMqRouteHelper;
-import gov.va.vro.camel.processor.InOnlySyncProcessor;
 import gov.va.vro.model.AbdEvidenceWithSummary;
 import gov.va.vro.model.HealthDataAssessment;
 import gov.va.vro.model.event.AuditEvent;

--- a/service/provider/src/main/java/gov/va/vro/service/provider/mas/MasCompletionStatus.java
+++ b/service/provider/src/main/java/gov/va/vro/service/provider/mas/MasCompletionStatus.java
@@ -29,6 +29,10 @@ public enum MasCompletionStatus {
     return result;
   }
 
+  public static MasCompletionStatus of(MasProcessingObject mpo) {
+    return of(mpo.getOrigin(), mpo.getSufficientForFastTracking(), mpo.getOffRampReason());
+  }
+
   public static MasCompletionStatus of(
       MasCamelStage origin, Boolean sufficientForFastTracking, String offRampError) {
     if (origin == MasCamelStage.START_COMPLETE

--- a/service/provider/src/main/java/gov/va/vro/service/provider/mas/MasProcessingObject.java
+++ b/service/provider/src/main/java/gov/va/vro/service/provider/mas/MasProcessingObject.java
@@ -18,6 +18,8 @@ public class MasProcessingObject implements Auditable {
   private HealthDataAssessment healthDataAssessment;
   private boolean isTSOJ = false;
 
+  private Boolean sufficientForFastTracking;
+
   public int getCollectionId() {
     return claimPayload.getCollectionId();
   }

--- a/service/provider/src/main/java/gov/va/vro/service/provider/services/HealthEvidenceProcessor.java
+++ b/service/provider/src/main/java/gov/va/vro/service/provider/services/HealthEvidenceProcessor.java
@@ -32,7 +32,7 @@ public class HealthEvidenceProcessor implements Processor {
       throw new MasException("Health Assessment Failed with error:" + evidence.getErrorMessage());
     }
 
-    exchange.setProperty("sufficientForFastTracking", evidence.getSufficientForFastTracking());
+    masTransferObject.setSufficientForFastTracking(evidence.getSufficientForFastTracking());
     log.info(
         " MAS Processing >> Sufficient Evidence >>> " + evidence.getSufficientForFastTracking());
 

--- a/shared/domain/src/main/java/gov/va/vro/model/mas/MasAutomatedClaimPayload.java
+++ b/shared/domain/src/main/java/gov/va/vro/model/mas/MasAutomatedClaimPayload.java
@@ -13,6 +13,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.UUID;
 import javax.validation.Valid;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
@@ -50,6 +51,8 @@ public class MasAutomatedClaimPayload implements Auditable {
   @Builder.Default @NotNull private String idType = CLAIM_V2_ID_TYPE;
 
   @Setter private String offRampReason;
+
+  @Setter private UUID evidenceSummaryDocumentId;
 
   private List<String> veteranFlashIds;
 


### PR DESCRIPTION
<!-- Ensure the PR title reflects the feature or bug name -->
Preparing existing for new feature to add BGS notes.

## What was the problem?
<!-- brief description of how things worked before this PR -->

`MasCompletionStatus` is needed to determine which BGS notes to add to the claim.

`MasCompletionStatus.of()` requires `sufficientForFastTracking`, which is set as a Camel property. However, Camel properties are not copied over to new exchanges which are created when a Camel message is passed to a new route.

- #1341

## How does this fix it?
<!-- description of how things will work after this PR -->

Add and use `MasProcessingObject.sufficientForFastTracking` instead of a Camel property.

The new feature will also need a reference to the uploaded PDF, so add  `evidenceSummaryDocumentId` to `MasProcessingObject` as well.
