### PR TITLE
BIE kafka pre prod environment cluster and schema registry urls corrections

### DIFF
--- a/svc-bie-kafka/src/main/resources/application-prod-test.yaml
+++ b/svc-bie-kafka/src/main/resources/application-prod-test.yaml
@@ -1,10 +1,10 @@
 spring:
   kafka:
-    bootstrap-servers: "${BIE_KAFKA_PLACEHOLDERS_BROKERS:kafka.prod.bip.va.gov:443}"
+    bootstrap-servers: "${BIE_KAFKA_PLACEHOLDERS_BROKERS:kafka.preprod.bip.va.gov:443}"
     properties:
       schema:
         registry:
-          url: "${BIE_KAFKA_PLACEHOLDERS_BROKERS:https://schemaregistry.prod.bip.va.gov:443}"
+          url: "${BIE_KAFKA_PLACEHOLDERS_BROKERS:https://schemaregistry.preprod.bip.va.gov:443}"
           ssl:
             protocol: SSL
             keystore:


### PR DESCRIPTION
## What was the problem?
not authorized to access BIE pre prod environment topics

Associated tickets or Slack threads:
- #1806 

## How does this fix it?[^1]
kafka broker and schema registry urls in pre prod environment need to be corrected in application yaml file

## How to test this PR
- deploy the changes to `prod-test` and verify it in the k8s pod log


[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
