### PR TITLE
exclude gradle plugin builds from codeql scanning

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,3 @@
+paths-ignore:
+  - 'gradle-plugins/build/**'
+  - 'build/**'

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -52,3 +52,4 @@ jobs:
         uses: department-of-veterans-affairs/codeql-tools/codeql-analysis@main
         with:
           language: ${{ matrix.language }}
+          config-file: .github/codeql/codeql-config.yml


### PR DESCRIPTION
<!-- Ensure the PR title reflects the feature or bug name -->

## What was the problem?
<!-- brief description of how things worked before this PR -->
There were many security alerts being created based on build files from the `gradle-plugins` directory which is not checked into the repo. This was creating a great deal of noise and obscuring more meaningful alerts.

## How does this fix it?[^1]
<!-- description of how things will work after this PR -->
Adds a codeql-config.yml file which configures CodeQL scanning to ignore build files in the TLD and in `gradle-plugins/build`

## How to test this PR
- Successful CodeQL scan

[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
