### PR TITLE
Upgrade OpenSSL and Postgres for Secrel

### DIFF
--- a/.github/secrel/config.yml
+++ b/.github/secrel/config.yml
@@ -9,6 +9,6 @@ languages:
       # Snyk does its own build to run SCA, so it needs the token to pull private artifacts
       - -PGITHUB_ACCESS_TOKEN=${{ secrets.ACCESS_TOKEN_GRADLE_BUILD }}
   python:
-    version: 3.9
+    version: 3.10
     requirements:
-      - ./domain-cc/cc-app/requirements.txt
+      - ./domain-cc/cc-app/src/requirements.txt

--- a/.github/secrel/config.yml
+++ b/.github/secrel/config.yml
@@ -9,6 +9,6 @@ languages:
       # Snyk does its own build to run SCA, so it needs the token to pull private artifacts
       - -PGITHUB_ACCESS_TOKEN=${{ secrets.ACCESS_TOKEN_GRADLE_BUILD }}
   python:
-    version: 3.10
+    version: 3.9
     requirements:
       - ./domain-cc/cc-app/src/requirements.txt

--- a/app/src/docker/Dockerfile
+++ b/app/src/docker/Dockerfile
@@ -1,9 +1,10 @@
 FROM eclipse-temurin:17-jre-alpine
 
 # hadolint ignore=DL3018
