### PR TITLE
Docker: use alpine for Python base image

### DIFF
--- a/gradle-plugins/src/main/resources/docker/Dockerfile-python
+++ b/gradle-plugins/src/main/resources/docker/Dockerfile-python
@@ -2,13 +2,13 @@
 # It acts as the default Dockerfile for Python-based containers, i.e., those created by build.gradle
 # that use the local.python.container-service-convention plugin.
 # To override this file, create a src/docker/Dockerfile file in your Gradle module.
-ARG BASE_IMAGE="bitnami/python:3.10"
+ARG BASE_IMAGE="python:3.10-alpine"
 FROM ${BASE_IMAGE}
 
 # hadolint ignore=DL3018
-#RUN apk update && apk --no-cache add libcrypto1.1=1.1.1t-r2 libcrypto3 libssl1.1=1.1.1t-r2 libssl3 && rm -rf /var/cache/apk/*
+RUN apk update && apk --no-cache upgrade && apk add git && rm -rf /var/cache/apk/*
 
-RUN adduser --gecos "" --disabled-password tron
+RUN adduser --disabled-password tron
 
 ARG HEALTHCHECK_PORT_ARG
 ENV HEALTHCHECK_PORT=${HEALTHCHECK_PORT_ARG}


### PR DESCRIPTION
## What was the problem?
Bitnami base image has a SecRel issue at the OS level and did not have a clear timeline when it would be fixed
Associated tickets or Slack threads:
- #?

## How does this fix it?[^1]
Python images will build with python:3.10-alpine, as was previously used. 

