### PR TITLE
 Update hostnames for BIP Claims API and Claim Evidence

### DIFF
--- a/helm/values-for-prod-test.yaml
+++ b/helm/values-for-prod-test.yaml
@@ -3,12 +3,11 @@ global:
   environment: prod-test
   endpoint: prod-test.lighthouse.va.gov
   lhdiCluster: prod
-
   imagePrefix: ""
 
   bip:
-    bipClaimUrl: claims-prodtest.prod8.bip.va.gov/api/v1
-    bipEvidenceUrl: vefs-claimevidence-prodtest.prod8.bip.va.gov/api/v1/rest
+    bipClaimUrl: claims-prodtest.prod.bip.va.gov/api/v1
+    bipEvidenceUrl: vefs-claimevidence-prodtest.prod.bip.va.gov/api/v1/rest
 
   mas:
     masApiAuthTokenUri: https://viccs-api-test.ibm-intelligent-automation.com/pca/api/test/token

--- a/helm/values-for-prod-test.yaml
+++ b/helm/values-for-prod-test.yaml
@@ -3,6 +3,7 @@ global:
   environment: prod-test
   endpoint: prod-test.lighthouse.va.gov
   lhdiCluster: prod
+
   imagePrefix: ""
 
   bip:

--- a/helm/values-for-prod.yaml
+++ b/helm/values-for-prod.yaml
@@ -3,6 +3,7 @@ global:
   environment: prod
   endpoint: api.lighthouse.va.gov
   lhdiCluster: prod
+
   imagePrefix: ""
 
   bip:

--- a/helm/values-for-prod.yaml
+++ b/helm/values-for-prod.yaml
@@ -3,12 +3,11 @@ global:
   environment: prod
   endpoint: api.lighthouse.va.gov
   lhdiCluster: prod
-
   imagePrefix: ""
 
   bip:
-    bipClaimUrl: claims-prod.prod8.bip.va.gov/api/v1
-    bipEvidenceUrl: vefs-claimevidence.prod8.bip.va.gov/api/v1/rest
+    bipClaimUrl: claims-prod.prod.bip.va.gov/api/v1
+    bipEvidenceUrl: vefs-claimevidence.prod.bip.va.gov/api/v1/rest
 
   mas:
     masApiAuthTokenUri: https://viccs-api-prod.ibm-intelligent-automation.com/pca/api/prod/token

--- a/helm/values-for-qa.yaml
+++ b/helm/values-for-qa.yaml
@@ -5,5 +5,5 @@ global:
   lhdiCluster: nonprod
 
   bip:
-    bipClaimUrl: claims-uat.stage8.bip.va.gov/api/v1
-    bipEvidenceUrl: vefs-claimevidence-dev.dev8.bip.va.gov/api/v1/rest/
+    bipClaimUrl: claims-uat.stage.bip.va.gov/api/v1
+    bipEvidenceUrl: vefs-claimevidence-uat.stage.bip.va.gov/api/v1/rest/

--- a/helm/values-for-sandbox.yaml
+++ b/helm/values-for-sandbox.yaml
@@ -3,12 +3,11 @@ global:
   environment: sandbox
   endpoint: sandbox.lighthouse.va.gov
   lhdiCluster: nonprod
-
   imagePrefix: ""
 
   bip:
-    bipClaimUrl: claims-uat.stage8.bip.va.gov/api/v1
-    bipEvidenceUrl: vefs-claimevidence-uat.stage8.bip.va.gov/api/v1/rest
+    bipClaimUrl: claims-uat.stage.bip.va.gov/api/v1
+    bipEvidenceUrl: vefs-claimevidence-uat.stage.bip.va.gov/api/v1/rest
 
 vro-app-chart:
   vroAudUrl: https://sandbox-api.va.gov/services/abd-vro

--- a/helm/values-for-sandbox.yaml
+++ b/helm/values-for-sandbox.yaml
@@ -3,6 +3,7 @@ global:
   environment: sandbox
   endpoint: sandbox.lighthouse.va.gov
   lhdiCluster: nonprod
+
   imagePrefix: ""
 
   bip:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -28,6 +28,7 @@ global:
 
   serviceUriPrefix: abd-vro
 
+
   hostnamePrefix: vro
 
   images:
@@ -79,8 +80,8 @@ global:
 
   bip:
     # TODO: Consider moving these URL settings to application-*.yml files
-    bipClaimUrl: claims-uat.stage8.bip.va.gov/api/v1
-    bipEvidenceUrl: vefs-claimevidence-uat.stage8.bip.va.gov/api/v1/rest
+    bipClaimUrl: claims-uat.stage.bip.va.gov/api/v1
+    bipEvidenceUrl: vefs-claimevidence-uat.stage.bip.va.gov/api/v1/rest
 
   mas:
     # TODO: Consider moving these URL settings to application-*.yml files


### PR DESCRIPTION
https://github.com/department-of-veterans-affairs/abd-vro/issues/1488
Update VRO configurations to point to the BIP APIs’ new EKS hostnames 
VRO is updated to point to the new hostnames for the BIP Claims API and Claim Evidence API  so that VRO avoids any issues connecting to these services.


## What was the problem?
VRO is updated to point to the new hostnames for the BIP Claims API and Claim Evidence API  so that VRO avoids any issues 
Updated changes in HELM Configuration

- [1488](https://github.com/department-of-veterans-affairs/abd-vro/issues/1488)

## How does this fix it?
Updating Values.yaml to reflect new VRO configurations for BIP Claims  and  BIP Evidence URLs

