### PR TITLE
Fix svc-bgs bugs in SSL config and request payload handling

### DIFF
--- a/svc-bgs-api/src/config/bgs_initializer.rb
+++ b/svc-bgs-api/src/config/bgs_initializer.rb
@@ -20,11 +20,10 @@ BGS.configure do |config|
   # $BGS_BASE_URL also determines whether HTTPS is used.
   config.jumpbox_url = ENV["BGS_BASE_URL"]
   config.env = nil
-  config.ssl_verify_mode = "none"
   if config.jumpbox_url.downcase.start_with?("https:")
     config.ssl_cert_file = settings["ssl_cert_file"]
     config.ssl_cert_key_file = settings["ssl_cert_key_file"]
     config.ssl_ca_cert = settings["ssl_ca_cert_file"]
-    config.ssl_verify_mode = settings["ssl_verify_mode"]
+    config.ssl_verify_mode = settings["ssl_verify_mode"].presence || "none"
   end
 end

--- a/svc-bgs-api/src/config/bgs_initializer.rb
+++ b/svc-bgs-api/src/config/bgs_initializer.rb
@@ -20,6 +20,7 @@ BGS.configure do |config|
   # $BGS_BASE_URL also determines whether HTTPS is used.
   config.jumpbox_url = ENV["BGS_BASE_URL"]
   config.env = nil
+  config.ssl_verify_mode = "none"
   if config.jumpbox_url.downcase.start_with?("https:")
     config.ssl_cert_file = settings["ssl_cert_file"]
     config.ssl_cert_key_file = settings["ssl_cert_key_file"]

--- a/svc-bgs-api/src/lib/bgs_client.rb
+++ b/svc-bgs-api/src/lib/bgs_client.rb
@@ -44,7 +44,7 @@ class BgsClient
 
   def handle_request(req)
     claim_id = req["vbmsClaimId"]
-    if req.has_key?("claimNotes")
+    if req.has_key?("claimNotes") && req["claimNotes"].any?
       raise ArgumentError.new("vbmsClaimId is required for claimNotes") unless claim_id
 
       create_claim_notes(claim_id: claim_id, notes: req["claimNotes"])

--- a/svc-bgs-api/src/spec/bgs_client_spec.rb
+++ b/svc-bgs-api/src/spec/bgs_client_spec.rb
@@ -13,7 +13,7 @@ describe BgsClient do
     subject { client.handle_request(req) }
 
     context "when given claimNotes but no vbmsClaimId" do
-      let(:req) { { "claimNotes" => [] } }
+      let(:req) { { "claimNotes" => ["a claim note"] } }
 
       it "raises an ArgumentError" do
         expect { subject }.to raise_error(ArgumentError, /vbmsClaimId is required/)
@@ -60,6 +60,17 @@ describe BgsClient do
         expect(notes_service).to have_received(:create_note).with(
           { participant_id: "2222", txt: "another note", user_id: "12345" }
         )
+      end
+
+      context "when given empty claimNotes and non-null veteranNote" do
+        let(:req) { { "claimNotes": [], "veteranParticipantId" => "2222", "veteranNote" => "another note" } }
+
+        it "interprets the request as a veteranNote accordingly" do
+          subject
+          expect(notes_service).to have_received(:create_note).with(
+            { participant_id: "2222", txt: "another note", user_id: "12345" }
+          )
+        end
       end
     end
   end


### PR DESCRIPTION
## What was the problem?
This PR fixes two bugs:
- When SSL is turned on via `jumpbox_url`, but no `ssl_verify_mode` is provided, the BGS client breaks on a `nil.to_sym` exception. It should be defaulted to `none`.
- When the request payload contains an empty claimNotes array, it should be treated as not having a claimNotes key (and defer to veteranNote if given)

Due to urgency, these two unrelated bugs are being addressed in one PR.

Associated tickets or Slack threads:
[Slack thread](https://dsva.slack.com/archives/C04QLHM9LR0/p1681232214379849)

## How to test this PR
- The new SSL config code was patched in-place in prodtest, and confirmed to work
- Tests have been updated to match the new request payload behavior. `bundle exec rspec spec/bgs_client_spec.rb`
