### PR TITLE
run container healthchecks on dependabot PRs

### DIFF
--- a/.github/workflows/container-healthchecks.yml
+++ b/.github/workflows/container-healthchecks.yml
@@ -6,6 +6,9 @@ on:
 
   # Allow being called by another GitHub Action
   workflow_call:
+  
+  pull_request:
+    branches: [ develop ]
 
 concurrency:
   group: containerHealthChecks-${{ github.ref }}
@@ -17,6 +20,7 @@ env:
 
 jobs:
   container-healthcheck:
+    if: ((github.event_name == 'pull_request' && startsWith(github.head_ref, 'dependabot/')) || github.event_name != 'pull_request')
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
<!-- Ensure the PR title reflects the feature or bug name -->

## What was the problem?
<!-- brief description of how things worked before this PR -->
When someone first took a look at a dependabot PR they would need to do manual testing of docker compose on containers to be sure that changes would not break the application.

Associated tickets or Slack threads:
- #1641 
- https://dsva.slack.com/archives/C04QLHM9LR0/p1687899539032099 for discussion of running continuous integration workflow on all PRs but it would be expensive

## How does this fix it?[^1]
<!-- description of how things will work after this PR -->
* Runs container healthcheck GH workflow on dependabot PRs (skips them on all other PRs)

## How to test this PR
- Can be seen in the GitHub actions for this PR

[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
