### PR TITLE
sql script to find test patients

### DIFF
--- a/cdw-scripts/presumptive-exam-cases.sql
+++ b/cdw-scripts/presumptive-exam-cases.sql
@@ -1,0 +1,26 @@
+-- This finds a test patient for presumptive exam ordering case.
+-- Patient will have an encounter diagnosis "I10." (ICD10) last year and
+-- single blood pressure last year as well.
+WITH Measurements (PatientSID, Diastolic, Systolic) AS (
+	SELECT PatientSID, Diastolic, Systolic
+	FROM CDWWork.Vital.VitalSign
+	WHERE Systolic IS NOT NULL AND Diastolic is NOT NULL AND VitalSignTakenDateTime > '2022-04-10'
+), ICNMeasurement (PatientICN, PatientSID, PatientSSN, Diastolic, Systolic, Cnt) AS (
+	SELECT p.PatientICN, p.PatientSID, p.PatientSSN, v.Diastolic, v.Systolic,
+	COUNT(1) OVER (PARTITION BY p.PatientICN)
+	FROM Measurements v
+	INNER JOIN CDWWork.SPatient.SPatient p ON p.PatientSID = v.PatientSID
+), SIDs (PatientSID, PatientSSN) AS (
+	SELECT DISTINCT PatientSID, PatientSSN FROM ICNMeasurement WHERE Cnt = 1
+), Dxs (ICD10SID) AS (
+	SELECT ICD10SID
+	FROM CDWWork.Dim.ICD10
+	WHERE ICD10Code = 'I10.'
+)
+SELECT s.PatientSID, s.PatientSSN
+FROM CDWWork.Outpat.Visit v
+INNER JOIN SIDs s ON s.PatientSID = v.PatientSID
+INNER JOIN CDWWork.Outpat.VDiagnosis dx ON dx.VisitSID = v.VisitSID AND
+    ICD10SID IN (SELECT ICD10SID FROM Dxs) AND dx.PrimarySecondary = 'P'
+WHERE v.EncounterDateTime >= '2022-04-20'
+ORDER BY s.PatientSSN


### PR DESCRIPTION
<!-- Ensure the PR title reflects the feature or bug name -->

## What was the problem?
<!-- brief description of how things worked before this PR -->

We needed to find a patient as a test case for presumptive exam ordering.

Associated tickets or Slack threads:
<!-- replace "000" with ticket number in both places -->
- [MCP-000](https://amida.atlassian.net/browse/MCP-000)

## How does this fix it?[^1]
<!-- description of how things will work after this PR -->

The attached script can be run to find such patients after playing with constants. The patients found by this script already served as presumptive test cases.

## How to test this PR
- Step 1
- Step 2[^secrel]


[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
