### PR TITLE
CC: add servers dropdown for FastAPI swagger docs

### DIFF
--- a/domain-cc/svc-cc-app/src/api.py
+++ b/domain-cc/svc-cc-app/src/api.py
@@ -4,7 +4,14 @@ from typing import Optional
 from fastapi import FastAPI
 from pydantic_models import ClaimForIncrease, PredictedClassification
 
-app = FastAPI()
+app = FastAPI(
+    servers=[
+        {
+            "url": "/contention-classification",
+            "description": "Contention Classification Default",
+        },
+    ]
+)
 
 logging.basicConfig(
     format="[%(asctime)s] %(levelname)-8s %(message)s",


### PR DESCRIPTION
<!-- Ensure the PR title reflects the feature or bug name -->

## What was the problem?
<!-- brief description of how things worked before this PR -->
Servers dropdown - [link](https://dsva.slack.com/archives/C04QLHM9LR0/p1684336373482229)

Associated tickets or Slack threads:
<!-- replace "000" with ticket number in both places -->
- n/a

## How does this fix it?[^1]
<!-- description of how things will work after this PR -->
http://localhost:18000/docs:
<img width="839" alt="Screenshot 2023-05-22 at 12 36 21 PM" src="https://github.com/department-of-veterans-affairs/abd-vro/assets/17188013/d4a24bf0-2845-48d6-9ecc-d4b0ba4fbef6">



## How to test this PR
- Run the Contention Classification python code w/ instructions per domain-cc's [README.md
](https://github.com/department-of-veterans-affairs/abd-vro/blob/develop/domain-cc/README.md)
- Navigate to localhost:18000/docs in browser
- Observer /contention-classification listed in Servers dropdown at the top of the page


[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
