### PR TITLE
Gradle: remove huge intellij plugin

### DIFF
--- a/gradle-plugins/build.gradle
+++ b/gradle-plugins/build.gradle
@@ -5,12 +5,12 @@
 plugins {
     // Support convention plugins written in Groovy. Convention plugins are build scripts in 'src/main' that automatically become available as plugins in the main build.
     id 'groovy-gradle-plugin'
-    id 'org.jetbrains.intellij' version '1.15.0'
+//    id 'org.jetbrains.intellij' version '1.15.0'
 }
 
-intellij {
-    version = '2023.1'
-}
+//intellij {
+//    version = '2023.1'
+//}
 
 repositories {
     // Use the plugin portal to apply community plugins in convention plugins.


### PR DESCRIPTION
<!-- Ensure the PR title reflects the feature or bug name -->

## What was the problem?
<!-- brief description of how things worked before this PR -->
Gradle is downloading a 3GB intellij plugin.

```sh
> du -sh ~/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea
3.4G	/Users/yoom/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea.BIG
```
[Slack](https://dsva.slack.com/archives/C04QLHM9LR0/p1688053889336159)

## How does this fix it?
<!-- description of how things will work after this PR -->

Remove intellij Gradle plugin.

## How to test this PR
