### PR TITLE
Fix BGS URL for prodtest

### DIFF
--- a/helm/values-for-prod-test.yaml
+++ b/helm/values-for-prod-test.yaml
@@ -20,5 +20,4 @@ vro-app-chart:
 
 vro-svcs-chart:
   bgs:
-    baseUrl: https://bepprep.vba.va.gov
-
+    baseUrl: https://bepprodtest.vba.va.gov


### PR DESCRIPTION
## What was the problem?
The BGS URL for prodtest was incorrectly set to BGS preprod. This PR updates it to the correct value.

## Associated tickets or Slack threads:
[Slack thread](https://dsva.slack.com/archives/C01Q7979Z7D/p1681396489272919?thread_ts=1681319396.085089&cid=C01Q7979Z7D)