### PR TITLE
batch fix CodeQL alerts for public repo

### DIFF
--- a/app/src/main/java/gov/va/vro/openapi/provider/DefaultJwtBearerSecuritySchemeProvider.java
+++ b/app/src/main/java/gov/va/vro/openapi/provider/DefaultJwtBearerSecuritySchemeProvider.java
@@ -18,6 +18,7 @@ public class DefaultJwtBearerSecuritySchemeProvider implements CustomSecuritySch
    *
    * @return created SecurityScheme object
    */
+  @Override
   public SecurityScheme create() {
 
     return new SecurityScheme().type(SecurityScheme.Type.HTTP).scheme("bearer").bearerFormat("JWT");
@@ -28,6 +29,7 @@ public class DefaultJwtBearerSecuritySchemeProvider implements CustomSecuritySch
    *
    * @return name of the SecurityScheme configuration object
    */
+  @Override
   public String getName() {
     return "bearer-jwt";
   }

--- a/app/src/main/java/gov/va/vro/openapi/provider/DefaultOauthSecuritySchemeProvider.java
+++ b/app/src/main/java/gov/va/vro/openapi/provider/DefaultOauthSecuritySchemeProvider.java
@@ -37,6 +37,7 @@ public class DefaultOauthSecuritySchemeProvider implements CustomSecuritySchemeP
    *
    * @return created SecurityScheme object
    */
+  @Override
   public SecurityScheme create() {
 
     Scopes scopes = new Scopes();
@@ -55,6 +56,7 @@ public class DefaultOauthSecuritySchemeProvider implements CustomSecuritySchemeP
    *
    * @return name of the SecurityScheme configuration object
    */
+  @Override
   public String getName() {
     return "oauth2";
   }

--- a/domain-rrd/rrd-workflows/src/main/java/gov/va/vro/service/provider/camel/BgsApiClientRoutes.java
+++ b/domain-rrd/rrd-workflows/src/main/java/gov/va/vro/service/provider/camel/BgsApiClientRoutes.java
@@ -76,8 +76,7 @@ public class BgsApiClientRoutes extends RouteBuilder {
 
   private RequestAndMerge<BgsNotesCamelBody, BgsApiClientRequest, BgsApiClientResponse>
       requestBgsToAddNotesProcessor() {
-    return RequestAndMerge.<BgsNotesCamelBody, BgsApiClientRequest, BgsApiClientResponse>factory(
-            producerTemplate)
+    return RequestAndMerge.<BgsNotesCamelBody, BgsApiClientRequest, BgsApiClientResponse>factory(producerTemplate)
         .requestUri(BGSCLIENT_ADDNOTES)
         .prepareRequest(body -> body.currentRequest())
         // set responseClass so that Camel auto-converts JSON into object

--- a/domain-xample/xample-api-controller/src/main/java/gov/va/vro/api/xample/v3/XampleResource.java
+++ b/domain-xample/xample-api-controller/src/main/java/gov/va/vro/api/xample/v3/XampleResource.java
@@ -29,7 +29,7 @@ public interface XampleResource {
   @Operation(
       summary = "Create Xample Resource",
       description =
-          "Generates a Xample Resource for a specific payload."
+          "Generates a Xample Resource for a specific payload. "
               + "The created resource will be available using the GET endpoint.")
   @ApiResponses(
       value = {

--- a/domain-xample/xample-workflows/src/main/java/gov/va/vro/routes/xample/XampleRoutes.java
+++ b/domain-xample/xample-workflows/src/main/java/gov/va/vro/routes/xample/XampleRoutes.java
@@ -51,7 +51,7 @@ public class XampleRoutes extends EndpointRouteBuilder {
     //            SomeDtoModel.class, model -> dbHelper.saveToDb(model)));
 
     var setStatusReceived =
-        new FunctionProcessor<SomeDtoModel, SomeDtoModel>(
+        FunctionProcessor.<SomeDtoModel, SomeDtoModel>fromFunction(
             SomeDtoModel.class, model -> model.status(StatusValue.RECEIVED));
 
     // This route looks long due to the code comments but it's not doing much:
@@ -144,7 +144,7 @@ public class XampleRoutes extends EndpointRouteBuilder {
 
   void configureRouteToServiceA() {
     var setStatusDone =
-        new FunctionProcessor<SomeDtoModel, SomeDtoModel>(
+        FunctionProcessor.<SomeDtoModel, SomeDtoModel>fromFunction(
             SomeDtoModel.class, model -> model.status(StatusValue.DONE));
 
     from(SERVICE_A_ENDPOINT)

--- a/shared/lib-camel-connector/src/main/java/gov/va/vro/camel/processor/FunctionProcessor.java
+++ b/shared/lib-camel-connector/src/main/java/gov/va/vro/camel/processor/FunctionProcessor.java
@@ -46,7 +46,7 @@ import java.util.function.Function;
 @SuperBuilder(toBuilder = true)
 @AllArgsConstructor
 @NoArgsConstructor
-public class FunctionProcessor<I, O>  extends VroCamelProcessor implements Processor{
+public class FunctionProcessor<I, O>  extends VroCamelProcessor implements Processor {
   // The expected input type. If null, no automatic conversion is done
   @Builder.Default Class<I> inputBodyClass = null;
 

--- a/shared/lib-camel-connector/src/main/java/gov/va/vro/camel/processor/FunctionProcessor.java
+++ b/shared/lib-camel-connector/src/main/java/gov/va/vro/camel/processor/FunctionProcessor.java
@@ -3,6 +3,7 @@ package gov.va.vro.camel.processor;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.NoArgsConstructor;
+import lombok.NonNull;
 import lombok.experimental.SuperBuilder;
 import org.apache.camel.Exchange;
 import org.apache.camel.Processor;
@@ -56,9 +57,15 @@ public class FunctionProcessor<I, O> implements Processor {
   ProcessorUtils processorUtils;
 
   /** When using this, no automatic conversion is done with the input message body. */
-  public static <I, O> FunctionProcessor<I, O> fromFunction(Function<I, O> function, ProcessorUtils processorUtils) {
+  public static <I, O> FunctionProcessor<I, O> fromFunction(Function<I, O> function) {
     return FunctionProcessor.<I, O>builder().function(function)
-            .processorUtils(processorUtils).build();
+            .processorUtils(new ProcessorUtils()).build();
+  }
+
+  public static <I, O> FunctionProcessor<I, O> fromFunction(Class<I> inputBodyClass, Function<I, O> function) {
+    return FunctionProcessor.<I, O>builder().function(function)
+            .inputBodyClass(inputBodyClass)
+            .processorUtils(new ProcessorUtils()).build();
   }
 
   @Override

--- a/shared/lib-camel-connector/src/main/java/gov/va/vro/camel/processor/FunctionProcessor.java
+++ b/shared/lib-camel-connector/src/main/java/gov/va/vro/camel/processor/FunctionProcessor.java
@@ -46,7 +46,7 @@ import java.util.function.Function;
 @SuperBuilder(toBuilder = true)
 @AllArgsConstructor
 @NoArgsConstructor
-public class FunctionProcessor<I, O> implements Processor {
+public class FunctionProcessor<I, O>  extends VroCamelProcessor implements Processor{
   // The expected input type. If null, no automatic conversion is done
   @Builder.Default Class<I> inputBodyClass = null;
 
@@ -60,10 +60,10 @@ public class FunctionProcessor<I, O> implements Processor {
 
   @Override
   public void process(Exchange exchange) {
-    I input = ProcessorUtils.getInputBody(exchange, inputBodyClass);
+    I input = getInputBody(exchange, inputBodyClass);
     // In case of ClassCastException here, did you set inputBodyClass?
     O result = function.apply(input);
 
-    ProcessorUtils.conditionallySetOutputBody(exchange, result);
+    conditionallySetOutputBody(exchange, result);
   }
 }

--- a/shared/lib-camel-connector/src/main/java/gov/va/vro/camel/processor/FunctionProcessor.java
+++ b/shared/lib-camel-connector/src/main/java/gov/va/vro/camel/processor/FunctionProcessor.java
@@ -46,24 +46,27 @@ import java.util.function.Function;
 @SuperBuilder(toBuilder = true)
 @AllArgsConstructor
 @NoArgsConstructor
-public class FunctionProcessor<I, O>  extends VroCamelProcessor implements Processor {
+public class FunctionProcessor<I, O> implements Processor {
   // The expected input type. If null, no automatic conversion is done
   @Builder.Default Class<I> inputBodyClass = null;
 
   // The operation to apply to the input message body
   Function<I, O> function;
 
+  ProcessorUtils processorUtils;
+
   /** When using this, no automatic conversion is done with the input message body. */
-  public static <I, O> FunctionProcessor<I, O> fromFunction(Function<I, O> function) {
-    return FunctionProcessor.<I, O>builder().function(function).build();
+  public static <I, O> FunctionProcessor<I, O> fromFunction(Function<I, O> function, ProcessorUtils processorUtils) {
+    return FunctionProcessor.<I, O>builder().function(function)
+            .processorUtils(processorUtils).build();
   }
 
   @Override
   public void process(Exchange exchange) {
-    I input = getInputBody(exchange, inputBodyClass);
+    I input = processorUtils.getInputBody(exchange, inputBodyClass);
     // In case of ClassCastException here, did you set inputBodyClass?
     O result = function.apply(input);
 
-    conditionallySetOutputBody(exchange, result);
+    processorUtils.conditionallySetOutputBody(exchange, result);
   }
 }

--- a/shared/lib-camel-connector/src/main/java/gov/va/vro/camel/processor/ProcessorUtils.java
+++ b/shared/lib-camel-connector/src/main/java/gov/va/vro/camel/processor/ProcessorUtils.java
@@ -1,14 +1,11 @@
 package gov.va.vro.camel.processor;
 
 import lombok.NoArgsConstructor;
-import lombok.experimental.SuperBuilder;
 import org.apache.camel.Exchange;
 
 import java.util.Optional;
 
-@SuperBuilder(toBuilder = true)
-@NoArgsConstructor
-abstract class VroCamelProcessor {
+final class ProcessorUtils {
 
   @SuppressWarnings("unchecked")
   <I> I getInputBody(Exchange exchange, Class<I> inputBodyClass) {
@@ -21,7 +18,7 @@ abstract class VroCamelProcessor {
     switch (exchange.getPattern()) {
       case InOut -> exchange.getMessage().setBody(body);
       case InOptionalOut -> {
-        if (body == null || (body instanceof Optional && ((Optional) body).isEmpty())) break;
+        if (body == null || (body instanceof Optional && ((Optional<?>) body).isEmpty())) break;
         exchange.getMessage().setBody(body);
       }
       default -> {}

--- a/shared/lib-camel-connector/src/main/java/gov/va/vro/camel/processor/RequestAndMerge.java
+++ b/shared/lib-camel-connector/src/main/java/gov/va/vro/camel/processor/RequestAndMerge.java
@@ -41,7 +41,7 @@ import java.util.function.Function;
 // see https://github.com/projectlombok/lombok/issues/2524#issuecomment-662838468
 @SuperBuilder(toBuilder = true)
 @AllArgsConstructor
-public class RequestAndMerge<I, REQ, RESP> implements Processor {
+public class RequestAndMerge<I, REQ, RESP> extends VroCamelProcessor implements Processor {
   ProducerTemplate producer;
 
   public static <I, REQ, RESP> RequestAndMergeBuilder<I, REQ, RESP, ?, ?> factory(
@@ -75,12 +75,12 @@ public class RequestAndMerge<I, REQ, RESP> implements Processor {
   }
 
   public void process(Exchange exchange) {
-    I input = ProcessorUtils.getInputBody(exchange, inputBodyClass);
+    I input = getInputBody(exchange, inputBodyClass);
     REQ request = prepareRequest.apply(input);
     RESP response = makeRequest(request, exchange.getMessage().getHeaders());
     I mergedBody = mergeResponse.apply(input, response);
 
-    ProcessorUtils.conditionallySetOutputBody(exchange, mergedBody);
+    conditionallySetOutputBody(exchange, mergedBody);
   }
 
   @SuppressWarnings("unchecked")

--- a/shared/lib-camel-connector/src/main/java/gov/va/vro/camel/processor/RequestAndMerge.java
+++ b/shared/lib-camel-connector/src/main/java/gov/va/vro/camel/processor/RequestAndMerge.java
@@ -68,12 +68,12 @@ public class RequestAndMerge<I, REQ, RESP> implements Processor {
 
   /** When using this, no automatic conversion is done with the input message body. */
   public static <I, REQ, RESP> RequestAndMerge<I, REQ, RESP> build(
-      String requestUri, Function<I, REQ> prepareRequest, BiFunction<I, RESP, I> mergeResponse, ProcessorUtils processorUtils) {
+      String requestUri, Function<I, REQ> prepareRequest, BiFunction<I, RESP, I> mergeResponse) {
     return RequestAndMerge.<I, REQ, RESP>builder()
         .requestUri(requestUri)
         .prepareRequest(prepareRequest)
         .mergeResponse(mergeResponse)
-        .processorUtils(processorUtils)
+        .processorUtils(new ProcessorUtils())
         .build();
   }
 

--- a/shared/lib-camel-connector/src/main/java/gov/va/vro/camel/processor/VroCamelProcessor.java
+++ b/shared/lib-camel-connector/src/main/java/gov/va/vro/camel/processor/VroCamelProcessor.java
@@ -1,9 +1,13 @@
 package gov.va.vro.camel.processor;
 
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 import org.apache.camel.Exchange;
 
 import java.util.Optional;
 
+@SuperBuilder(toBuilder = true)
+@NoArgsConstructor
 abstract class VroCamelProcessor {
 
   @SuppressWarnings("unchecked")

--- a/shared/lib-camel-connector/src/main/java/gov/va/vro/camel/processor/VroCamelProcessor.java
+++ b/shared/lib-camel-connector/src/main/java/gov/va/vro/camel/processor/VroCamelProcessor.java
@@ -4,22 +4,23 @@ import org.apache.camel.Exchange;
 
 import java.util.Optional;
 
-final class ProcessorUtils {
+abstract class VroCamelProcessor {
 
   @SuppressWarnings("unchecked")
-  static <I> I getInputBody(Exchange exchange, Class<I> inputBodyClass) {
+  <I> I getInputBody(Exchange exchange, Class<I> inputBodyClass) {
     if (inputBodyClass == null) return (I) exchange.getIn().getBody();
 
     return exchange.getIn().getBody(inputBodyClass);
   }
 
-  static void conditionallySetOutputBody(Exchange exchange, Object body) {
+  void conditionallySetOutputBody(Exchange exchange, Object body) {
     switch (exchange.getPattern()) {
       case InOut -> exchange.getMessage().setBody(body);
       case InOptionalOut -> {
         if (body == null || (body instanceof Optional && ((Optional) body).isEmpty())) break;
         exchange.getMessage().setBody(body);
       }
+      default -> {}
     }
   }
 }


### PR DESCRIPTION
<!-- Ensure the PR title reflects the feature or bug name -->

## What was the problem?
<!-- brief description of how things worked before this PR -->
Alerts of about points of common weakness on our public repo is concerning as a potential flag for malicious actors. Having a large number of security alerts which we have not addressed also obscures newer, potentially more serious alerts.

## How does this fix it?[^1]
<!-- description of how things will work after this PR -->
* Addresses the vulnerabilities (apart from those in `svc-bip-api` which is in development) in the queue at https://github.com/department-of-veterans-affairs/abd-vro/security/code-scanning
* Refactors a utility class to be an abstract superclass to clean up references and abide by https://www.vojtechruzicka.com/avoid-utility-classes recommendations

[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
