### PR TITLE
Specify stdout as stream for CC logging

### DIFF
--- a/domain-cc/cc-app/src/python_src/api.py
+++ b/domain-cc/cc-app/src/python_src/api.py
@@ -1,4 +1,5 @@
 import logging
+from sys import stdout
 from typing import Optional
 
 from fastapi import FastAPI, HTTPException
@@ -21,6 +22,7 @@ logging.basicConfig(
     format="[%(asctime)s] %(levelname)-8s %(message)s",
     level=logging.INFO,
     datefmt="%Y-%m-%d %H:%M:%S",
+    stream=stdout,
 )
 
 

--- a/domain-cc/cc-app/src/python_src/api.py
+++ b/domain-cc/cc-app/src/python_src/api.py
@@ -1,5 +1,5 @@
 import logging
-from sys import stdout
+import sys
 from typing import Optional
 
 from fastapi import FastAPI, HTTPException
@@ -22,7 +22,7 @@ logging.basicConfig(
     format="[%(asctime)s] %(levelname)-8s %(message)s",
     level=logging.INFO,
     datefmt="%Y-%m-%d %H:%M:%S",
-    stream=stdout,
+    stream=sys.stdout,
 )
 
 


### PR DESCRIPTION
<!-- Ensure the PR title reflects the feature or bug name -->

## What was the problem?
<!-- brief description of how things worked before this PR -->
All messages are showing as errors in datadog for the domain-cc application.

Associated tickets or Slack threads:
- #1723 

## How does this fix it?[^1]
<!-- description of how things will work after this PR -->
According to this issue https://stackoverflow.com/questions/73807939/python-logging-in-datadog-all-error-status stderr is used as default stream for logging implementation.

[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
