### PR TITLE
comment out svs-bip-api until dockerfile is ready

### DIFF
--- a/app/src/docker/docker-compose.yml
+++ b/app/src/docker/docker-compose.yml
@@ -189,18 +189,18 @@ services:
     networks:
       - intranet
 
-  svc-bip-api:
-    profiles: ["all", "svc", "bip"]
-    environment:
-      BIP_CLAIM_USERID: ${BIP_CLAIM_USERID}
-      BIP_CLAIM_SECRET: ${BIP_CLAIM_SECRET}
-      BIP_EVIDENCE_USERID: ${BIP_EVIDENCE_USERID}
-      BIP_EVIDENCE_SECRET: ${BIP_EVIDENCE_SECRET}
-      BIP_TRUSTSTORE: ${BIP_TRUSTSTORE}
-      BIP_PASSWORD: ${BIP_PASSWORD}
-      BIP_KEYSTORE: ${BIP_KEYSTORE}
-      BIP_CLAIM_URL: "mock-bip-claims-api:20300"
-      BIP_EVIDENCE_URL: "mock-bip-ce-api:20310"
+#  svc-bip-api:
+#    profiles: ["all", "svc", "bip"]
+#    environment:
+#      BIP_CLAIM_USERID: ${BIP_CLAIM_USERID}
+#      BIP_CLAIM_SECRET: ${BIP_CLAIM_SECRET}
+#      BIP_EVIDENCE_USERID: ${BIP_EVIDENCE_USERID}
+#      BIP_EVIDENCE_SECRET: ${BIP_EVIDENCE_SECRET}
+#      BIP_TRUSTSTORE: ${BIP_TRUSTSTORE}
+#      BIP_PASSWORD: ${BIP_PASSWORD}
+#      BIP_KEYSTORE: ${BIP_KEYSTORE}
+#      BIP_CLAIM_URL: "mock-bip-claims-api:20300"
+#      BIP_EVIDENCE_URL: "mock-bip-ce-api:20310"
 
 
   svc-bgs-api:


### PR DESCRIPTION
Fix the addition of svc-bip-api to the docker-compose file, before there was a docker file ready

Associated tickets or Slack threads:
https://dsva.slack.com/archives/C04QLHM9LR0/p1686606620207719?thread_ts=1686604725.081359&cid=C04QLHM9LR0