### PR TITLE
only run container healthchecks public repo

### DIFF
--- a/.github/workflows/container-healthchecks.yml
+++ b/.github/workflows/container-healthchecks.yml
@@ -20,7 +20,8 @@ env:
 
 jobs:
   container-healthcheck:
-    if: ((github.event_name == 'pull_request' && startsWith(github.head_ref, 'dependabot/')) || github.event_name != 'pull_request')
+    if: github.repository == 'department-of-veterans-affairs/abd-vro' &&
+        ((github.event_name == 'pull_request' && startsWith(github.head_ref, 'dependabot/')) || github.event_name != 'pull_request')
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
<!-- Ensure the PR title reflects the feature or bug name -->

## What was the problem?
<!-- brief description of how things worked before this PR -->
reduce the number of redundant runs of container healthchecks workflow by only running in public repo

Associated tickets or Slack threads:
- #1641 


[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
