### PR TITLE
4x the memory and 2x cpu for svc-bie-kafka service

### DIFF
--- a/helm/svc-bie-kafka/values.yaml
+++ b/helm/svc-bie-kafka/values.yaml
@@ -6,8 +6,8 @@ resources:
     cpu: 150m
     memory: 512Mi
   limits:
-    cpu: 1000m
-    memory: 1024Mi
+    cpu: 2000m
+    memory: 4096Mi
 
 replicaCount: 1
 


### PR DESCRIPTION
<!-- Ensure the PR title reflects the feature or bug name -->

## What was the problem?
dev pod experiences java head space out of memory issue

Associated tickets or Slack threads:
- NA

## How does this fix it?[^1]
increase memory 4x and cpu 2x

## How to test this PR
- deploy svc-bie-kafka to dev and see if the setting resolves the issue


[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
