### PR TITLE
remove vro-image output check for SecRel pipeline

### DIFF
--- a/.github/workflows/secrel.yml
+++ b/.github/workflows/secrel.yml
@@ -202,7 +202,7 @@ jobs:
   secrel:
     name: SecRel Pipeline
     needs: publish-to-ghcr
-    if: needs.publish-to-ghcr.outputs.run-secrel == 'true' && needs.publish-to-ghcr.outputs.vro-images != ''
+    if: needs.publish-to-ghcr.outputs.run-secrel == 'true'
     # https://psychic-disco-c1251ea1.pages.github.io/pipeline/release_notes/v4.2.0/
     uses: department-of-veterans-affairs/lighthouse-tornado-secrel-pipeline/.github/workflows/pipeline.yml@v4
     with:

--- a/scripts/image_versions.src
+++ b/scripts/image_versions.src
@@ -25,12 +25,18 @@
 # Fri Aug 25 16:36:30 UTC 2023 -- v3.4.8
 # Wed Aug 30 18:36:53 UTC 2023 -- v3.4.9
 # Fri Sep  1 21:08:58 UTC 2023 -- v3.4.12
+eemaxcfiapp_VER="v3.4.12"
 # Wed Sep  6 17:58:41 UTC 2023 -- v3.4.13
+ccapp_VER="v3.4.13"
 # Thu Sep  7 20:28:30 UTC 2023 -- v3.4.14
 # Tue Sep 12 20:23:04 UTC 2023 -- v3.4.15
 # Wed Sep 13 14:29:58 UTC 2023 -- v3.4.16
 # Fri Sep 15 15:14:20 UTC 2023 -- v3.4.17
 postgres_VER="v3.4.17"
 apigateway_VER="v3.4.17"
+app_VER="v3.4.17"
 dbinit_VER="v3.4.17"
+svcbgsapi_VER="v3.4.17"
 svclighthouseapi_VER="v3.4.17"
+svcbiekafka_VER="v3.4.17"
+xampleworkflows_VER="v3.4.17"

--- a/scripts/image_versions.src
+++ b/scripts/image_versions.src
@@ -25,18 +25,12 @@
 # Fri Aug 25 16:36:30 UTC 2023 -- v3.4.8
 # Wed Aug 30 18:36:53 UTC 2023 -- v3.4.9
 # Fri Sep  1 21:08:58 UTC 2023 -- v3.4.12
-eemaxcfiapp_VER="v3.4.12"
 # Wed Sep  6 17:58:41 UTC 2023 -- v3.4.13
-ccapp_VER="v3.4.13"
 # Thu Sep  7 20:28:30 UTC 2023 -- v3.4.14
 # Tue Sep 12 20:23:04 UTC 2023 -- v3.4.15
 # Wed Sep 13 14:29:58 UTC 2023 -- v3.4.16
 # Fri Sep 15 15:14:20 UTC 2023 -- v3.4.17
 postgres_VER="v3.4.17"
 apigateway_VER="v3.4.17"
-app_VER="v3.4.17"
 dbinit_VER="v3.4.17"
-svcbgsapi_VER="v3.4.17"
 svclighthouseapi_VER="v3.4.17"
-svcbiekafka_VER="v3.4.17"
-xampleworkflows_VER="v3.4.17"


### PR DESCRIPTION
## What was the problem?
When SecRel issues are fixed and re-run of the same workflow, the SecRel pipeline was skipped entired due to no new changes from vro-image output

Associated tickets or Slack threads:
- NA


## How does this fix it?[^1]
remove the if condition for the SecRel pipeline

## How to test this PR
- re-run SecRel workflow and verify that the SecRel pipeline scan is no longer skipped

[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
