### PR TITLE
Handle unexpected assessment exceptions gracefully

### DIFF
--- a/domain-rrd/rrd-shared/src/main/java/gov/va/vro/model/rrd/event/EventReason.java
+++ b/domain-rrd/rrd-shared/src/main/java/gov/va/vro/model/rrd/event/EventReason.java
@@ -18,7 +18,8 @@ public enum EventReason {
   PDF_UPLOAD_FAILED_AFTER_RFD("docUploadFailedRfd", "Failed to upload PDF file."),
   EXAM_ORDER_FAILED("examOrderFailed", "Failed to order exam."),
   ANNOTATIONS_FAILED("annotationDataRequestFailed", "Failed to get annotation data."),
-  BIP_UPDATE_FAILED("bipUpdateFailed", "BIP update failed.");
+  BIP_UPDATE_FAILED("bipUpdateFailed", "BIP update failed."),
+  HEALTH_PROCESSOR_FAILED("healthProcessFailed", "Processing health data failed.");
 
   private static int MAX_CODE_LENGTH = 50;
 

--- a/domain-rrd/rrd-workflows/src/main/java/gov/va/vro/service/provider/camel/MasIntegrationRoutes.java
+++ b/domain-rrd/rrd-workflows/src/main/java/gov/va/vro/service/provider/camel/MasIntegrationRoutes.java
@@ -179,9 +179,7 @@ public class MasIntegrationRoutes extends RouteBuilder {
         .process(masAssessmentResultProcessor)
         .choice()
         .when(simple("${body.errorMessage} != null"))
-        .log(
-            "Health Assessment Processing failed. Off-ramping claim"
-                + simple("${body.errorMessage}"))
+        .log("Health Assessment Processing failed. Off-ramping claim ${body.errorMessage}")
         // Completion code needs the MasProcessingObject as the body.
         .setBody(simple("${exchangeProperty.payload}"))
         .process(setOffRampReasonProcessor(EventReason.HEALTH_PROCESSOR_FAILED.getCode()))

--- a/domain-rrd/rrd-workflows/src/main/java/gov/va/vro/service/provider/services/HealthEvidenceProcessor.java
+++ b/domain-rrd/rrd-workflows/src/main/java/gov/va/vro/service/provider/services/HealthEvidenceProcessor.java
@@ -3,7 +3,6 @@ package gov.va.vro.service.provider.services;
 import gov.va.vro.model.rrd.AbdEvidence;
 import gov.va.vro.model.rrd.AbdEvidenceWithSummary;
 import gov.va.vro.model.rrd.ServiceLocation;
-import gov.va.vro.service.provider.mas.MasException;
 import gov.va.vro.service.provider.mas.MasProcessingObject;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.camel.Exchange;
@@ -25,12 +24,6 @@ public class HealthEvidenceProcessor implements Processor {
         (List<String>) exchange.getProperty("docsWoutAnnotsChecked");
 
     AbdEvidenceWithSummary evidence = exchange.getMessage().getBody(AbdEvidenceWithSummary.class);
-
-    String evidenceError = evidence.getErrorMessage();
-    if (evidenceError != null) {
-      log.error("Health Assessment Failed");
-      throw new MasException("Health Assessment Failed with error:" + evidence.getErrorMessage());
-    }
 
     masTransferObject.setSufficientForFastTracking(evidence.getSufficientForFastTracking());
     log.info(


### PR DESCRIPTION
## What was the problem?
In the event something goes wrong in the python processing, the java code could previously throw an error that was not handled gracefully and left the claim in a stuck state.
The errors that revealed this have since been fixed upstream, but this closes a potential hole in the code. 

Associated tickets or Slack threads:
- [MCP-2805](https://amida.atlassian.net/browse/MCP-2805)

## How does this fix it?
If an error happens after evidence is collected instead of throwing the exception, we offramp the claim with a new event reason. This is an unlikely scenario but, could happen. 

## How to test this PR
Testing this PR is something of a challenge as all known ways to cause the problem are currently fixed in the code. 
The JIRA ticket linked contains a file that can be replaced in svc-lighthouse to forcibly cause the error for testAutomatedClaimFullPositiveIncompleteBloodPressures in the VROV2EndToEndTests - which logs from the app module can then be used to verify. 

