### PR TITLE
address secrel by specifying latest guava version in constraint file

### DIFF
--- a/gradle-plugins/src/main/groovy/shared.java.vro-dep-constraints.gradle
+++ b/gradle-plugins/src/main/groovy/shared.java.vro-dep-constraints.gradle
@@ -46,6 +46,10 @@ dependencies {
             because("security vulnerability in prior versions")
         }
 
+        implementation('com.google.guava:guava:32.0.1-jre') {
+            because("security vulnerability in prior versions")
+        }
+
         // These are used indirectly but we need to specify versions, otherwise build error
         annotationProcessor "org.springframework.boot:spring-boot-autoconfigure-processor:${spring_boot_version}"
         annotationProcessor "org.mapstruct:mapstruct-processor:${mapstruct_version}"


### PR DESCRIPTION
This PR replaces 1770, to follow Yoom suggestion to use the constraints file, and discard previous commits.

App and Lighthouse have dependencies on google guava, and a vulnerability was found in older versions. The PR ensures that version 32.01 is used as recommended by Aqua.

Associated tickets or Slack threads:
https://dsva.slack.com/archives/C04CA47HV96/p1688059136226939
