### PR TITLE
1591: Increased request timeout to 3 seconds with 3 retries to vro app post endpoint.

### DIFF
--- a/.github/workflows/api-gateway-integration-test.yml
+++ b/.github/workflows/api-gateway-integration-test.yml
@@ -121,6 +121,8 @@ jobs:
           method: "POST"
           body: '{"resourceId":"20230706","diagnosticCode":"J"}'
           accept: 201
+          timeout: 3000
+          retries: 3
 
       - name: "Clean shutdown of all containers"
         if: always()


### PR DESCRIPTION
<!-- Ensure the PR title reflects the feature or bug name -->

## What was the problem?
<!-- brief description of how things worked before this PR -->
Post request made by API Gateway to VRO App reached timeout of 1000ms with only a single retry.

Associated tickets or Slack threads:
- #?

## How does this fix it?[^1]
<!-- description of how things will work after this PR -->
Set request timeout to 3000ms with 3 retries before failing test.

## How to test this PR
Run Continuous Integration test [here](https://github.com/department-of-veterans-affairs/abd-vro/actions/workflows/continuous-integration.yml)


[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
