### PR TITLE
SecRel- address Directory Traversal vulnerability in starlette

### DIFF
--- a/domain-cc/cc-app/src/requirements.txt
+++ b/domain-cc/cc-app/src/requirements.txt
@@ -1,5 +1,6 @@
-fastapi==0.92.*
+fastapi==0.97.*
 httpx==0.24.*
 pika==1.3.*
 pytest==7.3.1
+starlette>=0.27.0
 uvicorn[standard]==0.20.*


### PR DESCRIPTION
Python library 'starlette' was used in cc-app, by fastapi. Vulnerability was found in installed version. This PR updates startlette to 0.28.0 and fastAPI to 0.97.*.

Associated tickets or Slack threads:
https://github.com/department-of-veterans-affairs/abd-vro-internal/security/code-scanning/865