### PR TITLE
Task - include mechanism for updating lookup table version

### DIFF
--- a/domain-cc/cc-app/src/python_src/api.py
+++ b/domain-cc/cc-app/src/python_src/api.py
@@ -32,7 +32,6 @@ def get_health_status():
     return {"status": "ok"}
 
 
-
 @app.post("/classifier")
 def get_classification(
     claim_for_increase: ClaimForIncrease,

--- a/domain-cc/cc-app/src/python_src/api.py
+++ b/domain-cc/cc-app/src/python_src/api.py
@@ -24,7 +24,7 @@ logging.basicConfig(
 )
 
 
-@app.post("/classifier", status_code=201)
+@app.post("/classifier")
 def get_classification(
     claim_for_increase: ClaimForIncrease,
 ) -> Optional[PredictedClassification]:

--- a/domain-cc/cc-app/src/python_src/api.py
+++ b/domain-cc/cc-app/src/python_src/api.py
@@ -1,7 +1,7 @@
 import logging
 from typing import Optional
 
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
 
 from .pydantic_models import ClaimForIncrease, PredictedClassification
 from .util.lookup_table import get_classification_name, get_lookup_table
@@ -22,6 +22,14 @@ logging.basicConfig(
     level=logging.INFO,
     datefmt="%Y-%m-%d %H:%M:%S",
 )
+
+
+@app.get("/health")
+def get_health_status():
+    if not len(LOOKUP_TABLE):
+        raise HTTPException(status_code=500, detail="Lookup table is empty")
+
+    return {"status": "ok"}
 
 
 @app.post("/classifier")

--- a/domain-cc/cc-app/src/python_src/util/lookup_table.py
+++ b/domain-cc/cc-app/src/python_src/util/lookup_table.py
@@ -1,6 +1,7 @@
 import csv
 import json
 import os
+
 from .table_version import TABLE_VERSION
 
 # csv file exported from DC Lookup v0.1

--- a/domain-cc/cc-app/src/python_src/util/lookup_table.py
+++ b/domain-cc/cc-app/src/python_src/util/lookup_table.py
@@ -1,10 +1,11 @@
 import csv
 import json
 import os
+from .table_version import TABLE_VERSION
 
 # csv file exported from DC Lookup v0.1
 # https://docs.google.com/spreadsheets/d/18Mwnn9-cvJIRRupQyQ2zLYOBm3bd0pr4kKlsZtFiyc0/edit#gid=1711756762
-TABLE_NAME = "Contention Classification Diagnostic Codes Lookup table master sheet - DC Lookup v0.1.csv"
+TABLE_NAME = f'Contention Classification Diagnostic Codes Lookup table master sheet - DC Lookup {TABLE_VERSION}.csv'
 
 # sourced from Lighthouse Benefits Reference Data /disabilities endpoint:
 # https://developer.va.gov/explore/benefits/docs/benefits_reference_data?version=current

--- a/domain-cc/cc-app/src/python_src/util/table_version.py
+++ b/domain-cc/cc-app/src/python_src/util/table_version.py
@@ -1,0 +1,1 @@
+TABLE_VERSION = 'v0.1'

--- a/domain-cc/cc-app/tests/test_api.py
+++ b/domain-cc/cc-app/tests/test_api.py
@@ -14,7 +14,7 @@ def test_classification(client: TestClient):
     }
 
     response = client.post("/classifier", json=json_post_dict)
-    assert response.status_code == 201
+    assert response.status_code == 200
     assert (
         response.json()["classification_code"]
         == TUBERCULOSIS_CLASSIFICATION["classification_code"]
@@ -44,5 +44,5 @@ def test_unmapped_diagnostic_code(client: TestClient):
     }
 
     response = client.post("/classifier", json=json_post_dict)
-    assert response.status_code == 201
+    assert response.status_code == 200
     assert response.json() is None


### PR DESCRIPTION
<!-- Ensure the PR title reflects the feature or bug name -->
## Depends on 
https://github.com/department-of-veterans-affairs/abd-vro/pull/1689

## What was the problem?
- Provide an easier way to make updates to the dc lookup table mapping.
- Provide a way for CI to pull lookup table version for improving visibility
- Added a wiki [here](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Updating-Contention-Classification-DC-Lookup-Table) 

Associated tickets or Slack threads:
<!-- replace "000" with ticket number in both places -->
- https://github.com/department-of-veterans-affairs/vagov-claim-classification/issues/176

## How does this fix it?[^1]
<!-- description of how things will work after this PR -->

## How to test this PR
- run `pytest`
- I did ensure writing an erroneous version number will fail `pytest`

<img width="463" alt="Screenshot 2023-06-15 at 2 44 36 PM" src="https://github.com/department-of-veterans-affairs/abd-vro/assets/17188013/2db64be6-6b00-47a5-af6e-034db2bb06af">


# Next Steps
Added something to Helm? config so lookup table version shows up in logs
Can be pulled directly from `domain-cc/cc-app/src/python_src/util/table_version.py`


[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
