### PR TITLE
Update Kafka Consumer code after integrating schema registry KafkaAvroDeserializer

### DIFF
--- a/svc-bie-kafka/src/main/java/gov/va/vro/services/bie/service/kafka/KafkaConsumer.java
+++ b/svc-bie-kafka/src/main/java/gov/va/vro/services/bie/service/kafka/KafkaConsumer.java
@@ -4,6 +4,7 @@ import gov.va.vro.services.bie.config.BieProperties;
 import gov.va.vro.services.bie.service.AmqpMessageSender;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.avro.generic.GenericRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
@@ -25,16 +26,14 @@ public class KafkaConsumer {
         "#{'${kafka.topic.prefix}'}_CONTENTION_BIE_CONTENTION_COMPLETED_V02",
         "#{'${kafka.topic.prefix}'}_CONTENTION_BIE_CONTENTION_DELETED_V02"
       })
-  public void consume(ConsumerRecord<byte[], byte[]> record) {
-    String messageKey = new String(record.key(), StandardCharsets.UTF_8);
-    String messageValue = new String(record.value(), StandardCharsets.UTF_8);
+  public void consume(ConsumerRecord<String, GenericRecord> record) {
     String topicName = record.topic();
+    GenericRecord messageValue = record.value();
 
     log.info("Topic name: {}", topicName);
-    log.info("Consumed message key: {}", messageKey);
-    log.info("Consumed message value (before) decode: {}", messageValue);
+    log.info("Consumed message value (before) decode: {}", messageValue.toString());
 
     amqpMessageSender.send(
-        bieProperties.getKafkaTopicToAmqpExchangeMap().get(topicName), topicName, messageValue);
+        bieProperties.getKafkaTopicToAmqpExchangeMap().get(topicName), topicName, messageValue.toString());
   }
 }

--- a/svc-bie-kafka/src/main/resources/application-dev.yaml
+++ b/svc-bie-kafka/src/main/resources/application-dev.yaml
@@ -1,6 +1,22 @@
 spring:
-  # Specify where Spring connects to Kafka
   kafka:
-    consumer:
-      group-id: "${BIE_KAFKA_PLACEHOLDERS_GROUP_ID:vro-bie-tst-vro}"
     bootstrap-servers: "${BIE_KAFKA_PLACEHOLDERS_BROKERS:kafka.dev.bip.va.gov:443}"
+    properties:
+      schema.registry.url: "${BIE_KAFKA_PLACEHOLDERS_BROKERS:https://schemaregistry.dev.bip.va.gov:443}"
+      schema.registry.ssl.protocol: SSL
+      schema.registry.ssl.keystore.location: "file:${KEYSTORE_FILE}"
+      schema.registry.ssl.keystore.password: "${BIE_KAFKA_KEYSTORE_PASSWORD}"
+      schema.registry.ssl.keystore.type: "PKCS12"
+      schema.registry.ssl.truststore.location: "file:${TRUSTSTORE_FILE}"
+      schema.registry.ssl.truststore.password: "${BIE_KAFKA_TRUSTSTORE_PASSWORD}"
+      schema.registry.ssl.truststore.type: "PKCS12"
+    ssl:
+      protocol: SSL
+      key-store-location: "file:${KEYSTORE_FILE}"
+      key-store-password: "${BIE_KAFKA_KEYSTORE_PASSWORD}"
+      key-store-type: "PKCS12"
+      trust-store-location: "file:${TRUSTSTORE_FILE}"
+      trust-store-password: "${BIE_KAFKA_TRUSTSTORE_PASSWORD}"
+      trust-store-type: "PKCS12"
+    consumer:
+      group-id: "${BIE_KAFKA_PLACEHOLDERS_GROUP_ID:vro-bie-dev-vro}"

--- a/svc-bie-kafka/src/main/resources/application-prod-test.yaml
+++ b/svc-bie-kafka/src/main/resources/application-prod-test.yaml
@@ -1,9 +1,25 @@
 spring:
-  # Specify where Spring connects to Kafka
   kafka:
+    bootstrap-servers: "${BIE_KAFKA_PLACEHOLDERS_BROKERS:kafka.prod.bip.va.gov:443}"
+    properties:
+      schema.registry.url: "${BIE_KAFKA_PLACEHOLDERS_BROKERS:https://schemaregistry.prod.bip.va.gov:443}"
+      schema.registry.ssl.protocol: SSL
+      schema.registry.ssl.keystore.location: "file:${KEYSTORE_FILE}"
+      schema.registry.ssl.keystore.password: "${BIE_KAFKA_KEYSTORE_PASSWORD}"
+      schema.registry.ssl.keystore.type: "PKCS12"
+      schema.registry.ssl.truststore.location: "file:${TRUSTSTORE_FILE}"
+      schema.registry.ssl.truststore.password: "${BIE_KAFKA_TRUSTSTORE_PASSWORD}"
+      schema.registry.ssl.truststore.type: "PKCS12"
+    ssl:
+      protocol: SSL
+      key-store-location: "file:${KEYSTORE_FILE}"
+      key-store-password: "${BIE_KAFKA_KEYSTORE_PASSWORD}"
+      key-store-type: "PKCS12"
+      trust-store-location: "file:${TRUSTSTORE_FILE}"
+      trust-store-password: "${BIE_KAFKA_TRUSTSTORE_PASSWORD}"
+      trust-store-type: "PKCS12"
     consumer:
       group-id: "${BIE_KAFKA_PLACEHOLDERS_GROUP_ID:vro-bie-pre-vro}"
-    bootstrap-servers: "${BIE_KAFKA_PLACEHOLDERS_BROKERS:kafka.prod.bip.va.gov:443}"
 kafka:
   topic:
     prefix: PRE

