### PR TITLE
Dependabot and SecRel Issues

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
   dependencies {
-    classpath "org.yaml:snakeyaml:1.2.1"
+    classpath "org.yaml:snakeyaml:2.1"
   }
   // There's a conflict between versions of jgit between spotless and axion release plugin
   configurations.classpath {

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
   dependencies {
-    classpath "org.yaml:snakeyaml:3.1.2.RELEASE"
+    classpath "org.yaml:snakeyaml:1.2.1"
   }
   // There's a conflict between versions of jgit between spotless and axion release plugin
   configurations.classpath {

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
   dependencies {
-    classpath "org.yaml:snakeyaml:2.1"
+    classpath "org.yaml:snakeyaml:3.1.2.RELEASE"
   }
   // There's a conflict between versions of jgit between spotless and axion release plugin
   configurations.classpath {

--- a/gradle-plugins/src/main/groovy/replacement-for-starter.bom.gradle
+++ b/gradle-plugins/src/main/groovy/replacement-for-starter.bom.gradle
@@ -7,7 +7,7 @@ ext {
     opentracing_mock_version = "0.33.0"
     brave_opentracing_version = "1.0.0"
     zipkin_sender_okhttp3_version = "2.16.3"
-    springdoc_version =  "1.5.4"
+    springdoc_version =  "1.5.5"
     problem_spring_web_version="0.26.2"
     arch_unit_version = "0.21.0"
     mockserver_netty_version = "5.11.2"

--- a/gradle-plugins/src/main/groovy/shared.java.vro-dep-constraints.gradle
+++ b/gradle-plugins/src/main/groovy/shared.java.vro-dep-constraints.gradle
@@ -34,8 +34,6 @@ dependencies {
         implementation "com.squareup.okhttp3:okhttp:4.10.0"
         implementation "org.yaml:snakeyaml:${snakeyaml_version}"
         implementation "org.thymeleaf:thymeleaf:3.1.2.RELEASE"      // Fix for Security vulnerability
-        implementation "org.springframework.hateoas:spring-hateoas:2.1.1" // Fix for Security vulnerability
-        implementation "org.glassfish:jakarta.el:3.0.4"
 
         // for mockserver-netty and hapi-fhir
         implementation 'org.apache.commons:commons-text:1.10.0'

--- a/gradle-plugins/src/main/groovy/shared.java.vro-dep-constraints.gradle
+++ b/gradle-plugins/src/main/groovy/shared.java.vro-dep-constraints.gradle
@@ -9,7 +9,7 @@ plugins {
 
 ext {
     mapstruct_version="1.4.2.Final"
-    spring_framework_version="5.3.26"
+    spring_framework_version="5.3.29"
     snakeyaml_version="2.0"
 }
 
@@ -33,6 +33,7 @@ dependencies {
         implementation "com.fasterxml.jackson.core:jackson-databind:2.13.4.2"
         implementation "com.squareup.okhttp3:okhttp:4.10.0"
         implementation "org.yaml:snakeyaml:${snakeyaml_version}"
+        implementation "org.thymeleaf:thymeleaf:3.1.2.RELEASE"
 
         // for mockserver-netty and hapi-fhir
         implementation 'org.apache.commons:commons-text:1.10.0'

--- a/gradle-plugins/src/main/groovy/shared.java.vro-dep-constraints.gradle
+++ b/gradle-plugins/src/main/groovy/shared.java.vro-dep-constraints.gradle
@@ -33,7 +33,8 @@ dependencies {
         implementation "com.fasterxml.jackson.core:jackson-databind:2.13.4.2"
         implementation "com.squareup.okhttp3:okhttp:4.10.0"
         implementation "org.yaml:snakeyaml:${snakeyaml_version}"
-        implementation "org.thymeleaf:thymeleaf:3.1.2.RELEASE"
+        implementation "org.thymeleaf:thymeleaf:3.1.2.RELEASE"      // Fix for Security vulnerability
+        implementation "org.springframework.hateoas:spring-hateoas:2.1.1" // Fix for Security vulnerability
 
         // for mockserver-netty and hapi-fhir
         implementation 'org.apache.commons:commons-text:1.10.0'

--- a/gradle-plugins/src/main/groovy/shared.java.vro-dep-constraints.gradle
+++ b/gradle-plugins/src/main/groovy/shared.java.vro-dep-constraints.gradle
@@ -35,6 +35,7 @@ dependencies {
         implementation "org.yaml:snakeyaml:${snakeyaml_version}"
         implementation "org.thymeleaf:thymeleaf:3.1.2.RELEASE"      // Fix for Security vulnerability
         implementation "org.springframework.hateoas:spring-hateoas:2.1.1" // Fix for Security vulnerability
+        implementation "org.glassfish:jakarta.el:3.0.4"
 
         // for mockserver-netty and hapi-fhir
         implementation 'org.apache.commons:commons-text:1.10.0'

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,7 +14,7 @@ camel_version=3.19.0
 h2_version=2.1.214
 postgresql_version=42.5.0
 
-spring_security_version=5.7.5
+spring_security_version=5.7.10
 spring_boot_version=2.7.12
 
 org.gradle.jvmargs=--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \


### PR DESCRIPTION


## What was the problem?
Secrel issue and Dependabot issue identified

Associated tickets or Slack threads:
- #1811 

## How does this fix it?[^1]
Fixes by updating versions
Spring version from 1.5.4 to 1.5.5
Sprint framework from 5.3.26 to 5.3.29

Added New version override constraint for thymleaf to 3.1.2-Release

## How to test this PR
Run snyk and dependabot checks



