### PR TITLE
infinite error handling fix

### DIFF
--- a/domain-xample/svc-xample-j/src/main/java/gov/va/vro/services/xample/JavaMicroserviceApplication.java
+++ b/domain-xample/svc-xample-j/src/main/java/gov/va/vro/services/xample/JavaMicroserviceApplication.java
@@ -84,15 +84,14 @@ public class JavaMicroserviceApplication {
               org.springframework.messaging.Message<?> message,
               ListenerExecutionFailedException exception) {
             try {
-              log.error("Oh no!", exception);
+              log.error("Oh no! " + Util.fl(), exception);
               var errorModel = SomeDtoModel.builder().resourceId("").diagnosticCode("").build();
               errorModel.header(500, exception.toString());
               return errorModel;
-            }
-            catch(Exception e){
-              log.error("Exception handler threw exception. Call 911. Exiting");
+            } catch (Exception e) {
+              log.error("Exception handler threw exception. Call 911. Exiting. {}", Util.fl());
               System.exit(-1);
-              return null; //never executed
+              return null; // never executed
             }
           }
         };

--- a/domain-xample/svc-xample-j/src/main/java/gov/va/vro/services/xample/JavaMicroserviceApplication.java
+++ b/domain-xample/svc-xample-j/src/main/java/gov/va/vro/services/xample/JavaMicroserviceApplication.java
@@ -82,18 +82,18 @@ public class JavaMicroserviceApplication {
           public Object handleError(
               Message amqpMessage,
               org.springframework.messaging.Message<?> message,
-              ListenerExecutionFailedException exception)
-              throws Exception {
-            log.info("Oh no!", exception);
-
-            if (message != null && message.getHeaders().getReplyChannel() != null) {
+              ListenerExecutionFailedException exception) {
+            try {
+              log.error("Oh no!", exception);
               var errorModel = SomeDtoModel.builder().resourceId("").diagnosticCode("").build();
               errorModel.header(500, exception.toString());
-
               return errorModel;
             }
-
-            return null;
+            catch(Exception e){
+              log.error("Exception handler threw exception. Call 911. Exiting");
+              System.exit(-1);
+              return null; //never executed
+            }
           }
         };
     return handler;

--- a/domain-xample/svc-xample-j/src/main/java/gov/va/vro/services/xample/Util.java
+++ b/domain-xample/svc-xample-j/src/main/java/gov/va/vro/services/xample/Util.java
@@ -1,0 +1,12 @@
+package gov.va.vro.services.xample;
+
+public class Util {
+  /**
+   * @return A string containing the file name and line number of where the function was called
+   *     from.
+   */
+  public static String fl() {
+    StackTraceElement ste = Thread.currentThread().getStackTrace()[2];
+    return String.format("(%d,%s)", ste.getFileName(), ste.getLineNumber());
+  }
+}


### PR DESCRIPTION


Thi is a proposed solution to [this issue](https://github.com/department-of-veterans-affairs/abd-vro/issues/1738)

## What was the problem?

When error handler throws an error, it catches the error it just threw. And so on and on forever.

Associated tickets or Slack threads:
 [this issue](https://github.com/department-of-veterans-affairs/abd-vro/issues/1738)


## How does this fix it?[^1]
Instead of throwing exception it terminates the process. In prod that out to get the attention of dev ops much faster than an infinitely spinning process.

## How to test this PR
There is not really a way without modifying the code.

[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
