### PR TITLE
Stop using GitHub Action secrets

### DIFF
--- a/.github/workflows/bie-kafka-end2end-test.yml
+++ b/.github/workflows/bie-kafka-end2end-test.yml
@@ -15,25 +15,22 @@ env:
   TEST_TOPIC: 'TST_CONTENTION_BIE_CONTENTION_ASSOCIATED_TO_CLAIM_V02'
   # TEST_DATA should be replaced with data after event_details is populated with non PII data. See Github Issue 1680
   TEST_DATA: 'Lorem ipsum'
+  VRO_DEV_SECRETS_FOLDER: "${{ github.workspace }}/.cache/abd-vro-dev-secrets"
 
 jobs:
   integration-test:
     runs-on: ubuntu-latest
     steps:
-      - name: 'Install kcat and postgresql'
-        run: |
-          sudo apt-get update
-          sudo apt-get install kafkacat
-          which kafkacat
-
-          sudo apt-get install postgresql
-          which psql
-
       - name: 'Checkout source code'
         uses: actions/checkout@v3
 
-      - name: 'Build the images'
-        uses: ./.github/actions/build-images
+      - name: "Checkout abd-vro-dev-secrets repo"
+        uses: actions/checkout@v3
+        with:
+          # Checkout using a PAT so that we can access the internal repo
+          token: ${{ secrets.ACCESS_TOKEN_CHECKOUT_INTERNAL_REPO }}
+          repository: 'department-of-veterans-affairs/abd-vro-dev-secrets'
+          path: "${{ env.VRO_DEV_SECRETS_FOLDER }}"
 
       - name: 'Set RABBITMQ_BASIC_AUTH'
         run: |
@@ -44,6 +41,9 @@ jobs:
           echo "RABBITMQ_BASIC_AUTH=${BASIC_AUTH}" >> $GITHUB_ENV
 
           export -p | sed 's/declare -x //'
+
+      - name: 'Build the images'
+        uses: ./.github/actions/build-images
 
       - name: 'Start the containers'
         run: |
@@ -69,6 +69,15 @@ jobs:
           timeout: 2000
           # Quit after 60 seconds
           retries: 30
+
+      - name: 'Install kafkacat and postgresql'
+        run: |
+          sudo apt-get update
+          sudo apt-get install kafkacat
+          which kafkacat
+
+          sudo apt-get install postgresql
+          which psql
 
       - name: 'Wait for Kafka to be ready'
         run: |
@@ -131,7 +140,7 @@ jobs:
             WHERE
               event='${{env.TEST_TOPIC}}'
                 AND
-              event_details='${{env.TEST_DATA}}'
+              event_details='Lorem ipsum'
           ")
           echo $RESULTS
           if echo $RESULTS | grep -q 'count | 1'

--- a/.github/workflows/container-healthchecks.yml
+++ b/.github/workflows/container-healthchecks.yml
@@ -14,13 +14,8 @@ concurrency:
   group: containerHealthChecks-${{ github.ref }}
 
 env:
-  LH_ACCESS_CLIENT_ID: ${{ secrets.LH_ACCESS_CLIENT_ID }}
-  LH_PRIVATE_KEY: ${{ secrets.LH_PRIVATE_KEY }}
   SLACK_EXCEPTION_WEBHOOK: "http://mock-slack:20100/slack-messages"
-  BIE_KAFKA_KEYSTORE_INBASE64:   ${{ secrets.BIE_KAFKA_KEYSTORE_INBASE64 }}
-  BIE_KAFKA_KEYSTORE_PASSWORD:   ${{ secrets.BIE_KAFKA_KEYSTORE_PASSWORD }}
-  BIE_KAFKA_TRUSTSTORE_INBASE64: ${{ secrets.BIE_KAFKA_TRUSTSTORE_INBASE64 }}
-  BIE_KAFKA_TRUSTSTORE_PASSWORD: ${{ secrets.BIE_KAFKA_TRUSTSTORE_PASSWORD }}
+  VRO_DEV_SECRETS_FOLDER: "${{ github.workspace }}/.cache/abd-vro-dev-secrets"
 
 jobs:
   container-healthcheck:
@@ -31,6 +26,14 @@ jobs:
     steps:
       - name: "Checkout source code"
         uses: actions/checkout@v3
