### PR TITLE
1821: Fix issue causing api integration test to fail

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -152,7 +152,7 @@ services:
       <<: *common-vars
       VRO_APP_HOSTNAME: app
       VRO_CC_HOSTNAME: cc-app
-      VRO_MAX_CFI_APP_HOSTNAME: max-cfi-app
+      VRO_MAX_CFI_APP_HOSTNAME: ee-max-cfi-app
     networks:
       - intranet
 


### PR DESCRIPTION
<!-- Ensure the PR title reflects the feature or bug name -->

## What was the problem?
<!-- brief description of how things worked before this PR -->
Mismatched docker service name caused api-integration test to fail

## How does this fix it?[^1]
<!-- description of how things will work after this PR -->
Uses correct service name.

## How to test this PR
- See failing [run](https://github.com/department-of-veterans-affairs/abd-vro/actions/runs/5789798706/job/15691596755)
- See passing [run](https://github.com/department-of-veterans-affairs/abd-vro/actions/runs/5790219912) (ignore failing bie-kafka-end-2-end-integration-test)

[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
