### PR TITLE
GHCR: Don't overwrite existing published images with same tag

### DIFF
--- a/.github/actions/publish-images/action.yml
+++ b/.github/actions/publish-images/action.yml
@@ -7,9 +7,8 @@ inputs:
     type: string
     default: 'dev_'
   image_tag:
-    description: 'The tag/version for the image, e.g., first 7 of the commit hash or "release-1.2.3"'
+    description: 'The tag/version for the image, e.g., first 7 of the commit hash or "" (blank) to use image_versions.src'
     type: string
-    required: true
   ghcr_username:
     description: 'GHCR username'
     type: string
@@ -26,7 +25,7 @@ inputs:
 outputs:
   images_list:
     description: 'list of URLs to published images'
-    value: ${{ steps.published-images.outputs.images }}
+    value: ${{ steps.push-images.outputs.images }}
 
 runs:
   using: composite
@@ -48,34 +47,39 @@ runs:
         password: ${{ inputs.ghcr_password }}
 
     - name: "Tag and push images using commit hash and `latest`"
+      id: push-images
       shell: bash
       run: |
-        source scripts/image_vars.src
-        for PREFIX in "${VAR_PREFIXES_ARR[@]}"; do
-          GRADLE_IMG_NAME=$(getVarValue "${PREFIX}" _GRADLE_IMG)
-          IMG_NAME="${{ inputs.image_prefix }}$(getVarValue "${PREFIX}" _IMG)"
-          GHCR_PATH="ghcr.io/${{ github.repository }}/${IMG_NAME}"
+        # GHCR_TOKEN is expected by imageTagExists
+        # Reusing existing secret ACCESS_TOKEN_DELETE_PACKAGE to query packages, not deleted it.
+        export GHCR_TOKEN=$(echo ${{ secrets.ACCESS_TOKEN_DELETE_PACKAGE }} | base64)
 
-          echo "Tagging '$GRADLE_IMG_NAME' as '$IMG_NAME:${{ inputs.image_tag }}' and '$IMG_NAME:latest'"
-          docker tag "$GRADLE_IMG_NAME" "${GHCR_PATH}:${{ inputs.image_tag }}"
-          docker push "${GHCR_PATH}:${{ inputs.image_tag }}"
-
-          docker tag "$GRADLE_IMG_NAME" "${GHCR_PATH}:latest"
-          docker push "${GHCR_PATH}:latest"
-        done
-
-    - name: "Published images list"
-      id: published-images
-      shell: bash
-      run: |
-        docker image list
-        source scripts/image_vars.src
         echo "## Published images" >> $GITHUB_STEP_SUMMARY
         echo "images<<EOF" >> $GITHUB_OUTPUT
-        for VAR_PREFIX in ${VAR_PREFIXES_ARR[@]}; do
-          IMG_NAME=${{ inputs.image_prefix }}$(getVarValue "${VAR_PREFIX}" _IMG)
-          GHCR_PATH="ghcr.io/${{ github.repository }}/${IMG_NAME}"
-          echo "${GHCR_PATH}:${{ inputs.image_tag }}" >> $GITHUB_OUTPUT
-          echo "* ${GHCR_PATH}:${{ inputs.image_tag }}" >> $GITHUB_STEP_SUMMARY
+        source scripts/image_vars.src
+        for PREFIX in "${VAR_PREFIXES_ARR[@]}"; do
+          IMG_NAME="${{ inputs.image_prefix }}$(getVarValue "${PREFIX}" _IMG)"
+          if [ "${{ inputs.image_tag }}" ]; then
+            IMG_TAG="${{ inputs.image_tag }}"
+          else
+            IMG_TAG=$(getVarValue "${VAR_PREFIX}" _VER)
+          fi
+          if [ "$(imageTagExists "$IMG_NAME" "$IMG_TAG")" == "200" ]; then
+            echo "Image already exists: $IMG_NAME $IMG_TAG; not overwriting"
+          else
+            GRADLE_IMG_NAME=$(getVarValue "${PREFIX}" _GRADLE_IMG)
+            GHCR_PATH="ghcr.io/${{ github.repository }}/${IMG_NAME}"
+
+            echo "Tagging '$GRADLE_IMG_NAME' as '$IMG_NAME:$IMG_TAG' and '$IMG_NAME:latest'"
+            docker tag "$GRADLE_IMG_NAME" "${GHCR_PATH}:$IMG_TAG"
+            docker push "${GHCR_PATH}:$IMG_TAG"
+
+            docker tag "$GRADLE_IMG_NAME" "${GHCR_PATH}:latest"
+            docker push "${GHCR_PATH}:latest"
+
+            echo "* ${GHCR_PATH}:$IMG_TAG" >> $GITHUB_STEP_SUMMARY
+            echo "${GHCR_PATH}:$IMG_TAG" >> $GITHUB_OUTPUT
+          fi
         done
         echo "EOF" >> $GITHUB_OUTPUT
