### PR TITLE
Add container healthchecks GH action and run secrel on dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -45,7 +45,13 @@ updates:
       interval: "daily"
 
   - package-ecosystem: "docker"
-    directory: "/gradle-plugins/docker"
+    directory: "/console/src/docker"
+    target-branch: "develop"
+    schedule:
+      interval: "daily"
+
+  - package-ecosystem: "docker"
+    directory: "/svc-bgs-api/src/docker"
     target-branch: "develop"
     schedule:
       interval: "daily"

--- a/.github/workflows/container-healthchecks.yml
+++ b/.github/workflows/container-healthchecks.yml
@@ -21,14 +21,19 @@ jobs:
       - name: "Create platform containers with healthchecks"
         shell: bash
         run: |
-          ./gradlew :dockerComposeUp
+          COMPOSE_PROFILES="gateway" ./gradlew :dockerComposeUp
 
       - name: "Create app containers with healthchecks"
         shell: bash
         run: |
-          ./gradlew :app:dockerComposeUp
+          COMPOSE_PROFILES="svc" ./gradlew :app:dockerComposeUp
 
       - name: "Create domain-cc containers with healthchecks"
         shell: bash
         run: |
           ./gradlew :domain-cc:dockerComposeUp
+
+      - name: "Clean shutdown of all containers"
+        shell: bash
+        run: |
+          COMPOSE_PROFILES="all" ./gradlew dockerComposeDown

--- a/.github/workflows/container-healthchecks.yml
+++ b/.github/workflows/container-healthchecks.yml
@@ -15,9 +15,6 @@ jobs:
       - name: "Checkout source code"
         uses: actions/checkout@v3
 
-      - name: "Set up VRO build env"
-        uses: ./.github/actions/setup-vro
-
       - name: "Docker build"
         uses: ./.github/actions/build-images
 

--- a/.github/workflows/container-healthchecks.yml
+++ b/.github/workflows/container-healthchecks.yml
@@ -4,6 +4,9 @@ on:
   # Allow manual triggering
   workflow_dispatch:
 
+  # Trigger when called by another GitHub Action
+  workflow_call:
+
 concurrency:
   group: containerHealthChecks-${{ github.ref }}
 

--- a/.github/workflows/container-healthchecks.yml
+++ b/.github/workflows/container-healthchecks.yml
@@ -1,4 +1,4 @@
-name: "PR: Run Container Health Checks"
+name: "Container Health Checks"
 
 on:
   # Allow manual triggering

--- a/.github/workflows/container-healthchecks.yml
+++ b/.github/workflows/container-healthchecks.yml
@@ -1,0 +1,37 @@
+name: "PR: Run Container Health Checks"
+
+on:
+  # Allow manual triggering
+  workflow_dispatch:
+
+concurrency:
+  group: containerHealthChecks-${{ github.ref }}
+
+jobs:
+  container-healthcheck:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: "Checkout source code"
+        uses: actions/checkout@v3
+
+      - name: "Set up VRO build env"
+        uses: ./.github/actions/setup-vro
+
+      - name: "Docker build"
+        uses: ./.github/actions/build-images
+
+      - name: "Create platform containers with healthchecks"
+        shell: bash
+        run: |
+          ./gradlew :dockerComposeUp
+
+      - name: "Create app containers with healthchecks"
+        shell: bash
+        run: |
+          ./gradlew :app:dockerComposeUp
+
+      - name: "Create domain-cc containers with healthchecks"
+        shell: bash
+        run: |
+          ./gradlew :domain-cc:dockerComposeUp

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -19,6 +19,6 @@ jobs:
     uses: ./.github/workflows/codeql-analysis.yml
     secrets: inherit
 
-#  end2end-test:
-#    uses: ./.github/workflows/rrd-end2end-test.yml
-#    secrets: inherit
+  container-healthchecks:
+    uses: ./.github/workflows/container-healthchecks.yml
+    secrets: inherit

--- a/.github/workflows/secrel.yml
+++ b/.github/workflows/secrel.yml
@@ -10,6 +10,9 @@ on:
   release:
     types: [ "created" ]
 
+  pull_request:
+    branches: [ develop ]
+
   # Allow manual runs
   workflow_dispatch:
     inputs:
@@ -39,7 +42,8 @@ env:
 jobs:
   publish-to-ghcr:
     # only run for the internal repo, where the images are published
-    if: github.repository == 'department-of-veterans-affairs/abd-vro-internal'
+    if: github.repository == 'department-of-veterans-affairs/abd-vro-internal' &&
+      ((github.event_name == pull_request && startsWith(github.head_ref, 'dependabot/') || github.event_name != pull_request)
     outputs:
       vro-images: ${{ steps.publish-images.outputs.images_list }}
       slack-response-ts: ${{ fromJson(steps.notify-slack.outputs.slack-result).response.message.ts }}


### PR DESCRIPTION
<!-- Ensure the PR title reflects the feature or bug name -->

## What was the problem?
<!-- brief description of how things worked before this PR -->
* There was no GitHub action which spun up all our containers to make sure they were passing health checks. This is particularly useful for Dependabot PRs to have more confidence in the changes as soon as you get the PR.
* There were some Dockerfile definitions pulling in base images which were not covered by Dependabot analysis for upgrades.
* Engineers had to dispatch a secrel run manually for dependabot changes

Associated tickets or Slack threads:
- #1641 

## How does this fix it?[^1]
<!-- description of how things will work after this PR -->
- Updates the list of docker resources scanned by Dependabot 
- Adds a GitHub action which builds all the Docker images and then attempts to run docker compose for platform, app, and domain-cc containers (follow-on PRs can better modularize how partner team's containers are checked)
- I have confirmed that healthchecks are present either at the level of Dockerfiles or at the level of docker-compose to be sure that successful docker-compose runs also ensure healthy containers.
- Runs secrel workflows on PRs with a head branch that starts with `dependabot/`
- Once I have confirmed successful remote runs of the action, i will add triggers to run this for all dependabot PRs

## How to test this PR
- You can run the steps of the GitHub action manually
- Also, I'm going to run the GitHub action to confirm success

[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
