### PR TITLE
Do not perform Jacoco Coverage Comment for Dependabot

### DIFF
--- a/.github/workflows/test-code.yml
+++ b/.github/workflows/test-code.yml
@@ -82,7 +82,7 @@ jobs:
           fail_below_threshold: false
           publish_only_summary: false
       - name: "Add JaCoCo Coverage Report as PR comment"
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
         uses: madrapps/jacoco-report@v1.3
         with:
           paths: ${{ github.workspace }}/build/reports/jacoco/jacocoAggregatedReport/jacocoAggregatedReport.xml


### PR DESCRIPTION
<!-- Ensure the PR title reflects the feature or bug name -->

## What was the problem?
<!-- brief description of how things worked before this PR -->
Seeing failed testing actions because of what seems like a permissions error for dependabot integration when trying to comment
https://github.com/department-of-veterans-affairs/abd-vro/actions/runs/5136602057/jobs/9243741358?pr=1584

Associated tickets or Slack threads:
<!-- replace "000" with ticket number in both places -->
https://github.com/department-of-veterans-affairs/abd-vro/issues/1580

## How does this fix it?[^1]
<!-- description of how things will work after this PR -->
Skips the commenting test coverage step if the author is dependabot 

[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