+        docker image list

--- a/.github/actions/publish-images/action.yml
+++ b/.github/actions/publish-images/action.yml
@@ -51,8 +51,7 @@ runs:
       shell: bash
       run: |
         # GHCR_TOKEN is expected by imageTagExists
-        # Reusing existing secret ACCESS_TOKEN_DELETE_PACKAGE to query packages, not deleted it.
-        export GHCR_TOKEN=$(echo ${{ secrets.ACCESS_TOKEN_DELETE_PACKAGE }} | base64)
+        export GHCR_TOKEN=$(echo ${{ inputs.ghcr_password }} | base64)
 
         echo "## Published images" >> $GITHUB_STEP_SUMMARY
         echo "images<<EOF" >> $GITHUB_OUTPUT

--- a/.github/actions/publish-images/action.yml
+++ b/.github/actions/publish-images/action.yml
@@ -61,7 +61,7 @@ runs:
           if [ "${{ inputs.image_tag }}" ]; then
             IMG_TAG="${{ inputs.image_tag }}"
           else
-            IMG_TAG=$(getVarValue "${VAR_PREFIX}" _VER)
+            IMG_TAG=$(getVarValue "${PREFIX}" _VER)
           fi
           echo "::group::Push image $IMG_NAME $IMG_TAG"
           if [ "$(imageTagExists "$IMG_NAME" "$IMG_TAG")" == "200" ]; then

--- a/.github/actions/publish-images/action.yml
+++ b/.github/actions/publish-images/action.yml
@@ -63,8 +63,10 @@ runs:
           else
             IMG_TAG=$(getVarValue "${VAR_PREFIX}" _VER)
           fi
+          echo "::group::Push image $IMG_NAME $IMG_TAG"
           if [ "$(imageTagExists "$IMG_NAME" "$IMG_TAG")" == "200" ]; then
             echo "Image already exists: $IMG_NAME $IMG_TAG; not overwriting"
+            echo "* Image already exists, not overwriting: ${GHCR_PATH}:$IMG_TAG" >> $GITHUB_STEP_SUMMARY
           else
             GRADLE_IMG_NAME=$(getVarValue "${PREFIX}" _GRADLE_IMG)
             GHCR_PATH="ghcr.io/${{ github.repository }}/${IMG_NAME}"
@@ -79,6 +81,7 @@ runs:
             echo "* ${GHCR_PATH}:$IMG_TAG" >> $GITHUB_STEP_SUMMARY
             echo "${GHCR_PATH}:$IMG_TAG" >> $GITHUB_OUTPUT
           fi
+          echo "::endgroup::"
         done
         echo "EOF" >> $GITHUB_OUTPUT
         docker image list

--- a/.github/workflows/secrel.yml
+++ b/.github/workflows/secrel.yml
@@ -1,4 +1,5 @@
 name: "2. (Internal) SecRel workflow"
+run-name: "SecRel ${{inputs.image_prefix}} (${{github.ref_type}} ${{github.ref_name}}) ${{github.event.head_commit.message}}"
 
 on:
   # Trigger on every code push to main and develop branches

--- a/.github/workflows/secrel.yml
+++ b/.github/workflows/secrel.yml
@@ -70,7 +70,8 @@ jobs:
                        ;;
             release-*|v*.*.*) # if git tag reflects a release, then publish non-dev images
                        IMG_PREFIX=""
-                       IMG_TAG="${{ github.ref_name }}"
+                       # A blank IMG_TAG value will cause image_versions.src to be used
+                       IMG_TAG=""
                        ;;
             develop)   RUN_GRADLE_TESTS=false
                        ;;

