### PR TITLE
add atomic flag to helm upgrade

### DIFF
--- a/.github/workflows/update-deployment.yml
+++ b/.github/workflows/update-deployment.yml
@@ -251,7 +251,8 @@ jobs:
             --set vro-app.enabled=${{ inputs.vro-app }} \
             --set vro-svcs.enabled=${{ inputs.vro-svcs }} \
             --set postgres.enabled=${{ inputs.postgres }} \
-            --set console.enabled=${{ inputs.console }}
+            --set console.enabled=${{ inputs.console }} \
+            --atomic
           echo "::endgroup::"
 
           echo "==================================="


### PR DESCRIPTION
<!-- Ensure the PR title reflects the feature or bug name -->

## What was the problem?
<!-- brief description of how things worked before this PR -->
If an error occurs during the runtime of the `helm upgrade` command, the deployment could become stuck and require a manual intervention on the K8s cluster.

Associated tickets or Slack threads:
<!-- replace "000" with ticket number in both places -->
- No ticket for this because fix was faster than ticket writing

## How does this fix it?[^1]
<!-- description of how things will work after this PR -->
Adds the atomic flag to the helm upgrade command in the `update-deployment` GH Action. This will make it so that if any error occurs, the helm deployment process will be rolled back to its previous state prior to the issuance of the `helm upgrade` command.

## How to test this PR
- perform deployment to any environment
- Step 2[^secrel]


[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
