### PR TITLE
GH Action CodeQL: don't run on draft PRs

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -8,8 +8,6 @@ on:
 
   pull_request:
     branches: [main, develop, domain-*]
-    # Limit to certain PR event types since this action is slow
-    types: [ready_for_review, review_requested]
 
   schedule:
     - cron: 31 6 * * 5
@@ -23,6 +21,9 @@ on:
 jobs:
   analyze:
     name: Analyze
+    # https://docs.github.com/en/webhooks-and-events/webhooks/webhook-events-and-payloads#pull_request
+    if: github.event_name != 'pull_request' ||
+      (github.event_name == 'pull_request' && !github.event.pull_request.draft )
     runs-on: ubuntu-latest
     concurrency: ${{ github.workflow }}-${{ matrix.language }}-${{ github.ref }}
     permissions:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -21,6 +21,7 @@ on:
 jobs:
   analyze:
     name: Analyze
+    # For github.event.pull_request fields, see
     # https://docs.github.com/en/webhooks-and-events/webhooks/webhook-events-and-payloads#pull_request
     if: github.event_name != 'pull_request' ||
       (github.event_name == 'pull_request' && !github.event.pull_request.draft )

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -8,7 +8,7 @@ on:
 
   pull_request:
     branches: [main, develop, domain-*]
-    types: [ready_for_review, synchronize]
+    types: [ready_for_review, synchronize, opened, reopened]
   schedule:
     - cron: 31 6 * * 5
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -8,7 +8,7 @@ on:
 
   pull_request:
     branches: [main, develop, domain-*]
-
+    types: [ready_for_review, synchronize]
   schedule:
     - cron: 31 6 * * 5
 


### PR DESCRIPTION
<!-- Ensure the PR title reflects the feature or bug name -->

Problem: CodeQL doesn't re-run when new commits are made on a PR.

Improve logic for when CodeQL GH Action workflow runs so that the problem is addressed.