### PR TITLE
use StringDeserializer for local

### DIFF
--- a/svc-bie-kafka/src/main/java/gov/va/vro/services/bie/service/kafka/KafkaConsumer.java
+++ b/svc-bie-kafka/src/main/java/gov/va/vro/services/bie/service/kafka/KafkaConsumer.java
@@ -24,16 +24,20 @@ public class KafkaConsumer {
         "#{'${kafka.topic.prefix}'}_CONTENTION_BIE_CONTENTION_COMPLETED_V02",
         "#{'${kafka.topic.prefix}'}_CONTENTION_BIE_CONTENTION_DELETED_V02"
       })
-  public void consume(ConsumerRecord<String, GenericRecord> record) {
+  public void consume(ConsumerRecord<String, Object> record) {
+    String messageValue = null;
     String topicName = record.topic();
-    GenericRecord messageValue = record.value();
+
+    if (record.value() instanceof GenericRecord value) {
+      messageValue = value.toString();
+    } else if (record.value() instanceof String stringValue) {
+      messageValue = stringValue;
+    }
 
     log.info("Topic name: {}", topicName);
-    log.info("Consumed message value (before) decode: {}", messageValue.toString());
+    log.info("Consumed message value (before) decode: {}", messageValue);
 
     amqpMessageSender.send(
-        bieProperties.getKafkaTopicToAmqpExchangeMap().get(topicName),
-        topicName,
-        messageValue.toString());
+        bieProperties.getKafkaTopicToAmqpExchangeMap().get(topicName), topicName, messageValue);
   }
 }

--- a/svc-bie-kafka/src/main/resources/application-dev.yaml
+++ b/svc-bie-kafka/src/main/resources/application-dev.yaml
@@ -20,3 +20,5 @@ spring:
       trust-store-type: "PKCS12"
     consumer:
       group-id: "${BIE_KAFKA_PLACEHOLDERS_GROUP_ID:vro-bie-tst-vro}"
+      key-deserializer: "org.apache.kafka.common.serialization.StringDeserializer"
+      value-deserializer: "io.confluent.kafka.serializers.KafkaAvroDeserializer"

--- a/svc-bie-kafka/src/main/resources/application-prod-test.yaml
+++ b/svc-bie-kafka/src/main/resources/application-prod-test.yaml
@@ -20,6 +20,8 @@ spring:
       trust-store-type: "PKCS12"
     consumer:
       group-id: "${BIE_KAFKA_PLACEHOLDERS_GROUP_ID:vro-bie-pre-vro}"
+      key-deserializer: "org.apache.kafka.common.serialization.StringDeserializer"
+      value-deserializer: "io.confluent.kafka.serializers.KafkaAvroDeserializer"
 kafka:
   topic:
     prefix: PRE

--- a/svc-bie-kafka/src/main/resources/application-prod.yaml
+++ b/svc-bie-kafka/src/main/resources/application-prod.yaml
@@ -1,5 +1,27 @@
-
 spring:
-  # Specify where Spring connects to Kafka
   kafka:
     bootstrap-servers: "${BIE_KAFKA_PLACEHOLDERS_BROKERS:kafka.prod.bip.va.gov:443}"
+    properties:
+      schema.registry.url: "${BIE_KAFKA_PLACEHOLDERS_BROKERS:https://schemaregistry.prod.bip.va.gov:443}"
+      schema.registry.ssl.protocol: SSL
+      schema.registry.ssl.keystore.location: "file:${KEYSTORE_FILE}"
+      schema.registry.ssl.keystore.password: "${BIE_KAFKA_KEYSTORE_PASSWORD}"
+      schema.registry.ssl.keystore.type: "PKCS12"
+      schema.registry.ssl.truststore.location: "file:${TRUSTSTORE_FILE}"
+      schema.registry.ssl.truststore.password: "${BIE_KAFKA_TRUSTSTORE_PASSWORD}"
+      schema.registry.ssl.truststore.type: "PKCS12"
+    ssl:
+      protocol: SSL
+      key-store-location: "file:${KEYSTORE_FILE}"
+      key-store-password: "${BIE_KAFKA_KEYSTORE_PASSWORD}"
+      key-store-type: "PKCS12"
+      trust-store-location: "file:${TRUSTSTORE_FILE}"
+      trust-store-password: "${BIE_KAFKA_TRUSTSTORE_PASSWORD}"
+      trust-store-type: "PKCS12"
+    consumer:
+      group-id: "${BIE_KAFKA_PLACEHOLDERS_GROUP_ID:vro-bie-prod-vro}"
+      key-deserializer: "org.apache.kafka.common.serialization.StringDeserializer"
+      value-deserializer: "io.confluent.kafka.serializers.KafkaAvroDeserializer"
+kafka:
+  topic:
+    prefix: PROD

--- a/svc-bie-kafka/src/main/resources/application.yaml
+++ b/svc-bie-kafka/src/main/resources/application.yaml
@@ -18,7 +18,7 @@ spring:
     consumer:
       group-id: "${BIE_KAFKA_PLACEHOLDERS_GROUP_ID:vro-bie-tst-vro}"
       key-deserializer: "org.apache.kafka.common.serialization.StringDeserializer"
-      value-deserializer: "io.confluent.kafka.serializers.KafkaAvroDeserializer"
+      value-deserializer: "org.apache.kafka.common.serialization.StringDeserializer"
 
 kafka:
   topic:


### PR DESCRIPTION
<!-- Ensure the PR title reflects the feature or bug name -->

## What was the problem?
e2e testing was failing because local schema registry was not used and `GenericRecord` cannot be used to construct kafka consumer. 

Associated tickets or Slack threads:
- #?

## How does this fix it?[^1]
locally we can use String deserializer to avoid this issue

## How to test this PR
- run `CI: BIE Kafka End-2-End Test` github action on the branch


[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
