### PR TITLE
Secrets Vault: add further specific instructions

### DIFF
--- a/.github/runner/set-k8s-secrets.sh
+++ b/.github/runner/set-k8s-secrets.sh
@@ -19,7 +19,12 @@ fi
 
 # All secrets are in the Vault in mapi
 export VAULT_ADDR=https://ldx-mapi.lighthouse.va.gov
-vault login "$VAULT_TOKEN" &> /dev/null || { echo "Could not log into Vault $VAULT_ADDR using VAULT_TOKEN"; exit 4; }
+vault login "$VAULT_TOKEN" &> /dev/null || {
+  echo "Could not log into Vault $VAULT_ADDR using VAULT_TOKEN, which may be expired."
+  echo "Try running locally: scripts/set-secret-vault-token.sh <newTokenFromVaultWebGUI>"
+  echo "See https://github.com/department-of-veterans-affairs/abd-vro/wiki/Secrets-Vault#setting-the-vault-token-secret"
+  exit 4;
+}
 
 # GitHub Team name, which used as the root path for Vault secrets
 # https://github.com/orgs/department-of-veterans-affairs/teams/vro-admins/members


### PR DESCRIPTION
<!-- Ensure the PR title reflects the feature or bug name -->

## What was the problem?
<!-- brief description of how things worked before this PR -->
It's not obvious how to remedy a failure in running the `vro-set-secrets-dev` container in LHDI, triggered by the [Deploy secrets from Vault workflow](https://github.com/department-of-veterans-affairs/abd-vro-internal/actions/workflows/deploy-secrets.yml)

Associated tickets or Slack threads:
- #1791

## How does this fix it?
<!-- description of how things will work after this PR -->
Add more instructions to error message

## How to test this PR
Will pair with @msnwatson and @chengjie8 to address the error message.
Also documented at https://github.com/department-of-veterans-affairs/abd-vro/wiki/Secrets-Vault#setting-the-vault-token-secret