### PR TITLE
Change DB URLs to point to RDS

### DIFF
--- a/helm/_shared/named_templates/_postgres.tpl
+++ b/helm/_shared/named_templates/_postgres.tpl
@@ -1,16 +1,12 @@
-{{- define "vro.postgresUrl" -}}
-{{- printf "jdbc:postgresql://%s-postgres:%s/%s"
-  .Values.global.hostnamePrefix
-  (toString .Values.global.service.db.targetPort)
-  .Values.global.service.db.databaseName }}
-{{- end }}
-
 {{/*
   For clients to connect to DB
 */}}
 {{- define "vro.dbClient.envVars" -}}
 - name: POSTGRES_URL
-  value: {{ include "vro.postgresUrl" . }}
+  valueFrom:
+    secretKeyRef:
+      name: rds-db
+      key: DB_URL
 - name: POSTGRES_USER
   valueFrom:
     secretKeyRef:
@@ -32,7 +28,10 @@
 */}}
 {{- define "vro.flyway.envVars" -}}
 - name: FLYWAY_URL
-  value: {{ include "vro.postgresUrl" . }}
+  valueFrom:
+    secretKeyRef:
+      name: rds-db
+      key: DB_URL
 - name: FLYWAY_USER
   valueFrom:
     secretKeyRef:

--- a/scripts/image_versions.src
+++ b/scripts/image_versions.src
@@ -25,19 +25,9 @@
 # Fri Aug 25 16:36:30 UTC 2023 -- v3.4.8
 # Wed Aug 30 18:36:53 UTC 2023 -- v3.4.9
 # Fri Sep  1 21:08:58 UTC 2023 -- v3.4.12
-eemaxcfiapp_VER="v3.4.12"
 # Wed Sep  6 17:58:41 UTC 2023 -- v3.4.13
-ccapp_VER="v3.4.13"
 # Thu Sep  7 20:28:30 UTC 2023 -- v3.4.14
 # Tue Sep 12 20:23:04 UTC 2023 -- v3.4.15
 # Wed Sep 13 14:29:58 UTC 2023 -- v3.4.16
 # Fri Sep 15 15:14:20 UTC 2023 -- v3.4.17
-postgres_VER="v3.4.17"
-apigateway_VER="v3.4.17"
-app_VER="v3.4.17"
-dbinit_VER="v3.4.17"
-svcbgsapi_VER="v3.4.17"
-svclighthouseapi_VER="v3.4.17"
-svcbiekafka_VER="v3.4.17"
-xampleworkflows_VER="v3.4.17"
 # Wed Sep 20 17:22:23 UTC 2023 -- v3.4.18


### PR DESCRIPTION
<!-- Ensure the PR title reflects the feature or bug name -->

## What was the problem?
<!-- brief description of how things worked before this PR -->
Prior to this PR, Postgres URLs pointed to our self-hosted containerized instance of Postgres.

Associated tickets or Slack threads:
- #1845 

## How does this fix it?[^1]
<!-- description of how things will work after this PR -->
After this change, they will instead point to a Kubernetes secret which has been set to the endpoint for hitting RDS in each of our runtime environments.

Note that this will not have any effect prior to deployment updates.

## How to test this PR
- SecRel
- Since there are no active users of the self-hosted Postgres DB at this time, I will follow-up with a testing example in a separate PR under the `domain-xample` directory once we have cleaned up some of the current deployments.

[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
