### PR TITLE
use 200 code instead of 201 fixes #1667

### DIFF
--- a/domain-cc/cc-app/src/python_src/api.py
+++ b/domain-cc/cc-app/src/python_src/api.py
@@ -24,7 +24,7 @@ logging.basicConfig(
 )
 
 
-@app.post("/classifier", status_code=201)
+@app.post("/classifier")
 def get_classification(
     claim_for_increase: ClaimForIncrease,
 ) -> Optional[PredictedClassification]:

--- a/domain-cc/cc-app/tests/test_api.py
+++ b/domain-cc/cc-app/tests/test_api.py
@@ -14,7 +14,7 @@ def test_classification(client: TestClient):
     }
 
     response = client.post("/classifier", json=json_post_dict)
-    assert response.status_code == 201
+    assert response.status_code == 200
     assert (
         response.json()["classification_code"]
         == TUBERCULOSIS_CLASSIFICATION["classification_code"]
@@ -44,5 +44,5 @@ def test_unmapped_diagnostic_code(client: TestClient):
     }
 
     response = client.post("/classifier", json=json_post_dict)
-    assert response.status_code == 201
+    assert response.status_code == 200
     assert response.json() is None


### PR DESCRIPTION
<!-- Ensure the PR title reflects the feature or bug name -->

## What was the problem?
<!-- brief description of how things worked before this PR -->
After talking to Kyle, sounds like makes more sense to use 200 instead of 201.

Associated tickets or Slack threads:
<!-- replace "000" with ticket number in both places -->
- https://github.com/department-of-veterans-affairs/abd-vro/issues/1667

## How does this fix it?[^1]
<!-- description of how things will work after this PR -->

## How to test this PR
- run cc app w/ `./gradlew :domain-cc:dockerComposeUp`
- make a post request to /classifier, observe 200 status code


[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