--- a/build.gradle
+++ b/build.gradle
@@ -146,8 +146,11 @@ scmVersion {
 
   hooks {
     pre("fileUpdate", [file: "api-gateway/src/main/java/gov/va/vro/propmodel/Info.java",
-      pattern    : { v, p -> /version = "v.*"/ },
-      replacement: { v, p -> "version = \"v$v\"" }])
+      pattern    : { v, p -> /String version = "v.*"/ },
+      replacement: { v, p -> "String version = \"v$v\"" }])
+    pre("fileUpdate", [file: "scripts/image_versions.src",
+      pattern    : { v, p -> /CURRENT_RELEASE_VER="v.*"/ },
+      replacement: { v, p -> "CURRENT_RELEASE_VER=\"v$v\"" }])
     pre({ context ->
       setHelmChartAppVersions(context.currentVersion)
           .findAll{ it !=null }.each { file -> context.addCommitPattern(file.canonicalPath) }

--- a/scripts/image_vars.src
+++ b/scripts/image_vars.src
@@ -14,11 +14,21 @@ export VRO_IMAGES="api-gateway app postgres db-init console svc-bgs-api svc-ligh
 VAR_PREFIXES_ARR=( apigateway app postgres dbinit console svcbgsapi svclighthouseapi ccapp )
 export VAR_PREFIXES="apigateway app postgres dbinit console svcbgsapi svclighthouseapi ccapp"
 
-# Helper function
+## Helper functions
 # Usage example to get the variable value for app_GRADLE_IMG: GRADLE_IMG_TAG=`getVarValue app _GRADLE_IMG`
 getVarValue(){
   local VARNAME=${1}${2}
   echo "${!VARNAME}"
+}
+
+# Return non-zero error code if image tag does not exist
+# Usage: imageTagExists IMAGE_NAME IMAGE_TAG
+# Environment variable GHCR_TOKEN should be in base64
+imageTagExists(){
+  [ "$GHCR_TOKEN" ] || { echo "GHCR_TOKEN not set!" >&2; return 2; }
+  # https://superuser.com/a/442395
+  curl -s -o /dev/null -w "%{http_code}" -I -H "Authorization: Bearer ${GHCR_TOKEN}" \
+    "https://ghcr.io/v2/department-of-veterans-affairs/abd-vro-internal/$1/manifests/$2"
 }
 
 # Note: Bash arrays cannot be exported; use this workaround to
@@ -31,7 +41,7 @@ getVarValue(){
 #   echo
 # done
 
-
+######################################
 
 # --- api-gateway in folder ./api-gateway
 export apigateway_GRADLE_IMG="va/abd_vro-api-gateway"
@@ -65,4 +75,6 @@ export svclighthouseapi_IMG="vro-svc-lighthouse-api"
 export ccapp_GRADLE_IMG="va/abd_vro-cc-app"
 export ccapp_IMG="vro-cc-app"
 
+######################################
+source scripts/image_versions.src
 # End of file

--- a/scripts/image_versions.src
+++ b/scripts/image_versions.src
@@ -1,0 +1,15 @@
+
+CURRENT_RELEASE_VER="v3.1.0"
+
+: ${postgres_VER:=$CURRENT_RELEASE_VER}
+
+: ${console_VER:=$CURRENT_RELEASE_VER}
+apigateway_VER="v3.0.9"
+
+: ${app_VER:=$CURRENT_RELEASE_VER}
+: ${dbinit_VER:=$CURRENT_RELEASE_VER}
+
+: ${svcbgsapi_VER:=$CURRENT_RELEASE_VER}
+: ${svclighthouseapi_VER:=$CURRENT_RELEASE_VER}
+
+: ${ccapp_VER:=$CURRENT_RELEASE_VER}


### PR DESCRIPTION
<!-- Ensure the PR title reflects the feature or bug name -->

## What was the problem?
<!-- brief description of how things worked before this PR -->
Existing published images with the same tag were being overwritten unnecessarily.
As a result, unchanged published images were being needlessly rescanned by SecRel.

Associated tickets or Slack threads:
- #1725

## How does this fix it?
<!-- description of how things will work after this PR -->
Update publish GH Action to only publish images if the image tag doesn't already exist.
As a result, existing published images aren't sent to SecRel for rescanning.

## How to test this PR
1. Run SecRel once to publish the images.
1. Re-run and note that images are not re-published and not sent to SecRel.

Example:
1. [SecRel run](https://github.com/department-of-veterans-affairs/abd-vro-internal/actions/runs/5348654684/attempts/1)
2. [Re-run](https://github.com/department-of-veterans-affairs/abd-vro-internal/actions/runs/5348654684)
