### PR TITLE
Fix prod-test logging level to INFO

### DIFF
--- a/app/src/main/resources/application-prod-test.yml
+++ b/app/src/main/resources/application-prod-test.yml
@@ -26,4 +26,4 @@ lhAPIProvider:
 
 logging:
   level:
-    root: DEBUG
+    root: INFO


### PR DESCRIPTION
Quickfix to change `application-prod-test.yml` logging level from DEBUG to INFO.