### PR TITLE
Updating latest snappy java version using override file

### DIFF
--- a/gradle-plugins/src/main/groovy/shared.java.vro-dep-constraints.gradle
+++ b/gradle-plugins/src/main/groovy/shared.java.vro-dep-constraints.gradle
@@ -46,6 +46,11 @@ dependencies {
             because("security vulnerability in prior versions")
         }
 
+        // For Kafka svc-bie-kafka service override
+        implementation('org.xerial.snappy:snappy-java:1.1.10.1') {
+            because("security vulnerability in prior versions")
+        }
+
         implementation('com.google.guava:guava:32.0.1-jre') {
             because("security vulnerability in prior versions")
         }
@@ -53,5 +58,6 @@ dependencies {
         // These are used indirectly but we need to specify versions, otherwise build error
         annotationProcessor "org.springframework.boot:spring-boot-autoconfigure-processor:${spring_boot_version}"
         annotationProcessor "org.mapstruct:mapstruct-processor:${mapstruct_version}"
+
     }
 }


### PR DESCRIPTION
<!-- Ensure the PR title reflects the feature or bug name -->

## What was the problem?
Older version of Snappy Java has security issues

Associated tickets or Slack threads:
- #1798 

## How does this fix it?[^1]
Fixes #1798 - updating a dependent package of Kafka lib

## How to test this PR
- Makes sure that SecRel is passing after un-suppressing snappy java issues.