--- a/svc-bie-kafka/src/main/resources/application-qa.yaml
+++ b/svc-bie-kafka/src/main/resources/application-qa.yaml
@@ -1,9 +1,25 @@
 spring:
-  # Specify where Spring connects to Kafka
   kafka:
+    bootstrap-servers: "${BIE_KAFKA_PLACEHOLDERS_BROKERS:kafka.stage.bip.va.gov:443}"
+    properties:
+      schema.registry.url: "${BIE_KAFKA_PLACEHOLDERS_BROKERS:https://schemaregistry.stage.bip.va.gov:443}"
+      schema.registry.ssl.protocol: SSL
+      schema.registry.ssl.keystore.location: "file:${KEYSTORE_FILE}"
+      schema.registry.ssl.keystore.password: "${BIE_KAFKA_KEYSTORE_PASSWORD}"
+      schema.registry.ssl.keystore.type: "PKCS12"
+      schema.registry.ssl.truststore.location: "file:${TRUSTSTORE_FILE}"
+      schema.registry.ssl.truststore.password: "${BIE_KAFKA_TRUSTSTORE_PASSWORD}"
+      schema.registry.ssl.truststore.type: "PKCS12"
+    ssl:
+      protocol: SSL
+      key-store-location: "file:${KEYSTORE_FILE}"
+      key-store-password: "${BIE_KAFKA_KEYSTORE_PASSWORD}"
+      key-store-type: "PKCS12"
+      trust-store-location: "file:${TRUSTSTORE_FILE}"
+      trust-store-password: "${BIE_KAFKA_TRUSTSTORE_PASSWORD}"
+      trust-store-type: "PKCS12"
     consumer:
       group-id: "${BIE_KAFKA_PLACEHOLDERS_GROUP_ID:vro-bie-ivv-vro}"
-    bootstrap-servers: "${BIE_KAFKA_PLACEHOLDERS_BROKERS:kafka.stage.bip.va.gov:443}"
 kafka:
   topic:
     prefix: IVV

--- a/svc-bie-kafka/src/main/resources/application-sandbox.yaml
+++ b/svc-bie-kafka/src/main/resources/application-sandbox.yaml
@@ -1,9 +1,25 @@
 spring:
-  # Specify where Spring connects to Kafka
   kafka:
-    consumer:
-      group-id: "${BIE_KAFKA_PLACEHOLDERS_GROUP_ID:vro-uat-ivv-vro}"
     bootstrap-servers: "${BIE_KAFKA_PLACEHOLDERS_BROKERS:kafka.stage.bip.va.gov:443}"
+    properties:
+      schema.registry.url: "${BIE_KAFKA_PLACEHOLDERS_BROKERS:https://schemaregistry.stage.bip.va.gov:443}"
+      schema.registry.ssl.protocol: SSL
+      schema.registry.ssl.keystore.location: "file:${KEYSTORE_FILE}"
+      schema.registry.ssl.keystore.password: "${BIE_KAFKA_KEYSTORE_PASSWORD}"
+      schema.registry.ssl.keystore.type: "PKCS12"
+      schema.registry.ssl.truststore.location: "file:${TRUSTSTORE_FILE}"
+      schema.registry.ssl.truststore.password: "${BIE_KAFKA_TRUSTSTORE_PASSWORD}"
+      schema.registry.ssl.truststore.type: "PKCS12"
+    ssl:
+      protocol: SSL
+      key-store-location: "file:${KEYSTORE_FILE}"
+      key-store-password: "${BIE_KAFKA_KEYSTORE_PASSWORD}"
+      key-store-type: "PKCS12"
+      trust-store-location: "file:${TRUSTSTORE_FILE}"
+      trust-store-password: "${BIE_KAFKA_TRUSTSTORE_PASSWORD}"
+      trust-store-type: "PKCS12"
+    consumer:
+      group-id: "${BIE_KAFKA_PLACEHOLDERS_GROUP_ID:vro-bie-uat-vro}"
 kafka:
   topic:
     prefix: UAT

--- a/svc-bie-kafka/src/main/resources/application.yaml
+++ b/svc-bie-kafka/src/main/resources/application.yaml
@@ -13,8 +13,8 @@ spring:
   kafka:
     consumer:
       group-id: "${BIE_KAFKA_PLACEHOLDERS_GROUP_ID:vro-bie-tst-vro}"
-      key-deserializer: "org.apache.kafka.common.serialization.ByteArrayDeserializer"
-      value-deserializer: "org.apache.kafka.common.serialization.ByteArrayDeserializer"
+      key-deserializer: "org.apache.kafka.common.serialization.StringDeserializer"
+      value-deserializer: "io.confluent.kafka.serializers.KafkaAvroDeserializer"
       security:
         protocol: SSL
       ssl:


### PR DESCRIPTION


## What was the problem?
Currently we can only see byte array binary data in kafka topics. Adding confluent schema registry deserializer library along with ssl configurations, now the messages are decoded and become readable, which provide us the opportunity to update/modify the data prior to sending to rabbitmq queues

Associated tickets or Slack threads:
- #1682 

## How does this fix it?[^1]
- for non-local, ssl configurations for both kafka broker and schema registry are added in application-<env>.yaml files

## How to test this PR
since the connection to BIE kafka and schema registry requires VA network access, it cannot be verified in local. As soon as the svc-bie-kafka image is published and pod deployed to non-local environments, verify it in `vro-xample-workflows` log or datadog log

**_This PR depends on correct keystore/truststore base64 strings and passwords updated in Vault for each environment._**

[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