-RUN apk update && apk --no-cache add curl && rm -rf /var/cache/apk/*
-
-RUN adduser --no-create-home --disabled-password tron
+RUN apk update && \
+    apk --no-cache add curl redis sudo && rm -rf /var/cache/apk/* && \
+    apk upgrade openssl libssl3 libcrypto3 \
+    adduser --no-create-home --disabled-password tron
 
 HEALTHCHECK CMD curl --fail http://localhost:8111/actuator/health || exit 1
 

--- a/app/src/docker/Dockerfile
+++ b/app/src/docker/Dockerfile
@@ -3,8 +3,9 @@ FROM eclipse-temurin:17-jre-alpine
 # hadolint ignore=DL3018
 RUN apk update && \
     apk --no-cache add curl redis sudo && rm -rf /var/cache/apk/* && \
-    apk upgrade openssl libssl3 libcrypto3 \
-    adduser --no-create-home --disabled-password tron
+    apk upgrade openssl libssl3 libcrypto3
+
+RUN adduser --no-create-home --disabled-password tron
 
 HEALTHCHECK CMD curl --fail http://localhost:8111/actuator/health || exit 1
 

--- a/app/src/docker/Dockerfile
+++ b/app/src/docker/Dockerfile
@@ -2,8 +2,9 @@ FROM eclipse-temurin:17-jre-alpine
 
 # hadolint ignore=DL3018
 RUN apk update && \
-    apk --no-cache add curl redis sudo && rm -rf /var/cache/apk/* && \
-    apk upgrade openssl libssl3 libcrypto3
+    apk --no-cache add curl redis sudo && \
+    apk upgrade openssl libssl3 libcrypto3 && \
+    rm -rf /var/cache/apk/*
 
 RUN adduser --no-create-home --disabled-password tron
 

--- a/buildSrc/docker/Dockerfile-java
+++ b/buildSrc/docker/Dockerfile-java
@@ -8,8 +8,9 @@ FROM eclipse-temurin:17-jre-alpine
 # hadolint ignore=DL3018
 RUN apk update && \
     apk --no-cache add curl redis sudo && rm -rf /var/cache/apk/* && \
-    apk upgrade openssl libssl3 libcrypto3 \
-    adduser --no-create-home --disabled-password tron
+    apk upgrade openssl libssl3 libcrypto3
+
+RUN adduser --no-create-home --disabled-password tron
 
 # 8080 is the default port that spring-actuator uses
 ARG HEALTHCHECK_PORT_ARG=8080

--- a/buildSrc/docker/Dockerfile-java
+++ b/buildSrc/docker/Dockerfile-java
@@ -6,9 +6,10 @@ FROM eclipse-temurin:17-jre-alpine
 
 # curl is needed for HEALTHCHECK
 # hadolint ignore=DL3018
-RUN apk update && apk --no-cache add curl && rm -rf /var/cache/apk/*
-
-RUN adduser --no-create-home --disabled-password tron
+RUN apk update && \
+    apk --no-cache add curl redis sudo && rm -rf /var/cache/apk/* && \
+    apk upgrade openssl libssl3 libcrypto3 \
+    adduser --no-create-home --disabled-password tron
 
 # 8080 is the default port that spring-actuator uses
 ARG HEALTHCHECK_PORT_ARG=8080

--- a/console/src/docker/Dockerfile
+++ b/console/src/docker/Dockerfile
@@ -1,8 +1,9 @@
 FROM eclipse-temurin:17-jre-alpine
 
 # hadolint ignore=DL3018
-RUN apk update && apk --no-cache add curl redis sudo && rm -rf /var/cache/apk/*
-RUN apk upgrade openssl libssl3 libcrypto3
+RUN apk update && \
+    apk --no-cache add curl redis sudo && rm -rf /var/cache/apk/* && \
+    apk upgrade openssl libssl3 libcrypto3
 
 RUN adduser --disabled-password tron
 

--- a/console/src/docker/Dockerfile
+++ b/console/src/docker/Dockerfile
@@ -1,7 +1,8 @@
 FROM eclipse-temurin:17-jre-alpine
 
 # hadolint ignore=DL3018
-RUN apk update && apk --no-cache add curl redis sudo && rm -rf /var/cache/apk/* && apk upgrade openssl
+RUN apk update && apk --no-cache add curl redis sudo && rm -rf /var/cache/apk/*
+RUN apk upgrade openssl libssl3 libcrypto3
 
 RUN adduser --disabled-password tron
 

--- a/console/src/docker/Dockerfile
+++ b/console/src/docker/Dockerfile
@@ -1,7 +1,7 @@
 FROM eclipse-temurin:17-jre-alpine
 
 # hadolint ignore=DL3018
-RUN apk update && apk --no-cache add curl redis sudo && rm -rf /var/cache/apk/*
+RUN apk update && apk --no-cache add curl redis sudo && rm -rf /var/cache/apk/* && apk upgrade openssl
 
 RUN adduser --disabled-password tron
 

--- a/postgres/src/docker/Dockerfile
+++ b/postgres/src/docker/Dockerfile
@@ -1,7 +1,9 @@
 FROM postgres:14.7-alpine
 
 # hadolint ignore=DL3018
-RUN apk update && apk upgrade && apk --no-cache add sudo && rm -rf /var/cache/apk/*
+RUN apk update && \
+    apk --no-cache add curl redis sudo && rm -rf /var/cache/apk/* && \
+    apk upgrade openssl libssl3 libcrypto3
 
 # The following is needed to run the init-folder.sh script as root (to run chown)
 # before the postgres container does it's normal thing

--- a/postgres/src/docker/Dockerfile
+++ b/postgres/src/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM postgres:14.7-alpine
+FROM postgres:14.8-alpine
 
 # hadolint ignore=DL3018
 RUN apk update && \


### PR DESCRIPTION
<!-- Ensure the PR title reflects the feature or bug name -->

## What was the problem?
<!-- brief description of how things worked before this PR -->
There were SecRel failures associated with out-of-date postgres images and openssl packages. 

Associated tickets or Slack threads:
<!-- replace "000" with ticket number in both places -->
https://github.com/orgs/department-of-veterans-affairs/projects/871?pane=issue&itemId=28574209

## How does this fix it?[^1]
<!-- description of how things will work after this PR -->
* Upgrades to new minor version of postgres
* There is no new patch for the jre17-alpine base image so uses `apk upgrade` to get most recent openssl packages and dependencies.

## How to test this PR
- [Successful SecRel run](https://github.com/department-of-veterans-affairs/abd-vro-internal/actions/runs/5204870691)


[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
