### PR TITLE
Docker: add svc-bie-kafka container image

### DIFF
--- a/.github/workflows/update-deployment.yml
+++ b/.github/workflows/update-deployment.yml
@@ -23,6 +23,7 @@ on:
         options:
         - domain-cc
         - svc-bgs-api
+        - svc-bie-kafka
         - svc-lighthouse-api
         - api-gateway
 

--- a/app/docker-compose.yml
+++ b/app/docker-compose.yml
@@ -109,7 +109,7 @@ services:
       - vro_intranet
 
   svc-bie-kafka:
-    profiles: [ "all","kafka" ]
+    profiles: [ "all","svc","kafka" ]
     image: va/abd_vro-svc-bie-kafka:latest
     <<: [ *common-sde-security, *common-security-opt ]
     environment:

--- a/scripts/image-names.sh
+++ b/scripts/image-names.sh
@@ -32,7 +32,7 @@ prodImageName() {
 # subdirectory, be sure to add the sub directory to the gradleFolder function above
 IMAGES=( console postgres \
   api-gateway app db-init \
-  svc-bgs-api svc-lighthouse-api \
+  svc-bgs-api svc-lighthouse-api svc-bie-kafka \
   cc-app )
 echo
 echo "=== ${#IMAGES[@]} VRO images"

--- a/scripts/image_vars.src
+++ b/scripts/image_vars.src
@@ -5,14 +5,14 @@
 
 # Array of VRO images
 # shellcheck disable=SC2034
-VRO_IMAGES_ARR=( console postgres api-gateway app db-init svc-bgs-api svc-lighthouse-api cc-app )
+VRO_IMAGES_ARR=( console postgres api-gateway app db-init svc-bgs-api svc-lighthouse-api svc-bie-kafka cc-app )
 # Usage: for IMG in ${VRO_IMAGES_ARR[@]}; do echo "- $IMG"; done
-export VRO_IMAGES="console postgres api-gateway app db-init svc-bgs-api svc-lighthouse-api cc-app"
+export VRO_IMAGES="console postgres api-gateway app db-init svc-bgs-api svc-lighthouse-api svc-bie-kafka cc-app"
 
 # Array of variable prefixes
 # shellcheck disable=SC2034
-VAR_PREFIXES_ARR=( console postgres apigateway app dbinit svcbgsapi svclighthouseapi ccapp )
-export VAR_PREFIXES="console postgres apigateway app dbinit svcbgsapi svclighthouseapi ccapp"
+VAR_PREFIXES_ARR=( console postgres apigateway app dbinit svcbgsapi svclighthouseapi svcbiekafka ccapp )
+export VAR_PREFIXES="console postgres apigateway app dbinit svcbgsapi svclighthouseapi svcbiekafka ccapp"
 
 LAST_RELEASE_VERSION=$(tail -1 versions.txt)
 
@@ -89,6 +89,11 @@ export svcbgsapi_VER="$LAST_RELEASE_VERSION"
 export svclighthouseapi_GRADLE_IMG="va/abd_vro-svc-lighthouse-api"
 export svclighthouseapi_IMG="vro-svc-lighthouse-api"
 export svclighthouseapi_VER="$LAST_RELEASE_VERSION"
+
+# --- svc-bie-kafka in folder ./svc-bie-kafka
+export svcbiekafka_GRADLE_IMG="va/abd_vro-svc-bie-kafka"
+export svcbiekafka_IMG="vro-svc-bie-kafka"
+export svcbiekafka_VER="$LAST_RELEASE_VERSION"
 
 # --- cc-app in folder domain-cc/cc-app
 export ccapp_GRADLE_IMG="va/abd_vro-cc-app"


### PR DESCRIPTION
<!-- Ensure the PR title reflects the feature or bug name -->

## What was the problem?
<!-- brief description of how things worked before this PR -->
Need a container image for svc-bie-kafka in order to deploy to LHDI

Associated tickets or Slack threads:
- #1791 

## How does this fix it?
<!-- description of how things will work after this PR -->
- Add svc-bie-kafka container image so it can be built and published to GHCR
- Updated GH Action workflows to redeploy BIE Kafka microservice to LHDI

## How to test this PR
```
./gradlew docker
./gradlew :dockerComposeUp
COMPOSE_PROFILES="kafka" ./gradlew -p mocks :dockerComposeUp
COMPOSE_PROFILES="svc" ./gradlew :app:dockerComposeUp
```
Verify that svc-bie-kafka container is running.
