### PR TITLE
1677: Create End to End BIE Kafka Integration Test

### DIFF
--- a/.github/workflows/bie-kafka-end2end-test-with-mock.yml
+++ b/.github/workflows/bie-kafka-end2end-test-with-mock.yml
@@ -80,6 +80,16 @@ jobs:
             echo "Count not find Kafka broker"
           fi
 
+      - name: 'Wait for xample-workflow to be ready'
+        uses: nev7n/wait_for_response@v1
+        with:
+          url: 'http://localhost:10021/actuator/health'
+          responseCode: 200
+          # Retry every 2 seconds
+          interval: 2000
+          # Quit after 60 seconds
+          timeout: 60000
+
       - name: 'Wait for svc-bie-kafka to be ready'
         uses: nev7n/wait_for_response@v1
         with:
@@ -105,11 +115,11 @@ jobs:
 
       - name: 'Find entry in Postgres'
         run: |
-          psql postgres://$POSTGRES_USER:$POSTGRES_PASSWORD@localhost:5432/vro -x -c
+          psql postgres://$POSTGRES_USER:$POSTGRES_PASSWORD@localhost:5432/vro -c \
           "SELECT *
             FROM
               claims.bie_contention_event
-          ")
+          "
 
           RESULTS=$(psql postgres://$POSTGRES_USER:$POSTGRES_PASSWORD@localhost:5432/vro -x -c \
           "SELECT COUNT(*)

--- a/.github/workflows/bie-kafka-end2end-test-with-mock.yml
+++ b/.github/workflows/bie-kafka-end2end-test-with-mock.yml
@@ -93,14 +93,12 @@ jobs:
       - name: 'Create Kafka topic and send message'
         run: |
           # Create Test File:
-
-
           echo '${{env.TEST_DATA}}' > test.txt
 
           # Send the test message
-          kcat -b 127.0.0.1:9092 -P -t '${{env.TEST_TOPIC}}' -l test.txt
+          kafkacat -b localhost:9092 -P -t '${{env.TEST_TOPIC}}' -l test.txt
 
-      - name: 'Sleep to give time for message to travel end 2 end from kafka to saved in database'
+      - name: 'Sleep to give time for message to travel end to end from kafka to saved in database'
         run: sleep 5
 
       - name: 'Find entry in Postgres'

--- a/.github/workflows/bie-kafka-end2end-test-with-mock.yml
+++ b/.github/workflows/bie-kafka-end2end-test-with-mock.yml
@@ -1,0 +1,81 @@
+name: 'CI: BIE Kafka End 2 End Test with Mock'
+
+on:
+  # Allow manual triggering
+  workflow_dispatch:
+
+  # Allow being called by another GitHub Action
+  workflow_call:
+
+concurrency:
+  group: bieKafkaEnd2EndTestWithMock-${{ github.ref }}
+
+env:
+  COMPOSE_PROFILES: 'kafka'
+
+jobs:
+  integration-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Install kcat'
+        run: |
+          sudo apt-get update
+          sudo apt-get install kafkacat
+          which kafkacat
+
+      - name: 'Checkout source code'
+        uses: actions/checkout@v3
+
+      - name: 'Build the images'
+        uses: ./.github/actions/build-images
+
+      - name: 'Start the containers'
+        run: |
+          source scripts/setenv.sh
+
+          # create basic auth token for RabbitMQ and export to github environment
+          BASIC_AUTH=`echo "${RABBITMQ_PLACEHOLDERS_USERNAME}:${RABBITMQ_PLACEHOLDERS_USERPASSWORD}" | base64`
+          echo "RABBITMQ_PLACEHOLDERS_USERNAME=${RABBITMQ_PLACEHOLDERS_USERNAME}" >> $GITHUB_ENV
+          echo "RABBITMQ_PLACEHOLDERS_USERPASSWORD=${RABBITMQ_PLACEHOLDERS_USERPASSWORD}" >> $GITHUB_ENV
+          echo "RABBITMQ_BASIC_AUTH=${BASIC_AUTH}" >> $GITHUB_ENV
+
+          export -p | sed 's/declare -x //'
+
+          ./gradlew :dockerComposeUp
+
+          ./gradlew -p mocks :mock-bie-kafka:docker
+          ./gradlew -p mocks :dockerComposeUp
+
+          ./gradlew :domain-xample:dockerComposeUp
+          ./gradlew :app:dockerComposeUp
+
+      - name: 'Wait for RabbitMQ to be ready'
+        uses: indiesdev/curl@v1.1
+        with:
+          url: 'http://localhost:15672/api/vhosts'
+          method: 'GET'
+          basic-auth-token: '${{env.RABBITMQ_BASIC_AUTH}}'
+          accept: 200
+          # Retry every 2 seconds
+          timeout: 2000
+          # Quit after 60 seconds
+          retries: 30
+
+      - name: 'Wait for Kafka to be ready and create topic'
+        run: |
+          # Verify broker is up
+          BROKER_QUERY=$(kafkacat -m 30 -b localhost:9092 -L)
+          if echo $BROKER_QUERY | grep -q '1 brokers'
+          then
+            echo "Found Broker: $BROKER_QUERY"
+          else
+            echo "Count not find Kafka broker"
+          fi
+
+      - name: 'Clean shutdown of all containers'
+        if: always()
+        shell: bash
+        run: |
+          docker ps
+          COMPOSE_PROFILES="all" ./gradlew dockerComposeDown
+          ./gradlew -p mocks :dockerComposeDown

--- a/.github/workflows/bie-kafka-end2end-test-with-mock.yml
+++ b/.github/workflows/bie-kafka-end2end-test-with-mock.yml
@@ -105,6 +105,12 @@ jobs:
 
       - name: 'Find entry in Postgres'
         run: |
+          psql postgres://$POSTGRES_USER:$POSTGRES_PASSWORD@localhost:5432/vro -x -c
+          "SELECT *
+            FROM
+              claims.bie_contention_event
+          ")
+
           RESULTS=$(psql postgres://$POSTGRES_USER:$POSTGRES_PASSWORD@localhost:5432/vro -x -c \
           "SELECT COUNT(*)
             FROM
@@ -112,7 +118,7 @@ jobs:
             WHERE
               event='${{env.TEST_TOPIC}}'
                 AND
-              event_details = '${{env.TEST_DATA}}'
+              event_details='${{env.TEST_DATA}}'
           ")
           echo $RESULTS
           if echo $RESULTS | grep -q 'count | 1'
@@ -122,6 +128,21 @@ jobs:
             echo "Could not find record in DB."
             exit 10
           fi
+
+      - name: "Collect docker logs"
+        if: always()
+        uses: jwalton/gh-docker-logs@v2
+        with:
+          dest: './bie-kafka-end2end-test-with-mock-container-logs'
+
+      - name: "Upload artifact"
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: bie-kafka-end2end-test-with-mock-container-logs
+          path: ./bie-kafka-end2end-test-with-mock-container-logs/**
+          retention-days: 14
+
 
       - name: 'Clean shutdown of all containers'
         if: always()

--- a/.github/workflows/bie-kafka-end2end-test-with-mock.yml
+++ b/.github/workflows/bie-kafka-end2end-test-with-mock.yml
@@ -12,16 +12,22 @@ concurrency:
 
 env:
   COMPOSE_PROFILES: 'kafka'
+  TEST_TOPIC: 'TST_CONTENTION_BIE_CONTENTION_ASSOCIATED_TO_CLAIM_V02'
+  # TEST_DATA should be replaced with data after event_details is populated with non PII data. See Github Issue 1680
+  TEST_DATA: 'Lorem ipsum'
 
 jobs:
   integration-test:
     runs-on: ubuntu-latest
     steps:
-      - name: 'Install kcat'
+      - name: 'Install kcat and postgresql'
         run: |
           sudo apt-get update
           sudo apt-get install kafkacat
           which kafkacat
+
+          sudo apt-get install postgresql
+          which psql
 
       - name: 'Checkout source code'
         uses: actions/checkout@v3
@@ -38,6 +44,8 @@ jobs:
           echo "RABBITMQ_PLACEHOLDERS_USERNAME=${RABBITMQ_PLACEHOLDERS_USERNAME}" >> $GITHUB_ENV
           echo "RABBITMQ_PLACEHOLDERS_USERPASSWORD=${RABBITMQ_PLACEHOLDERS_USERPASSWORD}" >> $GITHUB_ENV
           echo "RABBITMQ_BASIC_AUTH=${BASIC_AUTH}" >> $GITHUB_ENV
+          echo "POSTGRES_USER=${POSTGRES_USER}" >> $GITHUB_ENV
+          echo "POSTGRES_PASSWORD=${POSTGRES_PASSWORD}" >> $GITHUB_ENV
 
           export -p | sed 's/declare -x //'
 
@@ -61,7 +69,7 @@ jobs:
           # Quit after 60 seconds
           retries: 30
 
-      - name: 'Wait for Kafka to be ready and create topic'
+      - name: 'Wait for Kafka to be ready'
         run: |
           # Verify broker is up
           BROKER_QUERY=$(kafkacat -m 30 -b localhost:9092 -L)
@@ -70,6 +78,49 @@ jobs:
             echo "Found Broker: $BROKER_QUERY"
           else
             echo "Count not find Kafka broker"
+          fi
+
+      - name: 'Wait for svc-bie-kafka to be ready'
+        uses: nev7n/wait_for_response@v1
+        with:
+          url: 'http://localhost:10301/actuator/health'
+          responseCode: 200
+          # Retry every 2 seconds
+          interval: 2000
+          # Quit after 60 seconds
+          timeout: 60000
+
+      - name: 'Create Kafka topic and send message'
+        run: |
+          # Create Test File:
+
+
+          echo '${{env.TEST_DATA}}' > test.txt
+
+          # Send the test message
+          kcat -b 127.0.0.1:9092 -P -t '${{env.TEST_TOPIC}}' -l test.txt
+
+      - name: 'Sleep to give time for message to travel end 2 end from kafka to saved in database'
+        run: sleep 5
+
+      - name: 'Find entry in Postgres'
+        run: |
+          RESULTS=$(psql postgres://$POSTGRES_USER:$POSTGRES_PASSWORD@localhost:5432/vro -x -c \
+          "SELECT COUNT(*)
+            FROM
+              claims.bie_contention_event
+            WHERE
+              event='${{env.TEST_TOPIC}}'
+                AND
+              event_details = '${{env.TEST_DATA}}'
+          ")
+          echo $RESULTS
+          if echo $RESULTS | grep -q 'count | 1'
+          then
+            echo "Found record in DB."
+          else
+            echo "Could not find record in DB."
+            exit 10
           fi
 
       - name: 'Clean shutdown of all containers'

--- a/.github/workflows/bie-kafka-end2end-test-with-mock.yml
+++ b/.github/workflows/bie-kafka-end2end-test-with-mock.yml
@@ -72,7 +72,7 @@ jobs:
       - name: 'Wait for Kafka to be ready'
         run: |
           # Verify broker is up
-          BROKER_QUERY=$(kafkacat -m 30 -b localhost:9092 -L)
+          BROKER_QUERY=$(kafkacat -m 30 -b localhost:9094 -L)
           if echo $BROKER_QUERY | grep -q '1 brokers'
           then
             echo "Found Broker: $BROKER_QUERY"
@@ -94,9 +94,11 @@ jobs:
         run: |
           # Create Test File:
           echo '${{env.TEST_DATA}}' > test.txt
+          echo "Producing message from test.txt on ${{env.TEST_TOPIC}}: "
+          cat test.txt
 
-          # Send the test message
-          kafkacat -b localhost:9092 -P -t '${{env.TEST_TOPIC}}' -l test.txt
+          # Create Topic and Produce message on test topic
+          kafkacat -b localhost:9094 -P -t '${{env.TEST_TOPIC}}' -l test.txt
 
       - name: 'Sleep to give time for message to travel end to end from kafka to saved in database'
         run: sleep 5

--- a/.github/workflows/bie-kafka-end2end-test.yml
+++ b/.github/workflows/bie-kafka-end2end-test.yml
@@ -1,4 +1,4 @@
-name: 'CI: BIE Kafka End 2 End Test with Mock'
+name: 'CI: BIE Kafka End-2-End Test'
 
 on:
   # Allow manual triggering
@@ -35,18 +35,19 @@ jobs:
       - name: 'Build the images'
         uses: ./.github/actions/build-images
 
-      - name: 'Start the containers'
+      - name: 'Set RABBITMQ_BASIC_AUTH'
         run: |
           source scripts/setenv.sh
 
           # create basic auth token for RabbitMQ and export to github environment
           BASIC_AUTH=`echo "${RABBITMQ_PLACEHOLDERS_USERNAME}:${RABBITMQ_PLACEHOLDERS_USERPASSWORD}" | base64`
-          echo "RABBITMQ_PLACEHOLDERS_USERNAME=${RABBITMQ_PLACEHOLDERS_USERNAME}" >> $GITHUB_ENV
-          echo "RABBITMQ_PLACEHOLDERS_USERPASSWORD=${RABBITMQ_PLACEHOLDERS_USERPASSWORD}" >> $GITHUB_ENV
           echo "RABBITMQ_BASIC_AUTH=${BASIC_AUTH}" >> $GITHUB_ENV
-          echo "POSTGRES_USER=${POSTGRES_USER}" >> $GITHUB_ENV
-          echo "POSTGRES_PASSWORD=${POSTGRES_PASSWORD}" >> $GITHUB_ENV
 
+          export -p | sed 's/declare -x //'
+
+      - name: 'Start the containers'
+        run: |
+          source scripts/setenv.sh
           export -p | sed 's/declare -x //'
 
           ./gradlew :dockerComposeUp
@@ -113,8 +114,10 @@ jobs:
       - name: 'Sleep to give time for message to travel end to end from kafka to saved in database'
         run: sleep 5
 
-      - name: 'Find entry in Postgres'
+      - name: 'Check for saved DB entry in Postgres'
         run: |
+          source scripts/setenv.sh
+
           psql postgres://$POSTGRES_USER:$POSTGRES_PASSWORD@localhost:5432/vro -c \
           "SELECT *
             FROM

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -35,6 +35,6 @@ jobs:
     uses: ./.github/workflows/svc-bgs-api-integration-test.yml
     secrets: inherit
 
-  bie-kafka-end-to-end-mock:
-    uses: ./.github/workflows/bie-kafka-end2end-test-with-mock.yml
+  bie-kafka-end-to-end:
+    uses: ./.github/workflows/bie-kafka-end2end-test.yml
     secrets: inherit

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -34,3 +34,7 @@ jobs:
   svc-bgs-api:
     uses: ./.github/workflows/svc-bgs-api-integration-test.yml
     secrets: inherit
+
+  bie-kafka-end-to-end-mock:
+    uses: ./.github/workflows/bie-kafka-end2end-test-with-mock.yml
+    secrets: inherit

--- a/app/docker-compose.yml
+++ b/app/docker-compose.yml
@@ -113,6 +113,7 @@ services:
 
   svc-bie-kafka:
     ports:
+      - # Expose healthcheck port for end2end test
       - "10301:10301"
     profiles: [ "all","svc","kafka" ]
     image: va/abd_vro-svc-bie-kafka:latest

--- a/app/docker-compose.yml
+++ b/app/docker-compose.yml
@@ -112,6 +112,8 @@ services:
       - vro_intranet
 
   svc-bie-kafka:
+    ports:
+      - "10301:10301"
     profiles: [ "all","svc","kafka" ]
     image: va/abd_vro-svc-bie-kafka:latest
     <<: [ *common-sde-security, *common-security-opt ]

--- a/app/docker-compose.yml
+++ b/app/docker-compose.yml
@@ -112,8 +112,8 @@ services:
       - vro_intranet
 
   svc-bie-kafka:
+    # Expose healthcheck port for end2end test
     ports:
-      - # Expose healthcheck port for end2end test
       - "10301:10301"
     profiles: [ "all","svc","kafka" ]
     image: va/abd_vro-svc-bie-kafka:latest

--- a/domain-xample/docker-compose.yml
+++ b/domain-xample/docker-compose.yml
@@ -53,8 +53,8 @@ services:
       <<: [*postgres-vars, *rabbitmq-placeholder-vars, *redis-placeholder-vars]
     networks:
       - vro_intranet
+    # Expose healthcheck port for end2end test
     ports:
-      # Expose healthcheck port for end2end test
       - "10021:10021"
 
   svc-xample-j:

--- a/domain-xample/docker-compose.yml
+++ b/domain-xample/docker-compose.yml
@@ -54,6 +54,7 @@ services:
     networks:
       - vro_intranet
     ports:
+      # Expose healthcheck port for end2end test
       - "10021:10021"
 
   svc-xample-j:

--- a/domain-xample/docker-compose.yml
+++ b/domain-xample/docker-compose.yml
@@ -53,6 +53,8 @@ services:
       <<: [*postgres-vars, *rabbitmq-placeholder-vars, *redis-placeholder-vars]
     networks:
       - vro_intranet
+    ports:
+      - "10021:10021"
 
   svc-xample-j:
     image: va/abd_vro-svc-xample-j:latest

--- a/mocks/docker-compose.yml
+++ b/mocks/docker-compose.yml
@@ -59,10 +59,12 @@ services:
     profiles: ["all","kafka"]
     image: va/vro_mocks-mock-bie-kafka:latest
     <<: [*common-sde-security, *common-security-opt]
+    # Port 9092 is for internal communication within the vro_intranet, and is needed for consuming/producing messages
+    # within the vro_intranet docker network. In order to produce/consume messages outside the vro_intranet network,
+    # the port 9094 is exposed for external communication with mock-bie-kafka from outside the vro_intranet. Advertised
+    # listeners are configured to consume messages on both ports.
     ports:
-      # Port 9092 is for internal communication within the vro_intranet
       - "9092:9092"
-      # Port 9094 is for external communication outside the vro_intranet
       - "9094:9094"
     environment:
       <<: *common-vars

--- a/mocks/docker-compose.yml
+++ b/mocks/docker-compose.yml
@@ -61,11 +61,15 @@ services:
     <<: [*common-sde-security, *common-security-opt]
     ports:
       - "9092:9092"
+      - "9094:9094"
     environment:
       <<: *common-vars
       # for development only; TODO: Update with BIE-like authentication
       ALLOW_PLAINTEXT_LISTENER: 'yes'
-      KAFKA_CFG_ADVERTISED_LISTENERS: PLAINTEXT://mock-bie-kafka:9092
+      KAFKA_ADVERTISED_HOST_NAME: mock-bie-kafka
+      KAFKA_CFG_LISTENERS: PLAINTEXT://:9092,CONTROLLER://:9093,EXTERNAL://:9094
+      KAFKA_CFG_ADVERTISED_LISTENERS: PLAINTEXT://mock-bie-kafka:9092,EXTERNAL://localhost:9094
+      KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,EXTERNAL:PLAINTEXT,PLAINTEXT:PLAINTEXT
     networks:
       - vro_intranet
 

--- a/mocks/docker-compose.yml
+++ b/mocks/docker-compose.yml
@@ -60,7 +60,9 @@ services:
     image: va/vro_mocks-mock-bie-kafka:latest
     <<: [*common-sde-security, *common-security-opt]
     ports:
+      # Port 9092 is for internal communication within the vro_intranet
       - "9092:9092"
+      # Port 9094 is for external communication outside the vro_intranet
       - "9094:9094"
     environment:
       <<: *common-vars

--- a/svc-bie-kafka/src/main/resources/application.yaml
+++ b/svc-bie-kafka/src/main/resources/application.yaml
@@ -14,15 +14,16 @@ spring:
   kafka:
     consumer:
       group-id: "${BIE_KAFKA_PLACEHOLDERS_GROUP_ID:vro-bie-group}"
-      security:
-        protocol: SSL
-      ssl:
-        keystore-location: "file:${KEYSTORE_FILE}"
-        keystore-password: "${BIE_KAFKA_KEYSTORE_PASSWORD}"
-        key-store-type: "PKCS12"
-        truststore-location: "file:${TRUSTSTORE_FILE}"
-        truststore-password: "${BIE_KAFKA_TRUSTSTORE_PASSWORD}"
-        trust-store-type: "PKCS12"
+      # TODO: Uncomment the following lines after completion of https://github.com/department-of-veterans-affairs/abd-vro/issues/1823
+#      security:
+#        protocol: SSL
+#      ssl:
+#        keystore-location: "file:${KEYSTORE_FILE}"
+#        keystore-password: "${BIE_KAFKA_KEYSTORE_PASSWORD}"
+#        key-store-type: "PKCS12"
+#        truststore-location: "file:${TRUSTSTORE_FILE}"
+#        truststore-password: "${BIE_KAFKA_TRUSTSTORE_PASSWORD}"
+#        trust-store-type: "PKCS12"
     bootstrap-servers: "${BIE_KAFKA_PLACEHOLDERS_BROKERS:localhost:9092}"
 
 ## Specify bie properties


### PR DESCRIPTION
<!-- Ensure the PR title reflects the feature or bug name -->

## What was the problem?
<!-- brief description of how things worked before this PR -->
There was no end to end test from mock kafka --> svc-bie-kafka --> xample-workflow --> postgres.

Associated tickets or Slack threads:
- #1677 
- #1680

## How does this fix it?[^1]
<!-- description of how things will work after this PR -->
Adds continuous integration test. See passing test [here](https://github.com/department-of-veterans-affairs/abd-vro/actions/runs/5627186062/job/15249308475).

## How to test this PR
- Run [continuous integration test](https://github.com/department-of-veterans-affairs/abd-vro/actions/workflows/continuous-integration.yml).

## Follow On:
This test should be updated if the `event_details` column in the table `claims.bie_contention_event` is updated. See [V1.1__BIE_Contention_Event.sql](https://github.com/department-of-veterans-affairs/abd-vro/blob/6b6b2ea72a949d7aaf9653319a7024be1eb102d2/db-init/src/main/resources/database/migrations/V1.1__BIE_Contention_Event.sql) and [ContentionEventEntity.java](https://github.com/department-of-veterans-affairs/abd-vro/blob/6b6b2ea72a949d7aaf9653319a7024be1eb102d2/shared/persistence-model/src/main/java/gov/va/vro/persistence/model/ContentionEventEntity.java) which may have been updated by #1680 

[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