+
+      - name: "Checkout abd-vro-dev-secrets repo"
+        uses: actions/checkout@v3
+        with:
+          # Checkout using a PAT so that we can access the internal repo
+          token: ${{ secrets.ACCESS_TOKEN_CHECKOUT_INTERNAL_REPO }}
+          repository: 'department-of-veterans-affairs/abd-vro-dev-secrets'
+          path: "${{ env.VRO_DEV_SECRETS_FOLDER }}"
 
       - name: "Docker build"
         uses: ./.github/actions/build-images

--- a/.github/workflows/test-code.yml
+++ b/.github/workflows/test-code.yml
@@ -8,9 +8,6 @@ on:
 
   # Trigger when called by another GitHub Action
   workflow_call:
-    secrets:
-      ACCESS_TOKEN_GRADLE_BUILD:
-        required: true
     inputs:
       run_all_tests:
         required: false

--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,9 @@ test.pdf
 test.html
 *_toc.xsl
 !base_toc.xsl
+
+### BIE Kafka generated files
+mocks/mock-bie-kafka/kafka.keystore.jks
+mocks/mock-bie-kafka/kafka.truststore.jks
+svc-bie-kafka/keystore.p12
+svc-bie-kafka/truststore.p12

--- a/scripts/setenv.sh
+++ b/scripts/setenv.sh
@@ -10,7 +10,6 @@ fi
 
 # Find checkout of abd-vro-dev-secrets GH repo
 findSecretsDir(){
-  local VRO_DEV_SECRETS_FOLDER
   [ "$1" ] && VRO_DEV_SECRETS_FOLDER="$1"
   : ${VRO_DEV_SECRETS_FOLDER:=$PWD/../abd-vro-dev-secrets}
   if SECRETS_DIR=$(cd -- "${VRO_DEV_SECRETS_FOLDER}/local" && pwd); then
@@ -24,12 +23,7 @@ findSecretsDir(){
   fi
 }
 
-# $CI is set by GitHub Action -- https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables
-if [ "$CI" ]; then
-  echo "Relying on Action to set environment variable secrets"
-else
-  findSecretsDir "$1" || return 11
-fi
+findSecretsDir "$1" || return 11
 
 ###
 # Before adding configuration settings in this file, prefer to add them to application*.yml (for Java)
@@ -61,7 +55,14 @@ exportSecretIfUnset(){
   if [ "${VAR_VALUE}" ]; then
     >&2 echo "Not overriding: $1 already set."
   else
-    eval "export $1=\$(getSecret $1)"
+    VAR_VALUE=$(getSecret "$1")
+    eval "export $1=\"$VAR_VALUE\""
+  fi
+  # When running in a GH Action, mask the secret
+  if [ "${CI}" ] && [ "${VAR_VALUE}" ]; then
+    echo "${VAR_VALUE}" | while read -r LINE; do
+      echo "::add-mask::${LINE}"
+    done
   fi
 }
 
@@ -77,6 +78,20 @@ exportIfUnset(){
 exportFile(){
   local FILE_VALUE=$(eval cat "$2")
   eval "export $1=${FILE_VALUE}"
+}
+
+decodeSecretToFile(){
+  if [ -f "$2" ]; then
+    >&2 echo "Not overwriting file: $2 already exists."
+  else
+    local VAR_VALUE=$(getSecret "$1")
+    if [ "$VAR_VALUE" ]; then
+      >&2 echo "Creating $2"
+      echo "$VAR_VALUE" | base64 -d > "$2"
+    else
+      >&2 echo "Not creating file $2 with empty content!"
+    fi
+  fi
 }
 
 ###


### PR DESCRIPTION
<!-- Ensure the PR title reflects the feature or bug name -->

## What was the problem?
<!-- brief description of how things worked before this PR -->
Secrets were being used from both [GitHub Secrets > Actions](https://github.com/department-of-veterans-affairs/abd-vro/settings/secrets/actions) and the `abd-vro-dev-secrets` repo, which means secrets were being maintained in 2 locations.

## How does this fix it?
<!-- description of how things will work after this PR -->

- Only use secrets from the `abd-vro-dev-secrets` repo (for both local testing and testing performed by GH Action workflows).
- Delete unused secrets in [GitHub Secrets > Actions](https://github.com/department-of-veterans-affairs/abd-vro/settings/secrets/actions)

## How to test this PR
Changed GH Action workflows still work and do not reveal secrets in logs.