### PR TITLE
Remove VALIDATE_TOKEN env variable

### DIFF
--- a/app/src/docker/docker-compose.yml
+++ b/app/src/docker/docker-compose.yml
@@ -28,7 +28,6 @@ x-mas-vars: &mas-vars
   LH_API_AUTH_URL: ${LH_API_AUTH_URL}
   VRO_AUD_URL: ${VRO_AUD_URL}
   LH_VRO_API_KEY: ${LH_VRO_API_KEY}
-  VALIDATE_TOKEN: ${VALIDATE_TOKEN}
 
 x-postgres-vars: &postgres-vars
   POSTGRES_URL: jdbc:postgresql://postgres-service:5432/vro

--- a/app/src/main/resources/application-prod-test.yml
+++ b/app/src/main/resources/application-prod-test.yml
@@ -1,4 +1,4 @@
-# This file is used when ENV=prod
+# This file is used when ENV=prod-test
 # Contrast this file against application-nonprod.yml
 #
 # File application-k8s.yml will also be loaded due to the spring.profiles.group configuration in application.yml

--- a/app/src/main/resources/application.yml
+++ b/app/src/main/resources/application.yml
@@ -105,6 +105,7 @@ spring:
       sandbox: nonprod,k8s
       # For prod, only load application-prod.yml and application-k8s.yml
       prod: k8s
+      # For prod-test, only load application-prod-test.yml and application-k8s.yml
       prod-test: k8s
 
   servlet:
@@ -159,7 +160,7 @@ lhAPIProvider:
   tokenValidatorURL: "${LH_API_AUTH_URL:placeholderUrl}"
   vroAudURL: "${VRO_AUD_URL:placeholderUrl}"
   apiKey: "${LH_VRO_API_KEY:placeholderKey}"
-  validateToken: "${VALIDATE_TOKEN:NO}"
+  validateToken: "NO"
 
 masVeteranFlashIds:
   agentOrange: "${MAS_FLASH_IDS_AGENT_ORANGE:Agent Orange Exposure Verified,266}"

--- a/helm/charts/vro-app/templates/deployment.yaml
+++ b/helm/charts/vro-app/templates/deployment.yaml
@@ -102,9 +102,6 @@ spec:
               value: {{ .Values.lhApiAuthUrl }}
             - name: VRO_AUD_URL
               value: {{ .Values.vroAudUrl }}
-            - name: VALIDATE_TOKEN
-              # Must quote, otherwise YAML interprets 'NO' as a boolean false
-              value: {{ .Values.validateToken | quote }}
 
             - name: VRO_SECRETS_MAS
               valueFrom:

--- a/helm/charts/vro-app/values.yaml
+++ b/helm/charts/vro-app/values.yaml
@@ -39,5 +39,4 @@ readinessProbe:
 #   maxReplicas: 100
 #   targetCPUUtilizationPercentage: 80
 
-validateToken: "NO"
 vroAudUrl: https://sandbox-api.va.gov/services/abd-vro

--- a/helm/values-for-sandbox.yaml
+++ b/helm/values-for-sandbox.yaml
@@ -11,7 +11,6 @@ global:
     bipEvidenceUrl: vefs-claimevidence-uat.stage8.bip.va.gov/api/v1/rest
 
 vro-app-chart:
-  validateToken: "YES"
   vroAudUrl: https://sandbox-api.va.gov/services/abd-vro
 
 vro-svcs-chart:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -78,26 +78,16 @@ global:
       targetPort: 6379
 
   bip:
+    # TODO: Consider moving these URL settings to application-*.yml files
     bipClaimUrl: claims-uat.stage8.bip.va.gov/api/v1
     bipEvidenceUrl: vefs-claimevidence-uat.stage8.bip.va.gov/api/v1/rest
 
   mas:
+    # TODO: Consider moving these URL settings to application-*.yml files
     masApiAuthTokenUri: https://viccs-api-dev.ibm-intelligent-automation.com/pca/api/dev/token
     masApiBaseUrl: https://viccs-api-dev.ibm-intelligent-automation.com/pca/api/dev
 
 vro-app-chart:
-  # Must quote, otherwise YAML interprets 'NO' as a boolean false
-  validateToken: "NO"
+  # TODO: Consider moving these URL settings to application-*.yml files
   vroAudUrl: https://sandbox-api.va.gov/services/abd-vro
   lhApiAuthUrl: https://sandbox-api.va.gov/internal/auth/v2/validation
-
-#  dbinit:
-#    secretKeyRef:
-#      name: dbinit
-#      # DB super user
-#      superUsernameKey: superUsername
-#      superPasswordKey: superPassword
-#      # DB admin user; for Flyway to do DB migrations
-#      # used as POSTGRES_FLYWAY_USER (in pg-isready container) and FLYWAY_USER (in the postgres and dbinit containers)
-#      usernameKey: username
-#      passwordKey: password


### PR DESCRIPTION
<!-- Ensure the PR title reflects the feature or bug name -->

## What was the problem?
<!-- brief description of how things worked before this PR -->

`VALIDATE_TOKEN` env variable isn't needed -- we don't need to change it manually in deployment environments. This setting can be set in `application-*.yml` files instead. 
This reduces DevOps maintenance of Helm configurations.

## How does this fix it?
Removes `VALIDATE_TOKEN` env variable

Also added TODOs for consideration to do the same for URLs that don't need to be manually changed in deployment environments.

Also a fix: renamed `application-prodtest.yml` to `application-prod-test.yml` since Spring loads `application-$ENV.yml` and `ENV` can be `prod-test` (not `prodtest`).