### PR TITLE
Fixed topic map property that was missed after refactored on review.

### DIFF
--- a/svc-bie-kafka/src/main/resources/application.yaml
+++ b/svc-bie-kafka/src/main/resources/application.yaml
@@ -14,7 +14,7 @@ spring:
 
 ## Specify bie properties
 bie:
-  topic-map:
+  kafka-topic-to-amqp-queue-map:
     # Map of entries where the keys are the kafka topics to which this app will subscribe. The value is the corresponding
     # RabbitMQ exchange/queue upon which the payload will be put. These values are separated by a colon ":" character.
     TST_CONTENTION_BIE_CONTENTION_ASSOCIATED_TO_CLAIM_V02: bie-events-contention-associated


### PR DESCRIPTION
<!-- Ensure the PR title reflects the feature or bug name -->

## What was the problem?
<!-- brief description of how things worked before this PR -->
topic to queue map was refactored at the end of review #1767 in BieProperties.java, but it was not changed to reflect new name in the application.yaml file.

## How does this fix it?
<!-- description of how things will work after this PR -->
Fixes the name.

## How to test this PR
- See steps in #1767 
