### PR TITLE
Task add a /health endpoint

### DIFF
--- a/domain-cc/cc-app/gradle.properties
+++ b/domain-cc/cc-app/gradle.properties
@@ -1,6 +1,4 @@
 # server_port=8120
-healthcheck_port=8121
-
-# TODO: replace this with something like:
-#   healthcheck_cmd=curl --fail http://localhost:${HEALTHCHECK_PORT}/health || exit 1
-healthcheck_cmd=pgrep uvicorn || exit 1
+# TODO: when application is restructured to use separate port for healthcheck
+#  this should be changed to 8121
+healthcheck_port=8120

--- a/domain-cc/cc-app/src/python_src/api.py
+++ b/domain-cc/cc-app/src/python_src/api.py
@@ -32,7 +32,6 @@ def get_health_status():
     return {"status": "ok"}
 
 
-
 @app.post("/classifier")
 def get_classification(
     claim_for_increase: ClaimForIncrease,

--- a/domain-cc/cc-app/src/python_src/api.py
+++ b/domain-cc/cc-app/src/python_src/api.py
@@ -24,7 +24,7 @@ logging.basicConfig(
 )
 
 
-@app.post("/classifier", status_code=201)
+@app.post("/classifier")
 def get_classification(
     claim_for_increase: ClaimForIncrease,
 ) -> Optional[PredictedClassification]:

--- a/domain-cc/cc-app/src/python_src/api.py
+++ b/domain-cc/cc-app/src/python_src/api.py
@@ -1,7 +1,7 @@
 import logging
 from typing import Optional
 
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
 
 from .pydantic_models import ClaimForIncrease, PredictedClassification
 from .util.lookup_table import get_classification_name, get_lookup_table
@@ -22,6 +22,14 @@ logging.basicConfig(
     level=logging.INFO,
     datefmt="%Y-%m-%d %H:%M:%S",
 )
+
+
+@app.get("/health")
+def get_health_status():
+    if not len(LOOKUP_TABLE):
+        raise HTTPException(status_code=500, detail="Lookup table is empty")
+
+    return {"status": "ok"}
 
 
 @app.post("/classifier")

--- a/domain-cc/cc-app/tests/test_api.py
+++ b/domain-cc/cc-app/tests/test_api.py
@@ -14,7 +14,7 @@ def test_classification(client: TestClient):
     }
 
     response = client.post("/classifier", json=json_post_dict)
-    assert response.status_code == 201
+    assert response.status_code == 200
     assert (
         response.json()["classification_code"]
         == TUBERCULOSIS_CLASSIFICATION["classification_code"]
@@ -44,5 +44,5 @@ def test_unmapped_diagnostic_code(client: TestClient):
     }
 
     response = client.post("/classifier", json=json_post_dict)
-    assert response.status_code == 201
+    assert response.status_code == 200
     assert response.json() is None


### PR DESCRIPTION
<!-- Ensure the PR title reflects the feature or bug name -->

## What was the problem?
<!-- brief description of how things worked before this PR -->
Follow up from [this discussion](https://dsva.slack.com/archives/C01Q7979Z7D/p1686770694199429) on slack.

Associated tickets or Slack threads:
<!-- replace "000" with ticket number in both places -->
- https://github.com/department-of-veterans-affairs/abd-vro/issues/1661

## How does this fix it?[^1]
<!-- description of how things will work after this PR -->
- This adds a new endpoint that an automated tool can make a request to in order to ensure the application is operating as expected.
- Despite the link to a pip package to do this, I don't think we need to add an extra dependency at least not when we're not doing more sophisticated checks (e.g. talking to databases, external services, etc)

## How to test this PR
- `./gradlew :domain-cc:dockerComposeUp`
- make a GET request to `/health`
- CI can programmaticaly check for status code or status: "ok", doesn't matter to me

## Next steps
- @msnwatson will add action to check the `/health` endpoint in github (https://github.com/department-of-veterans-affairs/abd-vro/issues/1638)

[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
