### PR TITLE
svc-bie-kafka: remove unnecessary RabbitMQ queue creation and binding

### DIFF
--- a/domain-xample/xample-workflows/src/main/java/gov/va/vro/routes/xample/BieXampleRoutes.java
+++ b/domain-xample/xample-workflows/src/main/java/gov/va/vro/routes/xample/BieXampleRoutes.java
@@ -35,7 +35,7 @@ public class BieXampleRoutes extends EndpointRouteBuilder {
   }
 
   void configureRouteToSaveContentionEventToDbFromQueue(final String exchangeName) {
-    final String queueName = "saveToDB-"+exchangeName;
+    final String queueName = "saveToDB-" + exchangeName;
     RabbitMqCamelUtils.fromRabbitmqFanoutExchange(this, exchangeName, queueName)
         .routeId(exchangeName + "-saveToDb-route")
         .log("Received ${headers} ${body.getClass()}: ${body}")

--- a/domain-xample/xample-workflows/src/main/java/gov/va/vro/routes/xample/BieXampleRoutes.java
+++ b/domain-xample/xample-workflows/src/main/java/gov/va/vro/routes/xample/BieXampleRoutes.java
@@ -23,22 +23,21 @@ public class BieXampleRoutes extends EndpointRouteBuilder {
 
   @Autowired final DbHelper dbHelper;
 
-  @Value("#{'${bie.queues}'.split(' ')}")
-  private final List<String> queues;
+  @Value("#{'${bie.exchanges}'.split(' ')}")
+  private final List<String> exchanges;
 
   @Override
   public void configure() {
     configureExceptionHandling();
-    for (String queue : queues) {
-      configureRouteToSaveContentionEventToDbFromQueue(queue);
+    for (String exchange : exchanges) {
+      configureRouteToSaveContentionEventToDbFromQueue(exchange);
     }
   }
 
-  void configureRouteToSaveContentionEventToDbFromQueue(final String queue) {
-    final String exchangeName = queue;
-    final String routingKey = queue;
-    RabbitMqCamelUtils.fromRabbitmqFanoutExchange(this, exchangeName, routingKey)
-        .routeId(queue + "-saveToDb-route")
+  void configureRouteToSaveContentionEventToDbFromQueue(final String exchangeName) {
+    final String queueName = "saveToDB-"+exchangeName;
+    RabbitMqCamelUtils.fromRabbitmqFanoutExchange(this, exchangeName, queueName)
+        .routeId(exchangeName + "-saveToDb-route")
         .log("Received ${headers} ${body.getClass()}: ${body}")
         .convertBodyTo(BieMessagePayload.class)
         .log("Converted to ${body.getClass()}: ${body}")

--- a/domain-xample/xample-workflows/src/main/resources/application.yml
+++ b/domain-xample/xample-workflows/src/main/resources/application.yml
@@ -52,7 +52,7 @@ spring.config.import: >
 
 ## Specify bie properties
 bie:
-  queues: >-
+  exchanges: >-
     bie-events-contention-associated
     bie-events-contention-updated
     bie-events-contention-classified

--- a/shared/lib-camel-connector/src/main/java/gov/va/vro/camel/RabbitMqCamelUtils.java
+++ b/shared/lib-camel-connector/src/main/java/gov/va/vro/camel/RabbitMqCamelUtils.java
@@ -44,8 +44,8 @@ public class RabbitMqCamelUtils {
   }
 
   public static RouteDefinition fromRabbitmqFanoutExchange(
-      RouteBuilder builder, String fanoutExchange, String routingKey) {
-    return fromRabbitmq(builder, rabbitmqFanoutConsumerEndpoint(fanoutExchange, routingKey));
+      RouteBuilder builder, String fanoutExchange, String queueName) {
+    return fromRabbitmq(builder, rabbitmqFanoutConsumerEndpoint(fanoutExchange, queueName));
   }
 
   public static RouteDefinition fromRabbitmq(RouteBuilder builder, String rabbitMqUri) {

--- a/svc-bie-kafka/src/main/java/gov/va/vro/services/bie/config/BieProperties.java
+++ b/svc-bie-kafka/src/main/java/gov/va/vro/services/bie/config/BieProperties.java
@@ -15,8 +15,8 @@ public class BieProperties {
 
   /**
    * Map of entries where the keys are the kafka topics to which this app will subscribe. The value
-   * is the corresponding RabbitMQ exchange/queue upon which the payload will be put. These values
-   * are separated by a colon ":" character.
+   * is the corresponding RabbitMQ exchange upon which the payload will be put. These values are
+   * separated by a colon ":" character.
    */
-  private Map<String, String> kafkaTopicToAmqpQueueMap;
+  private Map<String, String> kafkaTopicToAmqpExchangeMap;
 }

--- a/svc-bie-kafka/src/main/java/gov/va/vro/services/bie/config/MessageExchangeConfig.java
+++ b/svc-bie-kafka/src/main/java/gov/va/vro/services/bie/config/MessageExchangeConfig.java
@@ -15,7 +15,7 @@ import java.util.stream.Collectors;
 
 @Slf4j
 @Configuration
-public class MessageQueueConfig {
+public class MessageExchangeConfig {
 
   private static final boolean IS_DURABLE = true;
   private static final boolean IS_AUTO_DELETED = true;
@@ -28,7 +28,7 @@ public class MessageQueueConfig {
   @Bean
   Declarables topicBindings(final BieProperties bieProperties) {
     final List<AbstractDeclarable> list =
-        bieProperties.getKafkaTopicToAmqpQueueMap().values().stream()
+        bieProperties.getKafkaTopicToAmqpExchangeMap().values().stream()
             .map(
                 topic -> {
                   final FanoutExchange fanoutExchange =

--- a/svc-bie-kafka/src/main/java/gov/va/vro/services/bie/config/MessageQueueConfig.java
+++ b/svc-bie-kafka/src/main/java/gov/va/vro/services/bie/config/MessageQueueConfig.java
@@ -2,11 +2,8 @@ package gov.va.vro.services.bie.config;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.amqp.core.AbstractDeclarable;
-import org.springframework.amqp.core.Binding;
-import org.springframework.amqp.core.BindingBuilder;
 import org.springframework.amqp.core.Declarables;
 import org.springframework.amqp.core.FanoutExchange;
-import org.springframework.amqp.core.Queue;
 import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
 import org.springframework.amqp.support.converter.MessageConverter;
 import org.springframework.context.annotation.Bean;
@@ -22,7 +19,6 @@ public class MessageQueueConfig {
 
   private static final boolean IS_DURABLE = true;
   private static final boolean IS_AUTO_DELETED = true;
-  private static final boolean IS_EXCLUSIVE = false;
 
   @Bean
   public MessageConverter messageConverter() {
@@ -35,16 +31,10 @@ public class MessageQueueConfig {
         bieProperties.getKafkaTopicToAmqpQueueMap().values().stream()
             .map(
                 topic -> {
-                  final Queue queue = new Queue(topic, IS_DURABLE, IS_EXCLUSIVE, IS_AUTO_DELETED);
                   final FanoutExchange fanoutExchange =
                       new FanoutExchange(topic, IS_DURABLE, IS_AUTO_DELETED);
-                  final Binding binding = BindingBuilder.bind(queue).to(fanoutExchange);
-                  log.info(
-                      "event=setUpMQ queue={} exchange={} binding={}",
-                      queue,
-                      fanoutExchange,
-                      binding);
-                  return List.of(queue, fanoutExchange, binding);
+                  log.info("event=setUpMQ exchange={}", fanoutExchange);
+                  return List.of(fanoutExchange);
                 })
             .flatMap(Collection::stream)
             .collect(Collectors.toList());

--- a/svc-bie-kafka/src/main/java/gov/va/vro/services/bie/service/AmqpMessageSender.java
+++ b/svc-bie-kafka/src/main/java/gov/va/vro/services/bie/service/AmqpMessageSender.java
@@ -2,5 +2,5 @@ package gov.va.vro.services.bie.service;
 
 public interface AmqpMessageSender {
 
-  void send(String exchange, String queue, String message);
+  void send(String exchange, String routingKey, String message);
 }

--- a/svc-bie-kafka/src/main/java/gov/va/vro/services/bie/service/BieRabbitService.java
+++ b/svc-bie-kafka/src/main/java/gov/va/vro/services/bie/service/BieRabbitService.java
@@ -16,14 +16,15 @@ public class BieRabbitService implements AmqpMessageSender {
   private final RabbitTemplate rabbitTemplate;
 
   @Override
-  public void send(final String exchange, final String queue, final String message) {
+  public void send(final String exchange, final String routingKey, final String message) {
     final BieMessagePayload bieMessagePayload =
         BieMessagePayload.builder()
-            .event(queue)
+            .event(routingKey)
             .notifiedAt(LocalDateTime.now().toString())
             .eventDetails(message)
             .build();
-    rabbitTemplate.convertAndSend(exchange, queue, bieMessagePayload);
-    log.debug("event=messageSent exchange={} topic={} msg={}", exchange, queue, bieMessagePayload);
+    rabbitTemplate.convertAndSend(exchange, routingKey, bieMessagePayload);
+    log.debug(
+        "event=messageSent exchange={} topic={} msg={}", exchange, routingKey, bieMessagePayload);
   }
 }

--- a/svc-bie-kafka/src/main/java/gov/va/vro/services/bie/service/kafka/KafkaConsumerCreator.java
+++ b/svc-bie-kafka/src/main/java/gov/va/vro/services/bie/service/kafka/KafkaConsumerCreator.java
@@ -26,7 +26,8 @@ public class KafkaConsumerCreator {
       final ConsumerFactory<?, ?> consumerFactory,
       final AmqpMessageSender amqpMessageSender,
       final BieProperties bieProperties) {
-    setUpListeners(consumerFactory, amqpMessageSender, bieProperties.getKafkaTopicToAmqpQueueMap());
+    setUpListeners(
+        consumerFactory, amqpMessageSender, bieProperties.getKafkaTopicToAmqpExchangeMap());
   }
 
   private void setUpListeners(

--- a/svc-bie-kafka/src/main/resources/application.yaml
+++ b/svc-bie-kafka/src/main/resources/application.yaml
@@ -28,9 +28,9 @@ spring:
 
 ## Specify bie properties
 bie:
-  kafka-topic-to-amqp-queue-map:
+  kafka-topic-to-amqp-exchange-map:
     # Map of entries where the keys are the kafka topics to which this app will subscribe. The value is the corresponding
-    # RabbitMQ exchange/queue upon which the payload will be put. These values are separated by a colon ":" character.
+    # RabbitMQ exchange upon which the payload will be put. These values are separated by a colon ":" character.
     TST_CONTENTION_BIE_CONTENTION_ASSOCIATED_TO_CLAIM_V02: bie-events-contention-associated
     TST_CONTENTION_BIE_CONTENTION_UPDATED_V02: bie-events-contention-updated
     TST_CONTENTION_BIE_CONTENTION_CLASSIFIED: bie-events-contention-classified

--- a/svc-bie-kafka/src/test/java/gov/va/vro/services/bie/config/KafkaConsumerCreatorTest.java
+++ b/svc-bie-kafka/src/test/java/gov/va/vro/services/bie/config/KafkaConsumerCreatorTest.java
@@ -29,7 +29,7 @@ class KafkaConsumerCreatorTest {
 
   @Test
   void whenTopicMapIsEmpty_ShouldCreateNoListeners() {
-    bieProperties.setKafkaTopicToAmqpQueueMap(Map.of());
+    bieProperties.setKafkaTopicToAmqpExchangeMap(Map.of());
 
     kafkaConsumerCreator =
         new KafkaConsumerCreator(consumerFactory, amqpMessageSender, bieProperties);
@@ -39,7 +39,7 @@ class KafkaConsumerCreatorTest {
 
   @Test
   void whenTopicMapIsNotEmpty_ShouldCreateListeners() {
-    bieProperties.setKafkaTopicToAmqpQueueMap(Map.of("kafkaTopic", "rabbitQueue"));
+    bieProperties.setKafkaTopicToAmqpExchangeMap(Map.of("kafkaTopic", "rabbitExchange"));
 
     kafkaConsumerCreator =
         new KafkaConsumerCreator(consumerFactory, amqpMessageSender, bieProperties);

--- a/svc-bie-kafka/src/test/java/gov/va/vro/services/bie/config/MessageExchangeConfigTest.java
+++ b/svc-bie-kafka/src/test/java/gov/va/vro/services/bie/config/MessageExchangeConfigTest.java
@@ -5,22 +5,20 @@ import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.amqp.core.Binding;
 import org.springframework.amqp.core.Declarables;
 import org.springframework.amqp.core.Exchange;
-import org.springframework.amqp.core.Queue;
 
 import java.util.Map;
 
 @ExtendWith(MockitoExtension.class)
-class MessageQueueConfigTest {
+class MessageExchangeConfigTest {
 
   @Test
   void createTopicBindingsWithEmptyTopicMap_ShouldReturnEmptyListOfDeclarables() {
     final BieProperties bieProperties = new BieProperties();
-    bieProperties.setKafkaTopicToAmqpQueueMap(Map.of());
+    bieProperties.setKafkaTopicToAmqpExchangeMap(Map.of());
 
-    final MessageQueueConfig config = new MessageQueueConfig();
+    final MessageExchangeConfig config = new MessageExchangeConfig();
     final Declarables declarables = config.topicBindings(bieProperties);
 
     assertThat(declarables).isNotNull();
@@ -30,15 +28,13 @@ class MessageQueueConfigTest {
   @Test
   void createTopicBindingsWithNonEmptyTopicMap_ShouldReturnEmptyListOfDeclarables() {
     final BieProperties bieProperties = new BieProperties();
-    bieProperties.setKafkaTopicToAmqpQueueMap(Map.of("kafkaTopic", "rabbitQueue"));
+    bieProperties.setKafkaTopicToAmqpExchangeMap(Map.of("kafkaTopic", "rabbitExchange"));
 
-    final MessageQueueConfig config = new MessageQueueConfig();
+    final MessageExchangeConfig config = new MessageExchangeConfig();
     final Declarables declarables = config.topicBindings(bieProperties);
 
     assertThat(declarables).isNotNull();
-    assertThat(declarables.getDeclarables()).hasSize(3);
-    assertThat(declarables.getDeclarablesByType(Queue.class)).hasSize(1);
+    assertThat(declarables.getDeclarables()).hasSize(1);
     assertThat(declarables.getDeclarablesByType(Exchange.class)).hasSize(1);
-    assertThat(declarables.getDeclarablesByType(Binding.class)).hasSize(1);
   }
 }


### PR DESCRIPTION
<!-- Ensure the PR title reflects the feature or bug name -->

## What was the problem?
<!-- brief description of how things worked before this PR -->
`svc-bie-kafka` microservice creates a queue that doesn't have a consumer.
`svc-bie-kafka` client's (e.g., xample-workflow's) responsibility to create its queue (named whatever it wants) and bind its queue to one of the known fanout exchanges: https://github.com/department-of-veterans-affairs/abd-vro/blob/353628ca317b3d588730135fdd216d6ef37c5027/svc-bie-kafka/src/main/resources/application.yaml#L34-L38

Associated tickets or Slack threads:
- #1679

## How does this fix it?
<!-- description of how things will work after this PR -->
Removes queue creation and binding from the `svc-bie-kafka` microservice.

## How to test this PR
Ensure all associated tests pass.