### PR TITLE
Consolidate Kafka topic list

### DIFF
--- a/svc-bie-kafka/src/integrationTest/java/gov/va/vro/services/bie/IntegrationTestConfig.java
+++ b/svc-bie-kafka/src/integrationTest/java/gov/va/vro/services/bie/IntegrationTestConfig.java
@@ -21,8 +21,8 @@ public class IntegrationTestConfig {
   @Bean
   String kafkaTopic() {
     // Pick a random kafka topic
-    val topics = bieProperties.getKafkaTopicToAmqpExchangeMap().keySet().stream().toList();
-    return topics.get(new Random().nextInt(topics.size()));
+    val topics = bieProperties.topicNames();
+    return topics[new Random().nextInt(topics.length)];
   }
 
   // ###### MQ configuration:
@@ -33,7 +33,7 @@ public class IntegrationTestConfig {
   }
 
   String mqExchangeName() {
-    return bieProperties.getKafkaTopicToAmqpExchangeMap().get(kafkaTopic());
+    return bieProperties.getTopicToExchangeMap().get(kafkaTopic());
   }
 
   @Bean

--- a/svc-bie-kafka/src/main/java/gov/va/vro/services/bie/config/BieProperties.java
+++ b/svc-bie-kafka/src/main/java/gov/va/vro/services/bie/config/BieProperties.java
@@ -28,7 +28,7 @@ public class BieProperties {
   @Getter private Map<String, String> topicToExchangeMap;
 
   @PostConstruct
-  public void addTopicPrefix() {
+  public void addPrefixToTopicNames() {
     topicToExchangeMap =
         kafkaTopicToAmqpExchangeMap.entrySet().stream()
             .collect(Collectors.toMap(e -> topicPrefix + e.getKey(), Map.Entry::getValue));

--- a/svc-bie-kafka/src/main/java/gov/va/vro/services/bie/config/BieProperties.java
+++ b/svc-bie-kafka/src/main/java/gov/va/vro/services/bie/config/BieProperties.java
@@ -2,15 +2,17 @@ package gov.va.vro.services.bie.config;
 
 import lombok.Getter;
 import lombok.Setter;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 
 import java.util.Map;
+import java.util.stream.Collectors;
+import javax.annotation.PostConstruct;
 
 @Component
 @ConfigurationProperties(prefix = "bie")
 @Setter
-@Getter
 public class BieProperties {
 
   /**
@@ -19,4 +21,20 @@ public class BieProperties {
    * separated by a colon ":" character.
    */
   private Map<String, String> kafkaTopicToAmqpExchangeMap;
+
+  @Value("${kafka.topic.prefix}")
+  String topicPrefix;
+
+  @Getter private Map<String, String> topicToExchangeMap;
+
+  @PostConstruct
+  public void addTopicPrefix() {
+    topicToExchangeMap =
+        kafkaTopicToAmqpExchangeMap.entrySet().stream()
+            .collect(Collectors.toMap(e -> topicPrefix + e.getKey(), Map.Entry::getValue));
+  }
+
+  public String[] topicNames() {
+    return topicToExchangeMap.keySet().stream().toArray(String[]::new);
+  }
 }

--- a/svc-bie-kafka/src/main/java/gov/va/vro/services/bie/config/BieProperties.java
+++ b/svc-bie-kafka/src/main/java/gov/va/vro/services/bie/config/BieProperties.java
@@ -2,7 +2,6 @@ package gov.va.vro.services.bie.config;
 
 import lombok.Getter;
 import lombok.Setter;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 
@@ -22,8 +21,7 @@ public class BieProperties {
    */
   private Map<String, String> kafkaTopicToAmqpExchangeMap;
 
-  @Value("${kafka.topic.prefix}")
-  String topicPrefix;
+  String kakfaTopicPrefix;
 
   @Getter private Map<String, String> topicToExchangeMap;
 
@@ -31,7 +29,7 @@ public class BieProperties {
   public void addPrefixToTopicNames() {
     topicToExchangeMap =
         kafkaTopicToAmqpExchangeMap.entrySet().stream()
-            .collect(Collectors.toMap(e -> topicPrefix + e.getKey(), Map.Entry::getValue));
+            .collect(Collectors.toMap(e -> kakfaTopicPrefix + e.getKey(), Map.Entry::getValue));
   }
 
   public String[] topicNames() {

--- a/svc-bie-kafka/src/main/java/gov/va/vro/services/bie/config/MessageExchangeConfig.java
+++ b/svc-bie-kafka/src/main/java/gov/va/vro/services/bie/config/MessageExchangeConfig.java
@@ -28,7 +28,7 @@ public class MessageExchangeConfig {
   @Bean
   Declarables topicBindings(final BieProperties bieProperties) {
     final List<AbstractDeclarable> list =
-        bieProperties.getKafkaTopicToAmqpExchangeMap().values().stream()
+        bieProperties.getTopicToExchangeMap().values().stream()
             .map(
                 topic -> {
                   final FanoutExchange fanoutExchange =

--- a/svc-bie-kafka/src/main/java/gov/va/vro/services/bie/service/kafka/KafkaConsumer.java
+++ b/svc-bie-kafka/src/main/java/gov/va/vro/services/bie/service/kafka/KafkaConsumer.java
@@ -34,14 +34,7 @@ public class KafkaConsumer {
         KEY_EVENT_TIME
       };
 
-  @KafkaListener(
-      topics = {
-        "#{'${kafka.topic.prefix}'}_CONTENTION_BIE_CONTENTION_ASSOCIATED_TO_CLAIM_V02",
-        "#{'${kafka.topic.prefix}'}_CONTENTION_BIE_CONTENTION_UPDATED_V02",
-        "#{'${kafka.topic.prefix}'}_CONTENTION_BIE_CONTENTION_CLASSIFIED_V02",
-        "#{'${kafka.topic.prefix}'}_CONTENTION_BIE_CONTENTION_COMPLETED_V02",
-        "#{'${kafka.topic.prefix}'}_CONTENTION_BIE_CONTENTION_DELETED_V02"
-      })
+  @KafkaListener(topics = "#{bieProperties.topicNames()}")
   public void consume(ConsumerRecord<String, Object> record) {
     String messageValue = null;
     String topicName = record.topic();
@@ -60,6 +53,6 @@ public class KafkaConsumer {
     }
 
     amqpMessageSender.send(
-        bieProperties.getKafkaTopicToAmqpExchangeMap().get(topicName), topicName, messageValue);
+        bieProperties.getTopicToExchangeMap().get(topicName), topicName, messageValue);
   }
 }

--- a/svc-bie-kafka/src/main/resources/application-prod-test.yaml
+++ b/svc-bie-kafka/src/main/resources/application-prod-test.yaml
@@ -30,6 +30,6 @@ spring:
             type: PKCS12
             location: "${TRUSTSTORE_FILE}"
             password: "${BIE_KAFKA_TRUSTSTORE_PASSWORD}"
-kafka:
-  topic:
-    prefix: PRE
+
+bie:
+  kakfa-topic-prefix: "PRE_"

--- a/svc-bie-kafka/src/main/resources/application-prod.yaml
+++ b/svc-bie-kafka/src/main/resources/application-prod.yaml
@@ -31,6 +31,5 @@ spring:
             location: "${TRUSTSTORE_FILE}"
             password: "${BIE_KAFKA_TRUSTSTORE_PASSWORD}"
 
-kafka:
-  topic:
-    prefix: PROD
+bie:
+  kakfa-topic-prefix: "PROD_"

--- a/svc-bie-kafka/src/main/resources/application-qa.yaml
+++ b/svc-bie-kafka/src/main/resources/application-qa.yaml
@@ -30,6 +30,6 @@ spring:
             type: PKCS12
             location: "${TRUSTSTORE_FILE}"
             password: "${BIE_KAFKA_TRUSTSTORE_PASSWORD}"
-kafka:
-  topic:
-    prefix: IVV
+
+bie:
+  kakfa-topic-prefix: "IVV_"

--- a/svc-bie-kafka/src/main/resources/application-sandbox.yaml
+++ b/svc-bie-kafka/src/main/resources/application-sandbox.yaml
@@ -30,6 +30,6 @@ spring:
             type: PKCS12
             location: "${TRUSTSTORE_FILE}"
             password: "${BIE_KAFKA_TRUSTSTORE_PASSWORD}"
-kafka:
-  topic:
-    prefix: UAT
+
+bie:
+  kakfa-topic-prefix: "UAT_"

--- a/svc-bie-kafka/src/main/resources/application.yaml
+++ b/svc-bie-kafka/src/main/resources/application.yaml
@@ -33,17 +33,17 @@ spring:
 
 kafka:
   topic:
-    prefix: TST
+    prefix: "TST_"
 ## Specify bie properties
 bie:
   kafka-topic-to-amqp-exchange-map:
     # Map of entries where the keys are the kafka topics to which this app will subscribe. The value is the corresponding
     # RabbitMQ exchange upon which the payload will be put. These values are separated by a colon ":" character.
-    TST_CONTENTION_BIE_CONTENTION_ASSOCIATED_TO_CLAIM_V02: bie-events-contention-associated
-    TST_CONTENTION_BIE_CONTENTION_UPDATED_V02: bie-events-contention-updated
-    TST_CONTENTION_BIE_CONTENTION_CLASSIFIED_V02: bie-events-contention-classified
-    TST_CONTENTION_BIE_CONTENTION_COMPLETED_V02: bie-events-contention-completed
-    TST_CONTENTION_BIE_CONTENTION_DELETED_V02: bie-events-contention-deleted
+    CONTENTION_BIE_CONTENTION_ASSOCIATED_TO_CLAIM_V02: bie-events-contention-associated
+    CONTENTION_BIE_CONTENTION_UPDATED_V02: bie-events-contention-updated
+    CONTENTION_BIE_CONTENTION_CLASSIFIED_V02: bie-events-contention-classified
+    CONTENTION_BIE_CONTENTION_COMPLETED_V02: bie-events-contention-completed
+    CONTENTION_BIE_CONTENTION_DELETED_V02: bie-events-contention-deleted
 
 ## Actuator for health check
 management:

--- a/svc-bie-kafka/src/main/resources/application.yaml
+++ b/svc-bie-kafka/src/main/resources/application.yaml
@@ -31,11 +31,9 @@ spring:
         truststore-password: "${BIE_KAFKA_TRUSTSTORE_PASSWORD}"
         trust-store-type: "PKCS12"
 
-kafka:
-  topic:
-    prefix: "TST_"
 ## Specify bie properties
 bie:
+  kakfa-topic-prefix: "TST_"
   kafka-topic-to-amqp-exchange-map:
     # Map of entries where the keys are the kafka topics to which this app will subscribe. The value is the corresponding
     # RabbitMQ exchange upon which the payload will be put. These values are separated by a colon ":" character.

--- a/svc-bie-kafka/src/test/java/gov/va/vro/services/bie/config/MessageExchangeConfigTest.java
+++ b/svc-bie-kafka/src/test/java/gov/va/vro/services/bie/config/MessageExchangeConfigTest.java
@@ -1,6 +1,7 @@
 package gov.va.vro.services.bie.config;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -22,7 +23,7 @@ class MessageExchangeConfigTest {
     bieProperties = new BieProperties();
     bieProperties.setKafkaTopicToAmqpExchangeMap(Map.of());
     bieProperties.topicPrefix = "TST_";
-    bieProperties.addTopicPrefix();
+    bieProperties.addPrefixToTopicNames();
   }
 
   @Test
@@ -37,7 +38,9 @@ class MessageExchangeConfigTest {
   @Test
   void createTopicBindingsWithNonEmptyTopicMap_ShouldReturnEmptyListOfDeclarables() {
     bieProperties.setKafkaTopicToAmqpExchangeMap(Map.of("kafkaTopic", "rabbitExchange"));
-    bieProperties.addTopicPrefix();
+    bieProperties.addPrefixToTopicNames();
+
+    assertArrayEquals(bieProperties.topicNames(), new String[] {"TST_kafkaTopic"});
 
     final MessageExchangeConfig config = new MessageExchangeConfig();
     final Declarables declarables = config.topicBindings(bieProperties);

--- a/svc-bie-kafka/src/test/java/gov/va/vro/services/bie/config/MessageExchangeConfigTest.java
+++ b/svc-bie-kafka/src/test/java/gov/va/vro/services/bie/config/MessageExchangeConfigTest.java
@@ -22,7 +22,7 @@ class MessageExchangeConfigTest {
   void setUp() {
     bieProperties = new BieProperties();
     bieProperties.setKafkaTopicToAmqpExchangeMap(Map.of());
-    bieProperties.topicPrefix = "TST_";
+    bieProperties.kakfaTopicPrefix = "TST_";
     bieProperties.addPrefixToTopicNames();
   }
 

--- a/svc-bie-kafka/src/test/java/gov/va/vro/services/bie/config/MessageExchangeConfigTest.java
+++ b/svc-bie-kafka/src/test/java/gov/va/vro/services/bie/config/MessageExchangeConfigTest.java
@@ -1,7 +1,9 @@
 package gov.va.vro.services.bie.config;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -13,11 +15,18 @@ import java.util.Map;
 @ExtendWith(MockitoExtension.class)
 class MessageExchangeConfigTest {
 
+  private BieProperties bieProperties;
+
+  @BeforeEach
+  void setUp() {
+    bieProperties = new BieProperties();
+    bieProperties.setKafkaTopicToAmqpExchangeMap(Map.of());
+    bieProperties.topicPrefix = "TST_";
+    bieProperties.addTopicPrefix();
+  }
+
   @Test
   void createTopicBindingsWithEmptyTopicMap_ShouldReturnEmptyListOfDeclarables() {
-    final BieProperties bieProperties = new BieProperties();
-    bieProperties.setKafkaTopicToAmqpExchangeMap(Map.of());
-
     final MessageExchangeConfig config = new MessageExchangeConfig();
     final Declarables declarables = config.topicBindings(bieProperties);
 
@@ -27,8 +36,8 @@ class MessageExchangeConfigTest {
 
   @Test
   void createTopicBindingsWithNonEmptyTopicMap_ShouldReturnEmptyListOfDeclarables() {
-    final BieProperties bieProperties = new BieProperties();
     bieProperties.setKafkaTopicToAmqpExchangeMap(Map.of("kafkaTopic", "rabbitExchange"));
+    bieProperties.addTopicPrefix();
 
     final MessageExchangeConfig config = new MessageExchangeConfig();
     final Declarables declarables = config.topicBindings(bieProperties);
@@ -36,5 +45,7 @@ class MessageExchangeConfigTest {
     assertThat(declarables).isNotNull();
     assertThat(declarables.getDeclarables()).hasSize(1);
     assertThat(declarables.getDeclarablesByType(Exchange.class)).hasSize(1);
+    assertEquals(
+        (declarables.getDeclarablesByType(Exchange.class).get(0)).getName(), "rabbitExchange");
   }
 }


### PR DESCRIPTION
<!-- Ensure the PR title reflects the feature or bug name -->

## What was the problem?
<!-- brief description of how things worked before this PR -->
The Kafka topic list is repeated in multiple places:
- [KafkaConsumer.java](https://github.com/department-of-veterans-affairs/abd-vro/pull/1958/files/9c04495b09d5d8f207c3f238231a992c6f3c2147#diff-4dff030a6e0e98a6f993911f7eb0cde870521d2a6595adb11444b96233b323e3)
- application.yaml

Related comments:
- https://github.com/department-of-veterans-affairs/abd-vro/pull/1957/files/c8ce57c7cb94f2369b8fb2598ade2a1a57fc3b5b..5da31725713f61415705caa2c5e83bcdf0fa85b7#r1302019458
- https://github.com/department-of-veterans-affairs/abd-vro/pull/1869#discussion_r1302026795

## How does this fix it?
<!-- description of how things will work after this PR -->
Consolidate Kafka topic list to be only in application.yaml

## How to test this PR
[CI: BIE Kafka End-2-End Test](https://github.com/department-of-veterans-affairs/abd-vro/actions/runs/5943912048)