### PR TITLE
GH Actions: run CI actions on PRs

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -6,10 +6,6 @@ on:
   push:
     branches: [main]
 
-#  pull_request:
-#    branches: [main, develop, domain-*]
-#    types: [ready_for_review, synchronize, opened, reopened]
-
   schedule:
     - cron: 31 6 * * 5
 
@@ -22,10 +18,6 @@ on:
 jobs:
   analyze:
     name: Analyze
-#    # For github.event.pull_request fields, see
-#    # https://docs.github.com/en/webhooks-and-events/webhooks/webhook-events-and-payloads#pull_request
-#    if: github.event_name != 'pull_request' ||
-#      (github.event_name == 'pull_request' && !github.event.pull_request.draft )
     runs-on: ubuntu-latest
     concurrency: ${{ github.workflow }}-${{ matrix.language }}-${{ github.ref }}
     permissions:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -6,9 +6,10 @@ on:
   push:
     branches: [main]
 
-  pull_request:
-    branches: [main, develop, domain-*]
-    types: [ready_for_review, synchronize, opened, reopened]
+#  pull_request:
+#    branches: [main, develop, domain-*]
+#    types: [ready_for_review, synchronize, opened, reopened]
+
   schedule:
     - cron: 31 6 * * 5
 
@@ -21,10 +22,10 @@ on:
 jobs:
   analyze:
     name: Analyze
-    # For github.event.pull_request fields, see
-    # https://docs.github.com/en/webhooks-and-events/webhooks/webhook-events-and-payloads#pull_request
-    if: github.event_name != 'pull_request' ||
-      (github.event_name == 'pull_request' && !github.event.pull_request.draft )
+#    # For github.event.pull_request fields, see
+#    # https://docs.github.com/en/webhooks-and-events/webhooks/webhook-events-and-payloads#pull_request
+#    if: github.event_name != 'pull_request' ||
+#      (github.event_name == 'pull_request' && !github.event.pull_request.draft )
     runs-on: ubuntu-latest
     concurrency: ${{ github.workflow }}-${{ matrix.language }}-${{ github.ref }}
     permissions:

--- a/.github/workflows/container-healthchecks.yml
+++ b/.github/workflows/container-healthchecks.yml
@@ -7,8 +7,8 @@ on:
   # Allow being called by another GitHub Action
   workflow_call:
 
-  pull_request:
-    branches: [ develop ]
+#  pull_request:
+#    branches: [ develop ]
 
 env:
   SLACK_EXCEPTION_WEBHOOK: "http://mock-slack:20100/slack-messages"

--- a/.github/workflows/container-healthchecks.yml
+++ b/.github/workflows/container-healthchecks.yml
@@ -16,8 +16,7 @@ env:
 
 jobs:
   container-healthcheck:
-    if: github.repository == 'department-of-veterans-affairs/abd-vro' &&
-        ((github.event_name == 'pull_request' && startsWith(github.head_ref, 'dependabot/')) || github.event_name != 'pull_request')
+    if: github.repository == 'department-of-veterans-affairs/abd-vro'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/container-healthchecks.yml
+++ b/.github/workflows/container-healthchecks.yml
@@ -7,9 +7,6 @@ on:
   # Allow being called by another GitHub Action
   workflow_call:
 
-#  pull_request:
-#    branches: [ develop ]
-
 env:
   SLACK_EXCEPTION_WEBHOOK: "http://mock-slack:20100/slack-messages"
   VRO_DEV_SECRETS_FOLDER: "${{ github.workspace }}/.cache/abd-vro-dev-secrets"

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,6 +1,5 @@
-name: "3. Continuous Integration (run tests and checks)"
-# Runs tests and checks with merged code in the public repo so that the PR author is notified of failures.
-# The SecRel workflow (in the internal repo) publishes `dev_` images, regardless of test failures, for manual testing.
+name: "CI"
+# Runs Continuous Integration tests and checks
 # See https://github.com/department-of-veterans-affairs/abd-vro/wiki/CI-CD-Workflows
 
 on:
@@ -55,7 +54,7 @@ jobs:
     uses: ./.github/workflows/svc-bgs-api-integration-test.yml
     secrets: inherit
 
