### PR TITLE
Increase open pull requests limit for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,18 +12,21 @@ updates:
     target-branch: "develop"
     schedule:
       interval: "daily"
+    open-pull-requests-limit: 10
 
   - package-ecosystem: "gradle"
     directory: "/"
     target-branch: "develop"
     schedule:
       interval: "daily"
+    open-pull-requests-limit: 10
 
   - package-ecosystem: "pip"
     directory: "/"
     target-branch: "develop"
     schedule:
       interval: "daily"
+    open-pull-requests-limit: 10
 
   # For Docker ecosystem, we must specify each file because Dependabot doesn't recursive search
   - package-ecosystem: "docker"
@@ -31,27 +34,32 @@ updates:
     target-branch: "develop"
     schedule:
       interval: "daily"
-
+    open-pull-requests-limit: 10
+    
   - package-ecosystem: "docker"
     directory: "/postgres/src/docker"
     target-branch: "develop"
     schedule:
       interval: "daily"
+    open-pull-requests-limit: 10
 
   - package-ecosystem: "docker"
     directory: "/db-init/src/docker"
     target-branch: "develop"
     schedule:
       interval: "daily"
+    open-pull-requests-limit: 10
 
   - package-ecosystem: "docker"
     directory: "/console/src/docker"
     target-branch: "develop"
     schedule:
       interval: "daily"
+    open-pull-requests-limit: 10
 
   - package-ecosystem: "docker"
     directory: "/svc-bgs-api/src/docker"
     target-branch: "develop"
     schedule:
       interval: "daily"
+    open-pull-requests-limit: 10


### PR DESCRIPTION
<!-- Ensure the PR title reflects the feature or bug name -->

## What was the problem?
<!-- brief description of how things worked before this PR -->
Dependabot scans were failing because of too many open pull requests for Gradle package ecosystem. The default of 5 open PRs seems a bit restrictive.

Associated tickets or Slack threads:
- #1641 

## How does this fix it?[^1]
<!-- description of how things will work after this PR -->
* Adds new config field for increasing open pull request limit

[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
