### PR TITLE
Remove library versions from Dockerfile

### DIFF
--- a/db-init/src/docker/Dockerfile
+++ b/db-init/src/docker/Dockerfile
@@ -1,7 +1,7 @@
 FROM flyway/flyway:9.17-alpine
 
 # hadolint ignore=DL3018
-RUN apk update && apk --no-cache add libcrypto3=3.0.8-r4 libssl3=3.0.8-r4 openssl=3.0.8-r4  && rm -rf /var/cache/apk/*
+RUN apk update && apk --no-cache add libcrypto3 libssl3 openssl  && rm -rf /var/cache/apk/*
 
 
 COPY database /flyway/sql


### PR DESCRIPTION
<!-- Ensure the PR title reflects the feature or bug name -->

## What was the problem?
<!-- brief description of how things worked before this PR -->
Failed SecRel run: https://github.com/department-of-veterans-affairs/abd-vro-internal/actions/runs/5124989121/jobs/9217564520

Version numbers for libraries in Dockerfile were causing image publishing errors during SecRel workflow

## How does this fix it?[^1]
<!-- description of how things will work after this PR -->
Removes the version numbers from the Dockerfile's libraries

## How to test this PR
- Run secrel manually [^secrel]


[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
