### PR TITLE
Increase Base Memory to 1024Mi

### DIFF
--- a/helm/svc-bie-kafka/values.yaml
+++ b/helm/svc-bie-kafka/values.yaml
@@ -4,7 +4,7 @@ labels:
 resources:
   requests:
     cpu: 150m
-    memory: 512Mi
+    memory: 1024i
   limits:
     cpu: 2000m
     memory: 4096Mi

--- a/helm/svc-bie-kafka/values.yaml
+++ b/helm/svc-bie-kafka/values.yaml
@@ -4,7 +4,7 @@ labels:
 resources:
   requests:
     cpu: 150m
-    memory: 1024i
+    memory: 1024Mi
   limits:
     cpu: 2000m
     memory: 4096Mi


### PR DESCRIPTION
Increase base value to support kafka


## What was the problem?
dev pod experiences java head space out of memory issue

Associated tickets or Slack threads:

NA
How does this fix it?[1](https://github.com/department-of-veterans-affairs/abd-vro/pull/1888#user-content-fn-1-105faab8736ef1b5305a047a12fb4016)
increase memory 4x and cpu 2x

How to test this PR
deploy svc-bie-kafka to dev and see if the setting resolves the issue
Footnotes