### PR TITLE
add test case for value missing for diastolic and systolic

### DIFF
--- a/app/src/end2endTest/java/gov/va/vro/end2end/VroV2Tests.java
+++ b/app/src/end2endTest/java/gov/va/vro/end2end/VroV2Tests.java
@@ -829,6 +829,9 @@ public class VroV2Tests {
     // Check for evidence from mock LH API.
     assertTrue(pdfText.contains("190/-"));
     assertTrue(pdfText.contains("-/93"));
+    // Check for evidence from mock LH API. These are missing value examples.
+    assertTrue(pdfText.contains("177/-"));
+    assertTrue(pdfText.contains("-/88"));
 
     // Check that BP with missing systolic and diastolic is not included as evidence.
     assertFalse(pdfText.contains("-/-"));

--- a/mocks/mock-lighthouse-api/src/main/resources/mock-bundles/mock1012666073V986380/Observation.json
+++ b/mocks/mock-lighthouse-api/src/main/resources/mock-bundles/mock1012666073V986380/Observation.json
@@ -1,7 +1,7 @@
 {
   "resourceType": "Bundle",
   "type": "searchset",
-  "total": 10,
+  "total": 12,
   "link": [
     {
       "relation": "first",
@@ -879,6 +879,184 @@
                 }
               ],
               "text": "Unknown"
+            }
+          }
+        ]
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://sandbox-api.va.gov/services/fhir/v0/r4/Observation/I2-XT5YV4HFDDEDDD",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "I2-XT5YV4HFMF5JSBV2O6SYKK2J43JWGTMUIXSLF44V6G2GCC7QEGWQ0000",
+        "meta": {
+          "lastUpdated": "2021-07-20T15:08:09Z"
+        },
+        "status": "final",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "vital-signs",
+                "display": "Vital Signs"
+              }
+            ],
+            "text": "Vital Signs"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "85354-9",
+              "display": "Blood pressure systolic and diastolic"
+            }
+          ],
+          "text": "Blood pressure systolic and diastolic"
+        },
+        "subject": {
+          "reference": "https://sandbox-api.va.gov/services/fhir/v0/r4/Patient/mock1012666073V986297",
+          "display": "Mr. Jesse Gray"
+        },
+        "effectiveDateTime": "2021-06-20T15:08:09Z",
+        "issued": "2021-06-20T15:08:09Z",
+        "performer": [
+          {
+            "reference": "https://sandbox-api.va.gov/services/fhir/v0/r4/Organization/I2-IW3YK3BHOKBUACF6FQKT3V7P2T6BY6GA2JUITPGQ6WYPSYYDPC3Q0000",
+            "display": "WASHINGTON VA MEDICAL CENTER"
+          },
+          {
+            "reference": "https://sandbox-api.va.gov/services/fhir/v0/r4/Practitioner/I2-QKF4GEFVEPYZLMVPM3O6A74SWWG73P5V2VLMOWCNQJJSC6I7AFJQ0000",
+            "display": "DR. JOHN248 SMITH811 MD"
+          }
+        ],
+        "component": [
+          {
+            "code": {
+              "coding": [
+                {
+                  "system": "http://loinc.org",
+                  "code": "8480-6",
+                  "display": "Systolic blood pressure"
+                }
+              ],
+              "text": "Systolic blood pressure"
+            },
+            "valueQuantity": {
+              "value": 177.0,
+              "unit": "mm[Hg]",
+              "system": "http://unitsofmeasure.org",
+              "code": "mm[Hg]"
+            }
+          },
+          {
+            "code": {
+              "coding": [
+                {
+                  "system": "http://loinc.org",
+                  "code": "8462-4",
+                  "display": "Diastolic blood pressure"
+                }
+              ],
+              "text": "Diastolic blood pressure"
+            },
+            "valueQuantity": {
+              "unit": "mm[Hg]",
+              "system": "http://unitsofmeasure.org",
+              "code": "mm[Hg]"
+            }
+          }
+        ]
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://sandbox-api.va.gov/services/fhir/v0/r4/Observation/I2-XSED44V6G2GCC7QEGWQ0000",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "I2-XT5YV4HFMF5JSBV2O6SYKK2J43JWGTMUIXSLF44V6G2GCC7QEGWQ0000",
+        "meta": {
+          "lastUpdated": "2021-07-20T15:08:09Z"
+        },
+        "status": "final",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "vital-signs",
+                "display": "Vital Signs"
+              }
+            ],
+            "text": "Vital Signs"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "85354-9",
+              "display": "Blood pressure systolic and diastolic"
+            }
+          ],
+          "text": "Blood pressure systolic and diastolic"
+        },
+        "subject": {
+          "reference": "https://sandbox-api.va.gov/services/fhir/v0/r4/Patient/mock1012666073V986297",
+          "display": "Mr. Jesse Gray"
+        },
+        "effectiveDateTime": "2021-06-20T15:08:09Z",
+        "issued": "2021-06-20T15:08:09Z",
+        "performer": [
+          {
+            "reference": "https://sandbox-api.va.gov/services/fhir/v0/r4/Organization/I2-IW3YK3BHOKBUACF6FQKT3V7P2T6BY6GA2JUITPGQ6WYPSYYDPC3Q0000",
+            "display": "WASHINGTON VA MEDICAL CENTER"
+          },
+          {
+            "reference": "https://sandbox-api.va.gov/services/fhir/v0/r4/Practitioner/I2-QKF4GEFVEPYZLMVPM3O6A74SWWG73P5V2VLMOWCNQJJSC6I7AFJQ0000",
+            "display": "DR. JOHN248 SMITH811 MD"
+          }
+        ],
+        "component": [
+          {
+            "code": {
+              "coding": [
+                {
+                  "system": "http://loinc.org",
+                  "code": "8480-6",
+                  "display": "Systolic blood pressure"
+                }
+              ],
+              "text": "Systolic blood pressure"
+            },
+            "valueQuantity": {
+              "unit": "mm[Hg]",
+              "system": "http://unitsofmeasure.org",
+              "code": "mm[Hg]"
+            }
+          },
+          {
+            "code": {
+              "coding": [
+                {
+                  "system": "http://loinc.org",
+                  "code": "8462-4",
+                  "display": "Diastolic blood pressure"
+                }
+              ],
+              "text": "Diastolic blood pressure"
+            },
+            "valueQuantity": {
+              "value": 88,
+              "unit": "mm[Hg]",
+              "system": "http://unitsofmeasure.org",
+              "code": "mm[Hg]"
             }
           }
         ]


### PR DESCRIPTION
<!-- Ensure the PR title reflects the feature or bug name -->

## What was the problem?
<!-- brief description of how things worked before this PR -->

No test when only value field in diastolic or systolic record in FHIR/

Associated tickets or Slack threads:
<!-- replace "000" with ticket number in both places -->
- [MCP-000](https://amida.atlassian.net/browse/MCP-000)

## How does this fix it?[^1]
<!-- description of how things will work after this PR -->

Adds these cases to an existing end to end test.

## How to test this PR
- Step 1
- Step 2[^secrel]


[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