-  bie-kafka-end-to-end:
+  svc-bie-kafka-end-to-end:
     needs: nondraft-pr
     uses: ./.github/workflows/bie-kafka-end2end-test.yml
     secrets: inherit

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -13,6 +13,10 @@ on:
   # Allow manual triggering
   workflow_dispatch:
 
+concurrency:
+  group: ci-${{ github.ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   nondraft-pr:
     # Adding an `if:` that evaluates to false for this nondraft-pr job prevents other dependent jobs from running.

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -4,6 +4,10 @@ name: "3. Continuous Integration (run tests and checks)"
 # See https://github.com/department-of-veterans-affairs/abd-vro/wiki/CI-CD-Workflows
 
 on:
+  pull_request:
+    branches: [main, develop, domain-*]
+    types: [ready_for_review, synchronize, opened, reopened]
+
   push:
     branches: [ develop, domain-* ]
 
@@ -11,6 +15,18 @@ on:
   workflow_dispatch:
 
 jobs:
+  nondraft-pr:
+    # Adding an `if:` that evaluates to false for this nondraft-pr job prevents other dependent jobs from running.
+    # For github.event.pull_request fields, see
+    # https://docs.github.com/en/webhooks-and-events/webhooks/webhook-events-and-payloads#pull_request
+    if: github.event_name != 'pull_request' ||
+      (github.event_name == 'pull_request' && !github.event.pull_request.draft )
+    runs-on: ubuntu-latest
+    steps:
+    - name: "DEBUG"
+      run: |
+        echo "${{ github.event_name }} ${{ github.event.pull_request.draft }}"
+
   lint-and-test:
     uses: ./.github/workflows/test-code.yml
     secrets: inherit
@@ -20,21 +36,26 @@ jobs:
     secrets: inherit
 
   container-healthchecks:
+    needs: nondraft-pr
     uses: ./.github/workflows/container-healthchecks.yml
     secrets: inherit
 
   xample-domain:
+    needs: nondraft-pr
     uses: ./.github/workflows/xample-integration-test.yml
     secrets: inherit
 
   api-gateway:
+    needs: nondraft-pr
     uses: ./.github/workflows/api-gateway-integration-test.yml
     secrets: inherit
 
   svc-bgs-api:
+    needs: nondraft-pr
     uses: ./.github/workflows/svc-bgs-api-integration-test.yml
     secrets: inherit
 
   bie-kafka-end-to-end:
+    needs: nondraft-pr
     uses: ./.github/workflows/bie-kafka-end2end-test.yml
     secrets: inherit

--- a/.github/workflows/test-code.yml
+++ b/.github/workflows/test-code.yml
@@ -1,11 +1,6 @@
 name: "PR: Test code"
 
 on:
-  # Trigger on all pull requests
-#  pull_request:
-#    branches:
-#      - "*"
-
   # Trigger when called by another GitHub Action
   workflow_call:
     inputs:

--- a/.github/workflows/test-code.yml
+++ b/.github/workflows/test-code.yml
@@ -2,9 +2,9 @@ name: "PR: Test code"
 
 on:
   # Trigger on all pull requests
-  pull_request:
-    branches:
-      - "*"
+#  pull_request:
+#    branches:
+#      - "*"
 
   # Trigger when called by another GitHub Action
   workflow_call:


### PR DESCRIPTION
<!-- Ensure the PR title reflects the feature or bug name -->

## What was the problem?
<!-- brief description of how things worked before this PR -->
Not all CI checks were run for all PRs b/c some CI checks take a long time. Now, we prefer all CI checks pass _before_ a PR is merged.

- #1962
- [Slack thread](https://dsva.slack.com/archives/C04QLHM9LR0/p1692832422109179?thread_ts=1692831468.982709&cid=C04QLHM9LR0)

## How does this fix it?
<!-- description of how things will work after this PR -->
Run and require all CI checks pass _before_ a PR is merged. 
To avoid running extraneous intensive checks, _draft_ PRs do not trigger all CI checks.

## How to test this PR

Ensure all GH Action CI tests run and pass for this non-draft PR.
