### PR TITLE
Loosened the requirements for max-ratings endpoint.

### DIFF
--- a/domain-ee/README.md
+++ b/domain-ee/README.md
@@ -68,8 +68,9 @@ This should result in a response with the following body:
 * The `diagnostic_codes` array in the request are integers within the range of `5000 - 10000`.
     * Any request with an any entry that falls outside the range `5000 - 10000` will yield a `400`.
 * An invalid request such as missing/invalid field will result in `422` status code.
-* Duplicate entries in the `diagnostic_codes` array will yield `422` status code.
-* An empty `diagnostic_codes` array or more than 100 entries in `diagnostic_codes` array will yield a `422` status code.
+* Duplicate entries in the `diagnostic_codes` array will yield a ratings array with unique entries.
+* An empty `diagnostic_codes` array will yield an empty ratings array.
+* A `diagnostic_codes` array with more than 1000 entries will yield a `422` status code.
 
 #### Response
 

--- a/domain-ee/ee-max-cfi-app/src/python_src/api.py
+++ b/domain-ee/ee-max-cfi-app/src/python_src/api.py
@@ -44,7 +44,7 @@ def get_health_status():
 def get_max_ratings(
         claim_for_increase: MaxRatingsForClaimForIncreaseRequest, ) -> MaxRatingsForClaimForIncreaseResponse:
     ratings = []
-    for dc in claim_for_increase.diagnostic_codes:
+    for dc in set(claim_for_increase.diagnostic_codes):
         validate_diagnostic_code(dc)
         max_rating = get_max_rating(dc)
         if max_rating:

--- a/domain-ee/ee-max-cfi-app/src/python_src/pydantic_models.py
+++ b/domain-ee/ee-max-cfi-app/src/python_src/pydantic_models.py
@@ -2,7 +2,7 @@ from pydantic import BaseModel, conint, conlist
 
 
 class MaxRatingsForClaimForIncreaseRequest(BaseModel):
-    diagnostic_codes: conlist(conint(strict=True), unique_items=True, min_items=1, max_items=100)
+    diagnostic_codes: conlist(conint(strict=True), max_items=1000)
 
 
 class Rating(BaseModel):

--- a/domain-ee/ee-max-cfi-app/tests/test_api.py
+++ b/domain-ee/ee-max-cfi-app/tests/test_api.py
@@ -16,7 +16,11 @@ def test_max_rating_with_no_dc(client: TestClient):
     }
 
     response = client.post(MAX_RATING, json=json_post_dict)
-    assert response.status_code == 422
+    assert response.status_code == 200
+    response_json = response.json()
+
+    ratings = response_json["ratings"]
+    assert len(ratings) == 0
 
 
 def test_max_rating_with_one_dc(client: TestClient):
@@ -41,6 +45,22 @@ def test_max_rating_with_duplicate_dc(client: TestClient):
         "diagnostic_codes": [
             TINNITUS["diagnostic_code"],
             TINNITUS["diagnostic_code"]
+        ]
+    }
+
+    response = client.post(MAX_RATING, json=json_post_dict)
+    assert response.status_code == 200
+    response_json = response.json()
+    ratings = response_json["ratings"]
+    assert len(ratings) == 1
+    assert ratings[0]["diagnostic_code"] == TINNITUS["diagnostic_code"]
+    assert ratings[0]["max_rating"] == TINNITUS["max_rating"]
+
+
+def test_max_rating_with_too_many_dc(client: TestClient):
+    json_post_dict = {
+        "diagnostic_codes": [
+            *range(5000, 6001)
         ]
     }
 


### PR DESCRIPTION
<!-- Ensure the PR title reflects the feature or bug name -->

## What was the problem?
<!-- brief description of how things worked before this PR -->
The restrictions on the endpoint were too tight for the kinds of data vets-api has for the input.

Associated tickets or Slack threads:
- department-of-veterans-affairs/abd-vro/issues/1911

## How does this fix it?[^1]
Current Restrictions:
* diagnostic_codes array can have 1 to 100 integers
* no duplicates

Changed to:
* diagnostic_codes array can have 0 to 1000 integers
* duplicates are ok
* return array of unique dcs with ratings

## How to test this PR
- Start the server by following directions for Getting Started in the readme
- Send POST requests to the endpoint 


[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
