### PR TITLE
address secrel by specifying latest guava version in build

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -29,6 +29,7 @@ dependencies {
 
   implementation group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.14'
   implementation 'io.jsonwebtoken:jjwt:0.2'
+  implementation 'com.google.guava:guava:32.0.1-jre'
 
   testRuntimeOnly "com.h2database:h2:${h2_version}"
 }

--- a/svc-lighthouse-api/build.gradle
+++ b/svc-lighthouse-api/build.gradle
@@ -23,6 +23,7 @@ dependencies {
   implementation 'org.bouncycastle:bcprov-jdk15on:1.70'
   implementation 'org.apache.commons:commons-lang3:3.12.0'
   implementation 'io.jsonwebtoken:jjwt:0.9.1'
+  implementation 'com.google.guava:guava:32.0.1-jre'
 
   testImplementation "org.apache.camel.springboot:camel-rabbitmq-starter:${camel_version}"
   //  testImplementation "org.junit.jupiter:junit-jupiter-api:${junit_jupiter_version}"


### PR DESCRIPTION
App and Lighthouse have dependencies on google guava, and a vulnerability was found in older versions. The PR ensures that version 32.01 is used as recommended by Aqua.

Associated tickets or Slack threads:
https://dsva.slack.com/archives/C04CA47HV96/p1688059136226939

