### PR TITLE
Created async hoppy client for request/response pattern

### DIFF
--- a/shared/lib-hoppy/hoppy/__init__.py
+++ b/shared/lib-hoppy/hoppy/__init__.py
@@ -1,3 +1,1 @@
-from hoppy.mq import Service, ServiceError  # noqa: F401
-
-__version__ = "0.1"
+__version__ = "0.2"

--- a/shared/lib-hoppy/hoppy/async_consumer.py
+++ b/shared/lib-hoppy/hoppy/async_consumer.py
@@ -1,0 +1,211 @@
+import asyncio
+import functools
+import logging
+import time
+
+import pika
+from pika.adapters.asyncio_connection import AsyncioConnection
+
+
+class AsyncConsumer(object):
+    def __init__(self, exchange, exchange_type, queue, routing_key,
+                 connection_parameters: pika.ConnectionParameters,
+                 reply_callback):
+        self.exchange = exchange
+        self.exchange_type = exchange_type
+        self.queue = queue
+        self.routing_key = routing_key
+        self.connection_parameters = connection_parameters
+
+        self.should_reconnect = False
+        self.was_consuming = False
+
+        self._connection = None
+        self._channel = None
+        self._closing = False
+        self._consumer_tag = None
+        self._consuming = False
+        # In production, experiment with higher prefetch values
+        # for higher consumer throughput
+        self._prefetch_count = 1
+        self.reply_callback = reply_callback
+
+    def connect(self, loop):
+        logging.info(f'Consumer - Connecting to RabbitMq params={self.connection_parameters}')
+        return AsyncioConnection(
+            parameters=self.connection_parameters,
+            on_open_callback=self.on_connection_open,
+            on_open_error_callback=self.on_connection_open_error,
+            on_close_callback=self.on_connection_closed,
+            custom_ioloop=loop)
+
+    def close_connection(self):
+        self._consuming = False
+        if self._connection.is_closing or self._connection.is_closed:
+            logging.info('Consumer - Connection is closing or already closed')
+        else:
+            logging.info('Consumer - Closing connection')
+            self._connection.close()
+
+    def on_connection_open(self, connection):
+        self._connection = connection
+        logging.info('Consumer - Connection opened')
+        self.open_channel()
+
+    def on_connection_open_error(self, _unused_connection, err):
+        logging.error('Consumer - Connection open failed: %s', err)
+        self.reconnect()
+
+    def on_connection_closed(self, _unused_connection, reason):
+        self._channel = None
+        if self._closing:
+            self._connection.ioloop.stop()
+        else:
+            logging.warning(f'Consumer - Connection closed, reconnect necessary: {reason}')
+            self.reconnect()
+
+    def reconnect(self):
+        self.should_reconnect = True
+        self.stop()
+
+    def open_channel(self):
+        logging.info('Consumer - Creating a new channel')
+        self._connection.channel(on_open_callback=self.on_channel_open)
+
+    def on_channel_open(self, channel):
+        logging.info('Consumer - Channel opened')
+        self._channel = channel
+        self._channel.add_on_close_callback(self.on_channel_closed)
+        self.setup_exchange(self.exchange)
+
+    def on_channel_closed(self, channel, reason):
+        logging.warning(f'Consumer - Channel {channel} was closed: {reason}')
+        self.close_connection()
+
+    def setup_exchange(self, exchange_name):
+        logging.info(f'Consumer - Declaring exchange: {self.exchange}')
+        self._channel.exchange_declare(
+            exchange=exchange_name,
+            exchange_type=self.exchange_type,
+            durable=True,
+            auto_delete=True,
+            callback=self.on_exchange_declare_ok)
+
+    def on_exchange_declare_ok(self, _unused_frame):
+        logging.info(f'Consumer - Exchange declared: {self.exchange}')
+        self.setup_queue()
+
+    def setup_queue(self):
+        logging.info(f'Consumer - Declaring queue {self.queue}')
+        self._channel.queue_declare(queue=self.queue, callback=self.on_queue_declare_ok)
+
+    def on_queue_declare_ok(self, _unused_frame):
+        logging.info(f'Consumer - Binding {self.exchange} to {self.queue} with {self.routing_key}')
+        self._channel.queue_bind(
+            self.queue,
+            self.exchange,
+            routing_key=self.routing_key,
+            callback=self.on_bind_ok)
+
+    def on_bind_ok(self, _unused_frame):
+        logging.info(f'Consumer - Queue bound: {self.queue}')
+        self._channel.basic_qos(prefetch_count=self._prefetch_count, callback=self.on_basic_qos_ok)
+
+    def on_basic_qos_ok(self, _unused_frame):
+        logging.info(f'Consumer - QOS set to: {self._prefetch_count}')
+        self.start_consuming()
+
+    def start_consuming(self):
+        logging.info('Consumer - Issuing consumer related RPC commands')
+        self._channel.add_on_cancel_callback(self.on_consumer_cancelled)
+        self._consumer_tag = self._channel.basic_consume(self.queue, self.on_message)
+        self.was_consuming = True
+        self._consuming = True
+
+    def on_consumer_cancelled(self, method_frame):
+        logging.info(f'Consumer - Consumer was cancelled remotely, shutting down: {method_frame}')
+        if self._channel:
+            self._channel.close()
+
+    def on_message(self, _unused_channel, basic_deliver, properties, body):
+        logging.info(f'Consumer - Received message # {basic_deliver.delivery_tag} from {properties.app_id}: {body}')
+        self.reply_callback(self._channel,
+                            properties,
+                            basic_deliver.delivery_tag,
+                            body)
+
+    def acknowledge_message(self, delivery_tag):
+        logging.info('Consumer - Acknowledging message %s', delivery_tag)
+        self._channel.basic_ack(delivery_tag)
+
+    def reject_message(self, delivery_tag, requeue=True):
+        logging.info('Consumer - Rejecting message {delivery_tag}')
+        self._channel.basic_reject(delivery_tag, requeue)
+
+    def stop_consuming(self):
+        if self._channel:
+            logging.info('Consumer - Sending a Basic.Cancel RPC command to RabbitMQ')
+            cb = functools.partial(
+                self.on_cancel_ok, userdata=self._consumer_tag)
+            self._channel.basic_cancel(self._consumer_tag, cb)
+
+    def on_cancel_ok(self, _unused_frame, userdata):
+        self._consuming = False
+        logging.info('Consumer - RabbitMQ acknowledged the cancellation of the consumer: %s', userdata)
+        self.close_channel()
+
+    def close_channel(self):
+        logging.info('Consumer - Closing the channel')
+        self._channel.close()
+
+    def stop(self):
+        if not self._closing:
+            self._closing = True
+            logging.info('Consumer - Stopping Async Consumer')
+            if self._consuming:
+                self.stop_consuming()
+            logging.info('Consumer - Stopped Async Consumer')
+
+
+class ReconnectingConsumer(object):
+    """This is an example consumer that will reconnect if the nested
+    ExampleConsumer indicates that a reconnect is necessary.
+
+    """
+
+    def __init__(self, exchange, exchange_type, queue, routing_key, connection_parameters: pika.ConnectionParameters):
+        self.exchange = exchange
+        self.exchange_type = exchange_type
+        self.queue = queue
+        self.routing_key = routing_key
+        self.connection_parameters = connection_parameters
+
+        self._reconnect_delay = 0
+        self._consumer = AsyncConsumer(exchange, exchange_type, queue, routing_key, connection_parameters)
+
+    def run(self):
+        while True:
+            try:
+                self._consumer.connect(asyncio.get_running_loop())
+            except KeyboardInterrupt:
+                self._consumer.stop()
+                break
+            self._maybe_reconnect()
+
+    def _maybe_reconnect(self):
+        if self._consumer.should_reconnect:
+            self._consumer.stop()
+            reconnect_delay = self._get_reconnect_delay()
+            logging.info('Reconnecting after %d seconds', reconnect_delay)
+            time.sleep(reconnect_delay)
+            self._consumer = AsyncConsumer(self.exchange, self.exchange_type, self.queue, self.routing_key,
+                                           self.connection_parameters)
+
+    def _get_reconnect_delay(self):
+        if self._consumer.was_consuming:
+            self._reconnect_delay = 0
+        else:
+            self._reconnect_delay += 1
+        if self._reconnect_delay > 30:
+            self._reconnect_delay = 30
+        return self._reconnect_delay

--- a/shared/lib-hoppy/hoppy/async_consumer.py
+++ b/shared/lib-hoppy/hoppy/async_consumer.py
@@ -1,7 +1,7 @@
 import logging
 from typing import Callable
 
-from hoppy.base_queue_client import BaseQueueClient, Type
+from hoppy.base_queue_client import BaseQueueClient, ClientType
 from hoppy.hoppy_properties import ExchangeProperties, QueueProperties
 
 
@@ -35,7 +35,7 @@ class AsyncConsumer(BaseQueueClient):
                 reply_callback(_channel, properties, basic_deliver.delivery_tag, body)
         """
 
-        super().__init__(Type.CONSUMER, config, exchange_properties, queue_properties, routing_key)
+        super().__init__(ClientType.CONSUMER, config, exchange_properties, queue_properties, routing_key)
 
         self._consuming = False
         self._consumer_tag = None

--- a/shared/lib-hoppy/hoppy/async_consumer.py
+++ b/shared/lib-hoppy/hoppy/async_consumer.py
@@ -1,210 +1,109 @@
-import functools
 import logging
-import time
 from typing import Callable
 
-from hoppy.config import RABBITMQ_CONFIG
-from hoppy.hoppy_properties import ExchangeProperties, QueueProperties
-from hoppy.util import create_connection_parameters
-from pika.adapters.asyncio_connection import AsyncioConnection
+from base_queue_client import BaseQueueClient, Type
+from hoppy_properties import ExchangeProperties, QueueProperties
 
 
-class AsyncConsumer(object):
-    def __init__(self,
-                 config: [dict | None] = None,
+class AsyncConsumer(BaseQueueClient):
+
+    def __init__(self, config: [dict | None] = None,
                  exchange_properties: ExchangeProperties = ExchangeProperties(),
                  queue_properties: QueueProperties = QueueProperties(),
                  routing_key: str = '',
-                 reply_callback: Callable = None):
-        if config is None:
-            config = {}
-        self.config = {**RABBITMQ_CONFIG, **config}
-        self.connection_parameters = create_connection_parameters(self.config)
+                 reply_callback: Callable = None,
+                 prefetch_count: int = 1):
+        super().__init__(Type.CONSUMER, config, exchange_properties, queue_properties, routing_key)
 
-        self.exchange_name = exchange_properties.name
-        self.exchange_type = exchange_properties.type
-        self.passive_declare_exchange = exchange_properties.passive_declare
-        self.durable_exchange = exchange_properties.durable
-        self.auto_delete_exchange = exchange_properties.auto_delete
-
-        self.queue_name = queue_properties.name
-        self.passive_declare_queue = queue_properties.passive_declare
-        self.durable_queue = queue_properties.durable
-        self.auto_delete_queue = queue_properties.auto_delete
-        self.exclusive_queue = queue_properties.exclusive
-
-        self.routing_key = routing_key
-
-        self._loop = None
-        self._connection = None
-        self._channel = None
+        self._consuming = False
         self._consumer_tag = None
-        self._max_reconnect_delay = self.config.get('max_reconnect_delay', 30)
-
-        # In production, experiment with higher prefetch values
-        # for higher consumer throughput
-        self._prefetch_count = 1
+        self._prefetch_count = prefetch_count
         self.reply_callback = reply_callback
 
-        # The following attributes are used per connection session. When a reconnect happens, they should be reset.
-        # See self.initialize_connection_session()
-        self._reconnect_delay = self.config.get('initial_reconnect_delay', 0)
-        self._stopping = False
+    def _initialize_connection_session(self):
+        """The following attributes are used per connection session. When a reconnect happens, they should be reset."""
+
+        super()._initialize_connection_session()
+
         self._consuming = False
 
-    def initialize_connection_session(self):
-        self._reconnect_delay = self.config.get('initial_reconnect_delay', 0)
-        self._stopping = False
-        self._consuming = False
+    def _ready(self):
+        """Executed when the exchange and queue are ready and this class can start the process of consuming.
+        Overrides super class abstract method."""
+        logging.debug(f'event=specifyingQualityOfService '
+                      f'client_type={self._client_type} '
+                      f'prefetch_count={self._prefetch_count}')
+        self._channel.basic_qos(prefetch_count=self._prefetch_count, callback=self._on_basic_qos_ok)
 
-    def connect(self, loop=None):
-        self._loop = loop
+    def _shut_down(self):
+        """Called when the client is requested to stop.
+        Overrides super class abstract method"""
+        if self._consuming:
+            self._stop_consuming()
 
-        logging.debug(f'Consumer - Connecting to RabbitMq params={self.connection_parameters}')
-        return AsyncioConnection(
-            parameters=self.connection_parameters,
-            on_open_callback=self.on_connection_open,
-            on_open_error_callback=self.on_connection_open_error,
-            on_close_callback=self.on_connection_closed,
-            custom_ioloop=loop)
+    def _on_basic_qos_ok(self, _unused_frame):
+        logging.debug(f'event=specifiedQualityOfService '
+                      f'client_type={self._client_type} '
+                      f'prefetch_count={self._prefetch_count}')
+        self._start_consuming()
 
-    def close_connection(self):
-        self._consuming = False
-        if self._connection.is_closing or self._connection.is_closed:
-            logging.debug('Consumer - Connection is closing or already closed')
-        else:
-            logging.debug('Consumer - Closing connection')
-            self._connection.close()
-
-    def on_connection_open(self, connection):
-        self._connection = connection
-        logging.debug('Consumer - Connection opened')
-        self.initialize_connection_session()
-        self.open_channel()
-
-    def on_connection_open_error(self, _unused_connection, err):
-        logging.error('Consumer - Connection open failed: %s', err)
-        self.reconnect()
-
-    def on_connection_closed(self, _unused_connection, reason):
-        self._channel = None
-        if self._stopping:
-            self._connection.ioloop.stop()
-        else:
-            logging.warning(f'Consumer - Connection closed, reason: {reason}')
-            self.reconnect()
-
-    def reconnect(self):
-        self.stop()
-        reconnect_delay = self._get_reconnect_delay()
-        logging.warning('Reconnecting after %d seconds', reconnect_delay)
-        time.sleep(reconnect_delay)
-        self.connect(self._loop)
-
-    def _get_reconnect_delay(self):
-        self._reconnect_delay += 1
-        if self._reconnect_delay > self._max_reconnect_delay:
-            self._reconnect_delay = self._max_reconnect_delay
-        return self._reconnect_delay
-
-    def open_channel(self):
-        logging.debug('Consumer - Creating a new channel')
-        self._connection.channel(on_open_callback=self.on_channel_open)
-
-    def on_channel_open(self, channel):
-        logging.debug('Consumer - Channel opened')
-        self._channel = channel
-        self._channel.add_on_close_callback(self.on_channel_closed)
-        self.setup_exchange(self.exchange_name)
-
-    def on_channel_closed(self, channel, reason):
-        logging.warning(f'Consumer - Channel {channel} was closed: {reason}')
-        self.close_connection()
-
-    def setup_exchange(self, exchange_name):
-        logging.debug(f'Consumer - Declaring exchange: {self.exchange_name}')
-        self._channel.exchange_declare(exchange=exchange_name,
-                                       exchange_type=self.exchange_type,
-                                       passive=self.passive_declare_exchange,
-                                       durable=self.durable_exchange,
-                                       auto_delete=self.auto_delete_exchange,
-                                       callback=self.on_exchange_declare_ok)
-
-    def on_exchange_declare_ok(self, _unused_frame):
-        logging.debug(f'Consumer - Exchange declared: {self.exchange_name}')
-        self.setup_queue()
-
-    def setup_queue(self):
-        logging.debug(f'Consumer - Declaring queue {self.queue_name}')
-        self._channel.queue_declare(queue=self.queue_name,
-                                    passive=self.passive_declare_queue,
-                                    durable=self.durable_queue,
-                                    exclusive=self.exclusive_queue,
-                                    auto_delete=self.auto_delete_queue,
-                                    callback=self.on_queue_declare_ok)
-
-    def on_queue_declare_ok(self, _unused_frame):
-        logging.debug(f'Consumer - Binding {self.exchange_name} to {self.queue_name} with {self.routing_key}')
-        self._channel.queue_bind(
-            self.queue_name,
-            self.exchange_name,
-            routing_key=self.routing_key,
-            callback=self.on_bind_ok)
-
-    def on_bind_ok(self, _unused_frame):
-        logging.debug(f'Consumer - Queue bound: {self.queue_name}')
-        self._channel.basic_qos(prefetch_count=self._prefetch_count, callback=self.on_basic_qos_ok)
-
-    def on_basic_qos_ok(self, _unused_frame):
-        logging.debug(f'Consumer - QOS set to: {self._prefetch_count}')
-        self.start_consuming()
-
-    def start_consuming(self):
-        logging.debug('Consumer - Issuing consumer related RPC commands')
-        self._channel.add_on_cancel_callback(self.on_consumer_cancelled)
-        self._consumer_tag = self._channel.basic_consume(self.queue_name, self.on_message)
+    def _start_consuming(self):
+        self._channel.add_on_cancel_callback(self._on_consumer_cancelled)
+        self._consumer_tag = self._channel.basic_consume(self.queue_name, self._on_message)
         self._consuming = True
+        logging.debug(f'event=startConsuming '
+                      f'client_type={self._client_type} '
+                      f'consumer_tag={self._consumer_tag}')
 
-    def on_consumer_cancelled(self, method_frame):
-        logging.debug(f'Consumer - Consumer was cancelled remotely, shutting down: {method_frame}')
+    def _on_consumer_cancelled(self, method_frame):
+        logging.debug(f'event=serverCancelledConsumer '
+                      f'client_type={self._client_type} '
+                      f'method_frame={method_frame}')
+        super()._close_channel()
+
+    def _stop_consuming(self):
         if self._channel:
-            self._channel.close()
+            logging.debug(f'event=stoppingConsuming '
+                          f'client_type={self._client_type} '
+                          f'consumer_tag={self._consumer_tag}')
+            self._channel.basic_cancel(self._consumer_tag, self._on_cancel_ok)
 
-    def on_message(self, _unused_channel, basic_deliver, properties, body):
-        logging.debug(f'Consumer - Received message # {basic_deliver.delivery_tag} from {properties.app_id}: {body}')
-        self.reply_callback(self._channel,
-                            properties,
-                            basic_deliver.delivery_tag,
-                            body)
+    def _on_cancel_ok(self, _unused_frame):
+        self._consuming = False
+        logging.debug(f'event=stoppedConsuming '
+                      f'client_type={self._client_type} '
+                      f'consumer_tag={self._consumer_tag}')
+        self._close_channel()
 
-    def acknowledge_message(self, delivery_tag):
-        logging.debug('Consumer - Acknowledging message %s', delivery_tag)
+    def _on_message(self, _unused_channel, basic_deliver, properties, body):
+        logging.debug(f'event=receivedMessage '
+                      f'client_type={self._client_type} '
+                      f'app_id={properties.app_id} '
+                      f'delivery_tag={basic_deliver.delivery_tag} '
+                      f'correlation_id={properties.correlation_id}')
+        if self.reply_callback is not None:
+            try:
+                self.reply_callback(self._channel,
+                                    properties,
+                                    basic_deliver.delivery_tag,
+                                    body)
+            except Exception as e:
+                logging.error(f'event=couldNotCallConsumeCallback '
+                              f'client_type={self._client_type} '
+                              f'callback={self.reply_callback} '
+                              f'err={e}')
+
+    def acknowledge_message(self, properties, delivery_tag):
+        logging.debug(f'event=ackedMessage '
+                      f'client_type={self._client_type} '
+                      f'delivery_tag={delivery_tag} '
+                      f'correlation_id={properties.correlation_id}')
         self._channel.basic_ack(delivery_tag)
 
-    def reject_message(self, delivery_tag, requeue=True):
-        logging.debug('Consumer - Rejecting message {delivery_tag}')
+    def reject_message(self, properties, delivery_tag, requeue=True):
+        logging.debug(f'event=rejectedMessage '
+                      f'client_type={self._client_type} '
+                      f'delivery_tag={delivery_tag} '
+                      f'correlation_id={properties.correlation_id} '
+                      f'requeue={requeue}')
         self._channel.basic_reject(delivery_tag, requeue)
-
-    def stop_consuming(self):
-        if self._channel:
-            logging.debug('Consumer - Sending a Basic.Cancel RPC command to RabbitMQ')
-            cb = functools.partial(
-                self.on_cancel_ok, userdata=self._consumer_tag)
-            self._channel.basic_cancel(self._consumer_tag, cb)
-
-    def on_cancel_ok(self, _unused_frame, userdata):
-        self._consuming = False
-        logging.debug('Consumer - RabbitMQ acknowledged the cancellation of the consumer: %s', userdata)
-        self.close_channel()
-
-    def close_channel(self):
-        logging.debug('Consumer - Closing the channel')
-        self._channel.close()
-
-    def stop(self):
-        if not self._stopping:
-            self._stopping = True
-            logging.debug('Consumer - Stopping Async Consumer')
-            if self._consuming:
-                self.stop_consuming()
-            logging.debug('Consumer - Stopped Async Consumer')

--- a/shared/lib-hoppy/hoppy/async_consumer.py
+++ b/shared/lib-hoppy/hoppy/async_consumer.py
@@ -1,8 +1,8 @@
 import logging
 from typing import Callable
 
-from base_queue_client import BaseQueueClient, Type
-from hoppy_properties import ExchangeProperties, QueueProperties
+from hoppy.base_queue_client import BaseQueueClient, Type
+from hoppy.hoppy_properties import ExchangeProperties, QueueProperties
 
 
 class AsyncConsumer(BaseQueueClient):

--- a/shared/lib-hoppy/hoppy/async_hoppy_client.py
+++ b/shared/lib-hoppy/hoppy/async_hoppy_client.py
@@ -79,7 +79,7 @@ class AsyncHoppyClient:
             if response is not None:
                 return self.handle_response(request_id, correlation_id, response)
             else:
-                self.wait_for_response(correlation_id,
+                self.check_for_timeout(correlation_id,
                                        request_id,
                                        wait_for_response_time)
             await asyncio.sleep(0)
@@ -97,7 +97,7 @@ class AsyncHoppyClient:
                             f"id={request_id} "
                             f"queue={self.request_queue_properties.name} "
                             f"correlation_id={correlation_id} "
-                            f"error='{UNEXPECTED_PUBLISH_ERROR}: {e}'")
+                            f"error='{UNEXPECTED_PUBLISH_ERROR}: {e!r}'")
             raise ResponseException(message=UNEXPECTED_PUBLISH_ERROR)
 
     def handle_response(self, request_id, correlation_id, response):
@@ -118,7 +118,7 @@ class AsyncHoppyClient:
                          f"correlation_id={correlation_id}")
             return response
 
-    def wait_for_response(self, correlation_id, request_id, wait_for_response_time):
+    def check_for_timeout(self, correlation_id, request_id, wait_for_response_time):
         current_time = time.time()
         if current_time - wait_for_response_time >= self.max_latency:
             logging.warning(f"event=requestError "

--- a/shared/lib-hoppy/hoppy/async_hoppy_client.py
+++ b/shared/lib-hoppy/hoppy/async_hoppy_client.py
@@ -1,0 +1,167 @@
+import asyncio
+import json
+import logging
+import time
+import uuid
+
+from hoppy.async_consumer import AsyncConsumer
+from hoppy.async_publisher import AsyncPublisher
+from hoppy.exception import ResponseException
+from pika import BasicProperties, ConnectionParameters
+
+
+class AsyncHoppyClient:
+    responses = {}
+    rejected = {}
+
+    def __init__(self,
+                 name: str,
+                 app_id: str,
+                 connection_parameters: ConnectionParameters,
+                 exchange: str,
+                 request_queue: str,
+                 reply_to_queue: str,
+                 max_latency: int = 30,
+                 response_reject_and_requeue_attempts: int = 3):
+        self.name = name
+        self.app_id = app_id
+        self.exchange = exchange
+        self.request_queue = request_queue
+        self.reply_to_queue = reply_to_queue
+        self.max_latency = max_latency
+        self.response_reject_and_requeue_attempts = response_reject_and_requeue_attempts
+
+        self.async_publisher = AsyncPublisher(exchange=exchange,
+                                              exchange_type="direct",
+                                              queue=request_queue,
+                                              routing_key=request_queue,
+                                              connection_parameters=connection_parameters)
+
+        self.async_consumer = AsyncConsumer(exchange=exchange,
+                                            exchange_type="direct",
+                                            queue=reply_to_queue,
+                                            routing_key=reply_to_queue,
+                                            connection_parameters=connection_parameters,
+                                            reply_callback=self._on_reply)
+
+    def start(self, loop):
+        self.async_publisher.connect(loop)
+        self.async_consumer.connect(loop)
+
+    def stop(self):
+        self.async_publisher.stop()
+        self.async_consumer.stop()
+
+    async def make_request(self, request_id, body):
+        correlation_id = str(uuid.uuid4())
+        logging.info(
+            f"event=requestStarted id={request_id} queue={self.request_queue} correlation_id={correlation_id}")
+        self.responses[correlation_id] = None
+
+        try:
+            self.async_publisher.publish_message(body,
+                                                 BasicProperties(app_id=self.app_id,
+                                                                 content_type="application/json",
+                                                                 reply_to=self.reply_to_queue,
+                                                                 correlation_id=correlation_id))
+        except Exception as e:
+            logging.warning(f"event=requestError "
+                            f"id={request_id} "
+                            f"queue={self.request_queue} "
+                            f"correlation_id={correlation_id} "
+                            f"error='Unexpected Error While Publishing {e}'")
+            raise ResponseException(message="Unexpected Error Caught")
+
+        wait_for_response_time = None
+        while True:
+            response = self.responses.get(correlation_id)
+            if response:
+                self._terminate_correlation_id(correlation_id)
+                logging.info(
+                    f"event=requestCompleted id={request_id} queue={self.request_queue} correlation_id={correlation_id}")
+                return response
+            else:
+                if wait_for_response_time is None:
+                    wait_for_response_time = time.time()
+                    await asyncio.sleep(0)
+                elif time.time() - wait_for_response_time >= self.max_latency:
+                    logging.warning(f"event=requestError "
+                                    f"id={request_id} "
+                                    f"queue={self.request_queue} "
+                                    f"correlation_id={correlation_id} "
+                                    f"error='Request timed out'")
+                    self._terminate_correlation_id(correlation_id)
+                    raise ResponseException(message="Request timed out")
+
+    def _terminate_correlation_id(self, correlation_id):
+        if correlation_id in self.responses.keys():
+            del self.responses[correlation_id]
+        if correlation_id in self.rejected.keys():
+            del self.rejected[correlation_id]
+
+    def _on_reply(self, channel, properties, delivery_tag, body):
+        cor_id = properties.correlation_id
+
+        if cor_id and cor_id in self.responses.keys():
+            self.__log_response_event("responseAcked", cor_id, True, False, 1)
+            response = json.loads(body)
+            self.responses[cor_id] = response
+            self.async_consumer.acknowledge_message(delivery_tag)
+            return
+
+        if not cor_id:
+            self.__log_response_event("responseRejected", cor_id, False, False, 1)
+            self.async_consumer.reject_message(delivery_tag, requeue=False)
+            return
+
+        num_rejections = self.rejected.get(cor_id, 0) + 1
+        if num_rejections < self.response_reject_and_requeue_attempts:
+            self.__log_response_event("responseRejected", cor_id, False, True, num_rejections)
+            self.rejected[cor_id] = num_rejections
+            self.async_consumer.reject_message(delivery_tag, requeue=True)
+        else:
+            self.__log_response_event("responseRejected", cor_id, False, False, num_rejections)
+            self.async_consumer.reject_message(delivery_tag, requeue=False)
+            if cor_id in self.rejected:
+                del self.rejected[cor_id]
+
+    def __log_response_event(self, action: str, correlation_id: str, correlated: bool, requeued: bool, times_processed):
+        logging.info(
+            f"event={action} "
+            f"queue={self.request_queue} "
+            f"correlation_id={correlation_id} "
+            f"correlated={correlated} "
+            f"requeued={requeued} "
+            f"times_processed={times_processed}")
+
+
+class RetryableAsyncHoppyClient(AsyncHoppyClient):
+    def __init__(self,
+                 name: str,
+                 app_id: str,
+                 connection_parameters: ConnectionParameters,
+                 exchange: str,
+                 request_queue: str,
+                 reply_to_queue: str,
+                 max_latency: int = 30,
+                 response_reject_and_requeue_attempts: int = 3,
+                 max_retries=3):
+        self.max_retries = max_retries
+        super().__init__(name, app_id, connection_parameters, exchange, request_queue, reply_to_queue, max_latency,
+                         response_reject_and_requeue_attempts)
+
+    async def make_request(self, request_id, body):
+        attempt = 0
+        while attempt < self.max_retries:
+            try:
+                response = await super().make_request(request_id, body)
+                if response:
+                    return response
+            except ResponseException:
+                attempt += 1
+                continue
+        logging.warning(f"event=requestError "
+                        f"id={request_id} "
+                        f"queue={self.request_queue} "
+                        f"error='Max retries reached'")
+        raise ResponseException(message="Max retries reached")

--- a/shared/lib-hoppy/hoppy/async_hoppy_client.py
+++ b/shared/lib-hoppy/hoppy/async_hoppy_client.py
@@ -4,10 +4,10 @@ import logging
 import time
 import uuid
 
-from async_consumer import AsyncConsumer
-from async_publisher import AsyncPublisher
-from exception import ResponseException
-from hoppy_properties import ExchangeProperties, QueueProperties
+from hoppy.async_consumer import AsyncConsumer
+from hoppy.async_publisher import AsyncPublisher
+from hoppy.exception import ResponseException
+from hoppy.hoppy_properties import ExchangeProperties, QueueProperties
 from pika import BasicProperties
 
 MAX_RETRIES_REACHED = "Max retries reached"

--- a/shared/lib-hoppy/hoppy/async_hoppy_client.py
+++ b/shared/lib-hoppy/hoppy/async_hoppy_client.py
@@ -80,7 +80,7 @@ class AsyncHoppyClient:
         wait_for_response_time = None
         while True:
             response = self.responses.get(correlation_id)
-            if response:
+            if response is not None:
                 self._terminate_correlation_id(correlation_id)
                 logging.info(f"event=requestCompleted "
                              f"client={self.name} "
@@ -165,7 +165,7 @@ class RetryableAsyncHoppyClient(AsyncHoppyClient):
         while attempt < self.max_retries:
             try:
                 response = await super().make_request(request_id, body)
-                if response:
+                if response is not None:
                     return response
             except ResponseException:
                 attempt += 1

--- a/shared/lib-hoppy/hoppy/async_publisher.py
+++ b/shared/lib-hoppy/hoppy/async_publisher.py
@@ -1,7 +1,7 @@
 import json
 import logging
 
-from hoppy.base_queue_client import BaseQueueClient, Type
+from hoppy.base_queue_client import BaseQueueClient, ClientType
 from hoppy.hoppy_properties import ExchangeProperties, QueueProperties
 from pika.spec import BasicProperties
 
@@ -28,7 +28,7 @@ class AsyncPublisher(BaseQueueClient):
             the routing key used to route messages to the queue
         """
 
-        super().__init__(Type.PUBLISHER, config, exchange_properties, queue_properties, routing_key)
+        super().__init__(ClientType.PUBLISHER, config, exchange_properties, queue_properties, routing_key)
 
         self._deliveries = {}
         self._acked = 0

--- a/shared/lib-hoppy/hoppy/async_publisher.py
+++ b/shared/lib-hoppy/hoppy/async_publisher.py
@@ -1,174 +1,59 @@
-import functools
 import json
 import logging
-import time
 
-from hoppy.config import RABBITMQ_CONFIG
-from hoppy.hoppy_properties import ExchangeProperties, QueueProperties
-from hoppy.util import create_connection_parameters
-from pika.adapters.asyncio_connection import AsyncioConnection
+from base_queue_client import BaseQueueClient, Type
+from hoppy_properties import ExchangeProperties, QueueProperties
 from pika.spec import BasicProperties
 
 
-class AsyncPublisher(object):
+class AsyncPublisher(BaseQueueClient):
     def __init__(self,
                  config: [dict | None] = None,
                  exchange_properties: ExchangeProperties = ExchangeProperties(),
                  queue_properties: QueueProperties = QueueProperties(),
                  routing_key: str = ''):
-        if config is None:
-            config = {}
-        self.config = {**RABBITMQ_CONFIG, **config}
-        self.connection_parameters = create_connection_parameters(self.config)
+        super().__init__(Type.PUBLISHER, config, exchange_properties, queue_properties, routing_key)
 
-        self.exchange_name = exchange_properties.name
-        self.exchange_type = exchange_properties.type
-        self.passive_declare_exchange = exchange_properties.passive_declare
-        self.durable_exchange = exchange_properties.durable
-        self.auto_delete_exchange = exchange_properties.auto_delete
-
-        self.queue_name = queue_properties.name
-        self.passive_declare_queue = queue_properties.passive_declare
-        self.durable_queue = queue_properties.durable
-        self.auto_delete_queue = queue_properties.auto_delete
-        self.exclusive_queue = queue_properties.exclusive
-
-        self.routing_key = routing_key
-
-        self._loop = None
-        self._connection = None
-        self._channel = None
-        self._max_reconnect_delay = config.get('max_reconnect_delay', 30)
-
-        # The following attributes are used per connection session. When a reconnect happens, they should be reset.
-        # See self.initialize_connection_session()
-        self._reconnect_delay = config.get('initial_reconnect_delay', 0)
-        self._stopping = False
         self._deliveries = {}
         self._acked = 0
         self._nacked = 0
+        self._rejected = 0
         self._message_number = 0
 
-    def initialize_connection_session(self):
-        self._reconnect_delay = self.config.get('initial_reconnect_delay', 0)
-        self._stopping = False
+    def _initialize_connection_session(self):
+        """The following attributes are used per connection session. When a reconnect happens, they should be reset."""
+
+        super()._initialize_connection_session()
+
         self._deliveries = {}
         self._acked = 0
         self._nacked = 0
+        self._rejected = 0
         self._message_number = 0
 
-    def connect(self, loop=None):
-        self._loop = loop
+    def _ready(self):
+        """Executed when the exchange and queue are ready and this class can start the process of consuming.
+        Overrides super class abstract method."""
+        logging.debug(f'event=enabledDeliveryConfirmation client_type={self._client_type}')
+        self._channel.confirm_delivery(self._on_delivery_confirmation)
 
-        logging.debug(f'Publisher - Connecting to RabbitMq params={self.connection_parameters}')
-        self._connection = AsyncioConnection(
-            parameters=self.connection_parameters,
-            on_open_callback=self.on_connection_open,
-            on_open_error_callback=self.on_connection_open_error,
-            on_close_callback=self.on_connection_closed,
-            custom_ioloop=loop)
-        return self._connection
+    def _shut_down(self):
+        """Called when the client is requested to stop.
+        Overrides super class abstract method"""
+        self._close_channel()
+        self._close_connection()
 
-    def on_connection_open(self, connection):
-        logging.debug('Publisher - Connection opened')
-        self._connection = connection
-        self.initialize_connection_session()
-        self.open_channel()
-
-    def on_connection_open_error(self, _unused_connection, err):
-        logging.error(f'Publisher - Connection open failed: {err}')
-        self.reconnect()
-
-    def on_connection_closed(self, _unused_connection, reason):
-        self._channel = None
-        if self._stopping:
-            self._connection.ioloop.stop()
-        else:
-            logging.warning(f'Publisher - Connection closed, reason: {reason}')
-            self.reconnect()
-
-    def reconnect(self):
-        self.stop()
-        reconnect_delay = self._get_reconnect_delay()
-        logging.warning('Reconnecting after %d seconds', reconnect_delay)
-        time.sleep(reconnect_delay)
-        self.connect(self._loop)
-
-    def _get_reconnect_delay(self):
-        self._reconnect_delay += 1
-        if self._reconnect_delay > self._max_reconnect_delay:
-            self._reconnect_delay = self._max_reconnect_delay
-        return self._reconnect_delay
-
-    def open_channel(self):
-        logging.debug('Publisher - Creating a new channel')
-        self._connection.channel(on_open_callback=self.on_channel_open)
-
-    def on_channel_open(self, channel):
-        logging.debug('Publisher - Channel opened')
-        self._channel = channel
-        self.add_on_channel_close_callback()
-        self.setup_exchange(self.exchange_name)
-
-    def add_on_channel_close_callback(self):
-        logging.debug('Publisher - Adding channel close callback')
-        self._channel.add_on_close_callback(self.on_channel_closed)
-
-    def on_channel_closed(self, channel, reason):
-        logging.warning(f'Publisher - Channel {channel} was closed: {reason}')
-        self.close_connection()
-
-    def setup_exchange(self, exchange_name):
-        logging.debug(f'Publisher - Declaring exchange {exchange_name}')
-        cb = functools.partial(self.on_exchange_declare_ok,
-                               userdata=exchange_name)
-        self._channel.exchange_declare(exchange=exchange_name,
-                                       exchange_type=self.exchange_type,
-                                       passive=self.passive_declare_exchange,
-                                       durable=self.durable_exchange,
-                                       auto_delete=self.auto_delete_exchange,
-                                       callback=cb)
-
-    def on_exchange_declare_ok(self, _unused_frame, userdata):
-        logging.debug(f'Publisher - Exchange declared {userdata}')
-        self.setup_queue()
-
-    def setup_queue(self):
-        logging.debug(f'Publisher - Declaring queue {self.queue_name}', )
-        self._channel.queue_declare(queue=self.queue_name,
-                                    passive=self.passive_declare_queue,
-                                    durable=self.durable_queue,
-                                    exclusive=self.exclusive_queue,
-                                    auto_delete=self.auto_delete_queue,
-                                    callback=self.on_queue_declare_ok)
-
-    def on_queue_declare_ok(self, _unused_frame):
-        logging.debug(f'Publisher - Binding {self.exchange_name} to {self.queue_name} with {self.routing_key}')
-        self._channel.queue_bind(self.queue_name,
-                                 self.exchange_name,
-                                 routing_key=self.routing_key,
-                                 callback=self.on_bind_ok)
-
-    def on_bind_ok(self, _unused_frame):
-        logging.debug(f'Publisher - Queue bound {self.queue_name}')
-        self.start_publishing()
-
-    def start_publishing(self):
-        logging.debug('Publisher - Issuing Confirm.Select RPC command')
-        self._channel.confirm_delivery(self.on_delivery_confirmation)
-
-    def on_delivery_confirmation(self, method_frame):
+    def _on_delivery_confirmation(self, method_frame):
         confirmation_type = method_frame.method.NAME.split('.')[1].lower()
         ack_multiple = method_frame.method.multiple
         delivery_tag = method_frame.method.delivery_tag
-
-        logging.debug(
-            f'Publisher - Received {confirmation_type} for delivery tag: {delivery_tag} (multiple: {ack_multiple})')
 
         if confirmation_type == 'ack':
             self._acked += 1
         elif confirmation_type == 'nack':
             self._nacked += 1
+        elif confirmation_type == 'reject':
+            self._rejected += 1
 
         del self._deliveries[delivery_tag]
 
@@ -178,14 +63,22 @@ class AsyncPublisher(object):
                     self._acked += 1
                     del self._deliveries[tmp_tag]
 
-        logging.debug(
-            f'Publisher - Published {self._message_number} messages, '
-            f'{len(self._deliveries)} have yet to be confirmed, '
-            f'{self._acked} were acked and {self._nacked} were nacked')
+        logging.debug(f'event=receivedDeliveryConfirmation '
+                      f'client_type={self._client_type} '
+                      f'confirmation_type={confirmation_type} '
+                      f'delivery_tag={delivery_tag} '
+                      f'ack_multiple={ack_multiple} '
+                      f'total={self._message_number} '
+                      f'unconfirmed={len(self._deliveries)} '
+                      f'acked={self._acked} '
+                      f'nacked={self._nacked} '
+                      f'rejected={self._rejected}')
 
     def publish_message(self, message='hello', properties: BasicProperties = None):
         if self._channel is None or not self._channel.is_open:
-            logging.warning(f'Publisher - Could not publish message with channel={self._channel}')
+            logging.warning(f'event=publishMessageFailed '
+                            f'client_type={self._client_type} '
+                            f'channel={self._channel}')
             return
 
         self._channel.basic_publish(self.exchange_name, self.routing_key,
@@ -193,25 +86,6 @@ class AsyncPublisher(object):
                                     properties)
         self._message_number += 1
         self._deliveries[self._message_number] = True
-        logging.debug(f'Publisher - Published message # {self._message_number}', )
-
-    def stop(self):
-        if not self._stopping:
-            logging.debug('Publisher - Stopping Async Publisher')
-            self._stopping = True
-            self.close_channel()
-            self.close_connection()
-            logging.debug('Publisher - Stopped Async Publisher')
-
-    def close_channel(self):
-        if self._channel is not None:
-            logging.debug('Publisher - Closing the channel')
-            self._channel.close()
-
-    def close_connection(self):
-        if self._connection is not None:
-            if self._connection.is_closing or self._connection.is_closed:
-                logging.debug('Publisher - Connection is closing or already closed')
-            else:
-                logging.debug('Publisher - Closing connection')
-                self._connection.close()
+        logging.debug(f'event=publishedMessage '
+                      f'client_type={self._client_type} '
+                      f'message_number={self._message_number}')

--- a/shared/lib-hoppy/hoppy/async_publisher.py
+++ b/shared/lib-hoppy/hoppy/async_publisher.py
@@ -1,8 +1,8 @@
 import json
 import logging
 
-from base_queue_client import BaseQueueClient, Type
-from hoppy_properties import ExchangeProperties, QueueProperties
+from hoppy.base_queue_client import BaseQueueClient, Type
+from hoppy.hoppy_properties import ExchangeProperties, QueueProperties
 from pika.spec import BasicProperties
 
 

--- a/shared/lib-hoppy/hoppy/async_publisher.py
+++ b/shared/lib-hoppy/hoppy/async_publisher.py
@@ -1,0 +1,158 @@
+import functools
+import json
+import logging
+
+import pika
+from pika.adapters.asyncio_connection import AsyncioConnection
+
+
+class AsyncPublisher(object):
+    def __init__(self, exchange, exchange_type, queue, routing_key, connection_parameters: pika.ConnectionParameters):
+        """Set up the example publisher object, passing in the URL we will use to connect to RabbitMQ."""
+        self.exchange = exchange
+        self.exchange_type = exchange_type
+        self.queue = queue
+        self.routing_key = routing_key
+        self.connection_parameters = connection_parameters
+
+        self._connection = None
+        self._channel = None
+
+        self._deliveries = {}
+        self._acked = 0
+        self._nacked = 0
+        self._message_number = 0
+
+        self._stopping = False
+
+    def connect(self, loop):
+        logging.info(f'Publisher -  Connecting to RabbitMq params={self.connection_parameters}')
+        self._connection = AsyncioConnection(
+            parameters=self.connection_parameters,
+            on_open_callback=self.on_connection_open,
+            on_open_error_callback=self.on_connection_open_error,
+            on_close_callback=self.on_connection_closed,
+            custom_ioloop=loop)
+        return self._connection
+
+    def on_connection_open(self, connection):
+        logging.info('Publisher -  Connection opened')
+        self._connection = connection
+        self.open_channel()
+
+    def on_connection_open_error(self, _unused_connection, err):
+        logging.error(f'Publisher -  Connection open failed, reopening in 5 seconds: {err}')
+        self._connection.ioloop.call_later(5, self._connection.ioloop.stop)
+
+    def on_connection_closed(self, _unused_connection, reason):
+        self._channel = None
+        logging.warning('Publisher -  Channel Closed')
+
+    def open_channel(self):
+        logging.info('Publisher -  Creating a new channel')
+        self._connection.channel(on_open_callback=self.on_channel_open)
+
+    def on_channel_open(self, channel):
+        logging.info('Publisher -  Channel opened')
+        self._channel = channel
+        self.add_on_channel_close_callback()
+        self.setup_exchange(self.exchange)
+
+    def add_on_channel_close_callback(self):
+        logging.info('Publisher -  Adding channel close callback')
+        self._channel.add_on_close_callback(self.on_channel_closed)
+
+    def on_channel_closed(self, channel, reason):
+        logging.warning(f'Publisher -  Channel {channel} was closed: {reason}')
+        self._channel = None
+        if not self._stopping:
+            self._connection.close()
+
+    def setup_exchange(self, exchange_name):
+        logging.info(f'Publisher -  Declaring exchange {exchange_name}')
+        cb = functools.partial(self.on_exchange_declare_ok,
+                               userdata=exchange_name)
+        self._channel.exchange_declare(exchange=exchange_name,
+                                       exchange_type=self.exchange_type,
+                                       durable=True,
+                                       auto_delete=True,
+                                       callback=cb)
+
+    def on_exchange_declare_ok(self, _unused_frame, userdata):
+        logging.info(f'Publisher -  Exchange declared {userdata}')
+        self.setup_queue(self.queue)
+
+    def setup_queue(self, queue_name):
+        logging.info(f'Publisher -  Declaring queue {queue_name}', )
+        self._channel.queue_declare(queue=queue_name,
+                                    callback=self.on_queue_declare_ok)
+
+    def on_queue_declare_ok(self, _unused_frame):
+        logging.info(f'Publisher -  Binding {self.exchange} to {self.queue} with {self.routing_key}')
+        self._channel.queue_bind(self.queue,
+                                 self.exchange,
+                                 routing_key=self.routing_key,
+                                 callback=self.on_bind_ok)
+
+    def on_bind_ok(self, _unused_frame):
+        logging.info(f'Publisher -  Queue bound {self.queue}')
+        self.start_publishing()
+
+    def start_publishing(self):
+        logging.info('Publisher -  Issuing Confirm.Select RPC command')
+        self._channel.confirm_delivery(self.on_delivery_confirmation)
+
+    def on_delivery_confirmation(self, method_frame):
+        confirmation_type = method_frame.method.NAME.split('.')[1].lower()
+        ack_multiple = method_frame.method.multiple
+        delivery_tag = method_frame.method.delivery_tag
+
+        logging.info(
+            f'Publisher -  Received {confirmation_type} for delivery tag: {delivery_tag} (multiple: {ack_multiple})')
+
+        if confirmation_type == 'ack':
+            self._acked += 1
+        elif confirmation_type == 'nack':
+            self._nacked += 1
+
+        del self._deliveries[delivery_tag]
+
+        if ack_multiple:
+            for tmp_tag in list(self._deliveries.keys()):
+                if tmp_tag <= delivery_tag:
+                    self._acked += 1
+                    del self._deliveries[tmp_tag]
+
+        logging.info(
+            f'Publisher -  Published {self._message_number} messages, '
+            f'{len(self._deliveries)} have yet to be confirmed, '
+            f'{self._acked} were acked and {self._nacked} were nacked')
+
+    def publish_message(self, message='hello', properties: pika.BasicProperties = None):
+        if self._channel is None or not self._channel.is_open:
+            logging.warning(f'Publisher -  Could not publish message with channel={self._channel}')
+            return
+
+        self._channel.basic_publish(self.exchange, self.routing_key,
+                                    json.dumps(message, ensure_ascii=False),
+                                    properties)
+        self._message_number += 1
+        self._deliveries[self._message_number] = True
+        logging.info(f'Publisher -  Published message # {self._message_number}', )
+
+    def stop(self):
+        logging.info('Publisher - Stopping Async Publisher')
+        self._stopping = True
+        self.close_channel()
+        self.close_connection()
+        logging.info('Publisher - Stopped Async Publisher')
+
+    def close_channel(self):
+        if self._channel is not None:
+            logging.info('Publisher - Closing the channel')
+            self._channel.close()
+
+    def close_connection(self):
+        if self._connection is not None:
+            logging.info('Publisher - Closing connection')
+            self._connection.close()

--- a/shared/lib-hoppy/hoppy/async_publisher.py
+++ b/shared/lib-hoppy/hoppy/async_publisher.py
@@ -7,11 +7,27 @@ from pika.spec import BasicProperties
 
 
 class AsyncPublisher(BaseQueueClient):
+    """Creates an asynchronous publisher that can be used to publish messages to a queue"""
+
     def __init__(self,
                  config: [dict | None] = None,
                  exchange_properties: ExchangeProperties = ExchangeProperties(),
                  queue_properties: QueueProperties = QueueProperties(),
                  routing_key: str = ''):
+        """
+        Creates this class
+
+        :param config: dict | None = None
+            collection of key value pairs used to create the RabbitMQ connection parameters (see pika.ConnectionParameters)
+            this config is merged with the default RABBITMQ_CONFIG
+        :param exchange_properties: ExchangeProperties
+            properties dictating how the exchange is declared
+        :param queue_properties: QueueProperties
+            properties dictating how the queue is declared
+        :param routing_key: str = ''
+            the routing key used to route messages to the queue
+        """
+
         super().__init__(Type.PUBLISHER, config, exchange_properties, queue_properties, routing_key)
 
         self._deliveries = {}
@@ -34,12 +50,14 @@ class AsyncPublisher(BaseQueueClient):
     def _ready(self):
         """Executed when the exchange and queue are ready and this class can start the process of consuming.
         Overrides super class abstract method."""
+
         logging.debug(f'event=enabledDeliveryConfirmation client_type={self._client_type}')
         self._channel.confirm_delivery(self._on_delivery_confirmation)
 
     def _shut_down(self):
         """Called when the client is requested to stop.
         Overrides super class abstract method"""
+
         self._close_channel()
         self._close_connection()
 
@@ -75,6 +93,8 @@ class AsyncPublisher(BaseQueueClient):
                       f'rejected={self._rejected}')
 
     def publish_message(self, message='hello', properties: BasicProperties = None):
+        """Publishes a message to the queue"""
+
         if self._channel is None or not self._channel.is_open:
             logging.warning(f'event=publishMessageFailed '
                             f'client_type={self._client_type} '

--- a/shared/lib-hoppy/hoppy/base_queue_client.py
+++ b/shared/lib-hoppy/hoppy/base_queue_client.py
@@ -3,8 +3,8 @@ import time
 from abc import ABC, abstractmethod
 from enum import StrEnum, auto
 
-from config import RABBITMQ_CONFIG
-from hoppy_properties import ExchangeProperties, QueueProperties
+from hoppy.config import RABBITMQ_CONFIG
+from hoppy.hoppy_properties import ExchangeProperties, QueueProperties
 from pika import ConnectionParameters, PlainCredentials
 from pika.adapters.asyncio_connection import AsyncioConnection
 

--- a/shared/lib-hoppy/hoppy/base_queue_client.py
+++ b/shared/lib-hoppy/hoppy/base_queue_client.py
@@ -251,10 +251,7 @@ class BaseQueueClient(ABC):
 
     @staticmethod
     def __kwarg_str(**kwargs):
-        msg = ''
-        for k, v in kwargs.items():
-            msg += f'{k}={v} '
-        return msg.strip()
+        return ' '.join(f'{k}={v}' for k, v in kwargs.items())
 
     def _debug(self, event, **kwargs):
         msg = f'event={event} client_type={self._client_type.name} {self.__kwarg_str(**kwargs)}'
@@ -269,5 +266,5 @@ class BaseQueueClient(ABC):
         logging.warning(msg)
 
     def _error(self, event, error=None, **kwargs):
-        msg = f'event={event} client_type={self._client_type.name} err={repr(error)} {self.__kwarg_str(**kwargs)}'
+        msg = f'event={event} client_type={self._client_type.name} err={error!r} {self.__kwarg_str(**kwargs)}'
         logging.error(msg)

--- a/shared/lib-hoppy/hoppy/base_queue_client.py
+++ b/shared/lib-hoppy/hoppy/base_queue_client.py
@@ -1,7 +1,7 @@
 import logging
 import time
 from abc import ABC, abstractmethod
-from enum import StrEnum, auto
+from enum import Enum
 
 from hoppy.config import RABBITMQ_CONFIG
 from hoppy.hoppy_properties import ExchangeProperties, QueueProperties
@@ -9,9 +9,9 @@ from pika import ConnectionParameters, PlainCredentials
 from pika.adapters.asyncio_connection import AsyncioConnection
 
 
-class Type(StrEnum):
-    CONSUMER = auto()
-    PUBLISHER = auto()
+class ClientType(str, Enum):
+    CONSUMER = "CONSUMER"
+    PUBLISHER = "PUBLISHER"
 
     def __str__(self):
         return self.value
@@ -32,7 +32,7 @@ class BaseQueueClient(ABC):
     """
 
     def __init__(self,
-                 _client_type: Type,
+                 _client_type: ClientType,
                  config: [dict | None] = None,
                  exchange_properties: ExchangeProperties = ExchangeProperties(),
                  queue_properties: QueueProperties = QueueProperties(),

--- a/shared/lib-hoppy/hoppy/base_queue_client.py
+++ b/shared/lib-hoppy/hoppy/base_queue_client.py
@@ -1,0 +1,220 @@
+import logging
+import time
+from abc import ABC, abstractmethod
+from enum import StrEnum, auto
+
+from config import RABBITMQ_CONFIG
+from hoppy_properties import ExchangeProperties, QueueProperties
+from pika import ConnectionParameters, PlainCredentials
+from pika.adapters.asyncio_connection import AsyncioConnection
+
+
+class Type(StrEnum):
+    CONSUMER = auto()
+    PUBLISHER = auto()
+
+    def __str__(self):
+        return self.value
+
+
+class BaseQueueClient(ABC):
+    def __init__(self,
+                 _client_type: Type,
+                 config: [dict | None] = None,
+                 exchange_properties: ExchangeProperties = ExchangeProperties(),
+                 queue_properties: QueueProperties = QueueProperties(),
+                 routing_key: str = ''):
+        self._client_type = _client_type
+        if config is None:
+            config = {}
+        self.config = {**RABBITMQ_CONFIG, **config}
+        self.connection_parameters = self._create_connection_parameters()
+
+        self.exchange_name = exchange_properties.name
+        self.exchange_type = exchange_properties.type
+        self.passive_declare_exchange = exchange_properties.passive_declare
+        self.durable_exchange = exchange_properties.durable
+        self.auto_delete_exchange = exchange_properties.auto_delete
+
+        self.queue_name = queue_properties.name
+        self.passive_declare_queue = queue_properties.passive_declare
+        self.durable_queue = queue_properties.durable
+        self.auto_delete_queue = queue_properties.auto_delete
+        self.exclusive_queue = queue_properties.exclusive
+
+        self.routing_key = routing_key
+
+        self._loop = None
+        self._connection = None
+        self._channel = None
+        self._max_reconnect_delay = self.config.get('max_reconnect_delay', 30)
+        self._reconnect_delay = self.config.get('initial_reconnect_delay', 0)
+        self._stopping = False
+
+    def _create_connection_parameters(self) -> ConnectionParameters:
+        credentials = PlainCredentials(self.config["username"], self.config["password"])
+        return ConnectionParameters(
+            host=self.config['host'],
+            port=self.config['port'],
+            credentials=credentials)
+
+    def _initialize_connection_session(self):
+        """The following attributes are used per connection session. When a reconnect happens, they should be reset."""
+        self._reconnect_delay = self.config.get('initial_reconnect_delay', 0)
+        self._stopping = False
+
+    def connect(self, loop=None):
+        self._loop = loop
+
+        logging.debug(f'event=connectingToRabbitMq client_type={self._client_type} config={self.config}')
+        self._connection = AsyncioConnection(
+            parameters=self.connection_parameters,
+            on_open_callback=self._on_connection_open,
+            on_open_error_callback=self._on_connection_open_error,
+            on_close_callback=self._on_connection_closed,
+            custom_ioloop=loop)
+        return self._connection
+
+    @abstractmethod
+    def _ready(self):
+        pass
+
+    @abstractmethod
+    def _shut_down(self):
+        pass
+
+    def stop(self):
+        if not self._stopping:
+            self._stopping = True
+            logging.debug(f'event=stopping client_type={self._client_type}')
+            self._shut_down()
+            logging.debug(f'event=stopped client_type={self._client_type}')
+
+    def _on_connection_open(self, connection):
+        logging.debug(f'event=openedConnection client_type={self._client_type}')
+        self._connection = connection
+        self._initialize_connection_session()
+        self._open_channel()
+
+    def _on_connection_open_error(self, _unused_connection, err):
+        logging.error(f'event=failedToOpenConnection client_type={self._client_type} err={err}')
+        self._reconnect()
+
+    def _on_connection_closed(self, _unused_connection, reason):
+        self._channel = None
+        if self._stopping:
+            self._connection.ioloop.stop()
+            logging.debug(f'event=closedConnection '
+                          f'client_type={self._client_type} '
+                          f'closing={self._connection.is_closing} '
+                          f'closed={self._connection.is_closed}')
+        else:
+            logging.warning(f'event=connectionClosedUnexpectedly client_type={self._client_type} reason={reason}')
+            self._reconnect()
+
+    def _close_connection(self):
+        if self._connection is not None:
+            logging.debug(f'event=closingConnection '
+                          f'client_type={self._client_type} '
+                          f'closing={self._connection.is_closing} '
+                          f'closed={self._connection.is_closed}')
+            if not self._connection.is_closing and not self._connection.is_closed:
+                self._connection.close()
+
+    def _reconnect(self):
+        self.stop()
+        reconnect_delay = self._get_reconnect_delay()
+        logging.warning(f'event=reconnecting client_type={self._client_type} reconnect_delay_seconds={reconnect_delay}')
+        time.sleep(reconnect_delay)
+        self.connect(self._loop)
+
+    def _get_reconnect_delay(self):
+        self._reconnect_delay += 1
+        if self._reconnect_delay > self._max_reconnect_delay:
+            self._reconnect_delay = self._max_reconnect_delay
+        return self._reconnect_delay
+
+    def _open_channel(self):
+        logging.debug(f'event=openingChannel client_type={self._client_type}')
+        self._connection.channel(on_open_callback=self._on_channel_open)
+
+    def _on_channel_open(self, channel):
+        logging.debug(f'event=openedChannel client_type={self._client_type} channel={channel}')
+        self._channel = channel
+        self._channel.add_on_close_callback(self._on_channel_closed)
+        self._setup_exchange()
+
+    def _on_channel_closed(self, channel, reason):
+        logging.warning(f'event=closedChannel client_type={self._client_type} channel={channel} reason={reason}')
+        self._close_connection()
+
+    def _close_channel(self):
+        if self._channel is not None:
+            logging.debug(f'event=closingChannel client_type={self._client_type} channel={self._channel}')
+            self._channel.close()
+
+    def _setup_exchange(self):
+        logging.debug(f'event=declaringExchange '
+                      f'client_type={self._client_type} '
+                      f'exchange={self.exchange_name} '
+                      f'type={self.exchange_type} '
+                      f'passive_declare={self.passive_declare_exchange} '
+                      f'durable={self.durable_exchange} '
+                      f'auto_delete={self.auto_delete_exchange}')
+        self._channel.exchange_declare(exchange=self.exchange_name,
+                                       exchange_type=self.exchange_type,
+                                       passive=self.passive_declare_exchange,
+                                       durable=self.durable_exchange,
+                                       auto_delete=self.auto_delete_exchange,
+                                       callback=self._on_exchange_declare_ok)
+
+    def _on_exchange_declare_ok(self, _unused_frame):
+        logging.debug(f'event=declaredExchange '
+                      f'client_type={self._client_type} '
+                      f'exchange={self.exchange_name} '
+                      f'type={self.exchange_type} '
+                      f'passive_declare={self.passive_declare_exchange} '
+                      f'durable={self.durable_exchange} '
+                      f'auto_delete={self.auto_delete_exchange}')
+        self._setup_queue()
+
+    def _setup_queue(self):
+        logging.debug(f'event=declaringQueue '
+                      f'client_type={self._client_type} '
+                      f'queue={self.queue_name} '
+                      f'passive_declare={self.passive_declare_queue} '
+                      f'durable={self.durable_queue} '
+                      f'exclusive={self.exclusive_queue} '
+                      f'auto_delete={self.auto_delete_exchange}')
+        self._channel.queue_declare(queue=self.queue_name,
+                                    passive=self.passive_declare_queue,
+                                    durable=self.durable_queue,
+                                    exclusive=self.exclusive_queue,
+                                    auto_delete=self.auto_delete_queue,
+                                    callback=self._on_queue_declare_ok)
+
+    def _on_queue_declare_ok(self, _unused_frame):
+        logging.debug(f'event=declaredQueue '
+                      f'client_type={self._client_type} '
+                      f'queue={self.queue_name} '
+                      f'passive_declare={self.passive_declare_queue} '
+                      f'durable={self.durable_queue} '
+                      f'exclusive={self.exclusive_queue} '
+                      f'auto_delete={self.auto_delete_exchange}')
+        logging.debug(f'event=bindingQueue '
+                      f'client_type={self._client_type} '
+                      f'queue={self.queue_name} '
+                      f'exchange={self.exchange_name} '
+                      f'routing_key={self.routing_key}')
+        self._channel.queue_bind(self.queue_name,
+                                 self.exchange_name,
+                                 routing_key=self.routing_key,
+                                 callback=self._on_bind_ok)
+
+    def _on_bind_ok(self, _unused_frame):
+        logging.debug(f'event=boundQueue '
+                      f'client_type={self._client_type} '
+                      f'queue={self.queue_name} '
+                      f'exchange={self.exchange_name} '
+                      f'routing_key={self.routing_key}')
+        self._ready()

--- a/shared/lib-hoppy/hoppy/config.py
+++ b/shared/lib-hoppy/hoppy/config.py
@@ -7,4 +7,6 @@ RABBITMQ_CONFIG = {
     "port": int(os.environ.get("RABBITMQ_PORT") or 5672),
     "retry_limit": int(os.environ.get("RABBITMQ_RETRY_LIMIT") or 3),
     "timeout": int(os.environ.get("RABBITMQ_TIMEOUT") or 60 * 60 * 3),  # 3 hours
+    "initial_reconnect_delay": int(os.environ.get("RABBITMQ_INITIAL_RECONNECT_DELAY") or 0),
+    "max_reconnect_delay": int(os.environ.get("RABBITMQ_MAX_RECONNECT_DELAY") or 30)
 }

--- a/shared/lib-hoppy/hoppy/exception.py
+++ b/shared/lib-hoppy/hoppy/exception.py
@@ -1,0 +1,6 @@
+class ResponseException(Exception):
+    """Raised when the request could not be made."""
+
+    def __init__(self, message=None):
+        self.message = message
+        super().__init__(self.message)

--- a/shared/lib-hoppy/hoppy/hoppy_properties.py
+++ b/shared/lib-hoppy/hoppy/hoppy_properties.py
@@ -1,0 +1,19 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class ExchangeProperties:
+    name: str = '',
+    type: str = 'direct'
+    passive_declare: bool = True
+    durable: bool = True
+    auto_delete: bool = False
+
+
+@dataclass
+class QueueProperties:
+    name: str = '',
+    passive_declare: bool = True
+    durable: bool = True
+    auto_delete: bool = False
+    exclusive: bool = False

--- a/shared/lib-hoppy/hoppy/hoppy_properties.py
+++ b/shared/lib-hoppy/hoppy/hoppy_properties.py
@@ -7,7 +7,7 @@ class ExchangeProperties:
     type: str = 'direct'
     passive_declare: bool = True
     durable: bool = True
-    auto_delete: bool = False
+    auto_delete: bool = True
 
 
 @dataclass
@@ -15,5 +15,5 @@ class QueueProperties:
     name: str = '',
     passive_declare: bool = True
     durable: bool = True
-    auto_delete: bool = False
+    auto_delete: bool = True
     exclusive: bool = False

--- a/shared/lib-hoppy/hoppy/util.py
+++ b/shared/lib-hoppy/hoppy/util.py
@@ -1,9 +1,0 @@
-from pika import ConnectionParameters, PlainCredentials
-
-
-def create_connection_parameters(config) -> ConnectionParameters:
-    credentials = PlainCredentials(config["username"], config["password"])
-    return ConnectionParameters(
-        host=config['host'],
-        port=config['port'],
-        credentials=credentials)

--- a/shared/lib-hoppy/hoppy/util.py
+++ b/shared/lib-hoppy/hoppy/util.py
@@ -1,0 +1,9 @@
+from pika import ConnectionParameters, PlainCredentials
+
+
+def create_connection_parameters(config) -> ConnectionParameters:
+    credentials = PlainCredentials(config["username"], config["password"])
+    return ConnectionParameters(
+        host=config['host'],
+        port=config['port'],
+        credentials=credentials)

--- a/shared/lib-hoppy/pyproject.toml
+++ b/shared/lib-hoppy/pyproject.toml
@@ -21,5 +21,5 @@ version = { attr = "hoppy.__version__" }
 addopts = [
     "--import-mode=importlib",
 ]
-#log_cli = true
-#log_cli_level = "INFO"
+log_cli = true
+log_cli_level = "INFO"

--- a/shared/lib-hoppy/pyproject.toml
+++ b/shared/lib-hoppy/pyproject.toml
@@ -4,12 +4,22 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hoppy"
-description = "Python library for building VRO microservices"
+description = "Python library for building VRO microservices that need to interact with Rabbit MQ"
 requires-python = ">=3.6"
 dependencies = [
     "pika",
+    "pytest",
+    "pytest-mock",
+    "pytest-asyncio"
 ]
 dynamic = ["version"]
 
 [tool.setuptools.dynamic]
-version = {attr = "hoppy.__version__"}
+version = { attr = "hoppy.__version__" }
+
+[tool.pytest.ini_options]
+addopts = [
+    "--import-mode=importlib",
+]
+#log_cli = true
+#log_cli_level = "INFO"

--- a/shared/lib-hoppy/pyproject.toml
+++ b/shared/lib-hoppy/pyproject.toml
@@ -20,6 +20,8 @@ version = { attr = "hoppy.__version__" }
 [tool.pytest.ini_options]
 addopts = [
     "--import-mode=importlib",
+    "-rfesp"
 ]
-log_cli = true
-log_cli_level = "INFO"
+testpaths = [
+    "tests"
+]

--- a/shared/lib-hoppy/test/async_hoppy_client_test.py
+++ b/shared/lib-hoppy/test/async_hoppy_client_test.py
@@ -10,7 +10,7 @@ from hoppy.async_hoppy_client import (AsyncHoppyClient,
                                       RetryableAsyncHoppyClient)
 from hoppy.exception import ResponseException
 
-pika_params = pika.ConnectionParameters()
+config = {}
 
 
 @pytest.fixture(autouse=True)
@@ -25,7 +25,7 @@ def mock_async_publisher(mocker):
 
 def get_client(mock_async_publisher, mock_async_consumer, app_id="test", exchange="exchange", queue="queue",
                reply_queue="reply_queue", max_latency=3, requeue_attempts=3):
-    client = AsyncHoppyClient("test_client", app_id, pika_params, exchange, queue, reply_queue, max_latency, requeue_attempts)
+    client = AsyncHoppyClient("test_client", app_id, config, exchange, queue, reply_queue, max_latency, requeue_attempts)
     client.async_publisher = mock_async_publisher
     client.async_consumer = mock_async_consumer
     return client
@@ -195,7 +195,7 @@ class TestAsyncHoppyClient:
 
 def get_retry_client(mock_async_publisher, mock_async_consumer, app_id="test", exchange="exchange", queue="queue",
                      reply_queue="reply_queue", max_latency=3, requeue_attempts=3, max_retries=3):
-    client = RetryableAsyncHoppyClient("test_client", app_id, pika_params, exchange, queue, reply_queue, max_latency, requeue_attempts,
+    client = RetryableAsyncHoppyClient("test_client", app_id, config, exchange, queue, reply_queue, max_latency, requeue_attempts,
                                        max_retries)
     client.async_publisher = mock_async_publisher
     client.async_consumer = mock_async_consumer

--- a/shared/lib-hoppy/test/async_hoppy_client_test.py
+++ b/shared/lib-hoppy/test/async_hoppy_client_test.py
@@ -1,6 +1,5 @@
 import asyncio
 import json
-import logging
 import uuid
 from unittest.mock import ANY, call
 
@@ -43,7 +42,6 @@ class TestAsyncHoppyClient:
 
         client.async_publisher.connect.assert_called_once_with(loop)
         client.async_consumer.connect.assert_called_once_with(loop)
-        logging.info(client.async_publisher.mock_calls)
 
     def test_stop(self, mock_async_publisher, mock_async_consumer):
         # Given
@@ -150,7 +148,6 @@ class TestAsyncHoppyClient:
         with pytest.raises(ResponseException):
             await asyncio.wait_for(results_future, 5)
         client.async_publisher.publish_message.assert_called_once_with(request, ANY)
-        logging.info(client.rejected)
 
         # reply_correlation_id is not in rejected. Limit of response_reject_and_requeue_attempts has been reached.
         assert reply_correlation_id not in client.rejected.keys()

--- a/shared/lib-hoppy/test/async_hoppy_client_test.py
+++ b/shared/lib-hoppy/test/async_hoppy_client_test.py
@@ -11,6 +11,7 @@ from hoppy.async_hoppy_client import (MAX_RETRIES_REACHED, TIMED_OUT,
                                       AsyncHoppyClient,
                                       RetryableAsyncHoppyClient)
 from hoppy.exception import ResponseException
+from hoppy.hoppy_properties import ExchangeProperties, QueueProperties
 
 config = {}
 
@@ -25,10 +26,13 @@ def mock_async_publisher(mocker):
     return mocker.patch('hoppy.async_publisher.AsyncPublisher')
 
 
-def get_client(mock_async_publisher, mock_async_consumer, app_id="test", exchange="exchange", queue="queue",
+def get_client(mock_async_publisher, mock_async_consumer, app_id="test", exchange_name="exchange", queue_name="queue",
                reply_queue="reply_queue", max_latency=3, requeue_attempts=3):
-    client = AsyncHoppyClient("test_client", app_id, config, exchange, queue, reply_queue, max_latency,
-                              requeue_attempts)
+    exchange_props = ExchangeProperties(name=exchange_name)
+    request_props = QueueProperties(name=queue_name)
+    reply_props = QueueProperties(name=reply_queue)
+    client = AsyncHoppyClient("test_client", app_id, config, exchange_props, request_props, reply_props, queue_name,
+                              reply_queue, max_latency, requeue_attempts)
     client.async_publisher = mock_async_publisher
     client.async_consumer = mock_async_consumer
     return client
@@ -251,11 +255,14 @@ class TestAsyncHoppyClient:
         client.async_publisher.publish_message.assert_called_once_with(request, ANY)
 
 
-def get_retry_client(mock_async_publisher, mock_async_consumer, app_id="test", exchange="exchange", queue="queue",
+def get_retry_client(mock_async_publisher, mock_async_consumer, app_id="test", exchange_name="exchange",
+                     queue_name="queue",
                      reply_queue="reply_queue", max_latency=3, requeue_attempts=3, max_retries=3):
-    client = RetryableAsyncHoppyClient("test_client", app_id, config, exchange, queue, reply_queue, max_latency,
-                                       requeue_attempts,
-                                       max_retries)
+    exchange_props = ExchangeProperties(name=exchange_name)
+    request_props = QueueProperties(name=queue_name)
+    reply_props = QueueProperties(name=reply_queue)
+    client = RetryableAsyncHoppyClient("test_client", app_id, config, exchange_props, request_props, reply_props,
+                                       queue_name, reply_queue, max_latency, requeue_attempts, max_retries)
     client.async_publisher = mock_async_publisher
     client.async_consumer = mock_async_consumer
     return client

--- a/shared/lib-hoppy/test/async_hoppy_client_test.py
+++ b/shared/lib-hoppy/test/async_hoppy_client_test.py
@@ -1,0 +1,289 @@
+import asyncio
+import json
+import logging
+import uuid
+from unittest.mock import ANY, call
+
+import pika
+import pika.spec
+import pytest
+from hoppy.async_hoppy_client import (AsyncHoppyClient,
+                                      RetryableAsyncHoppyClient)
+from hoppy.exception import ResponseException
+
+pika_params = pika.ConnectionParameters()
+
+
+@pytest.fixture(autouse=True)
+def mock_async_consumer(mocker):
+    return mocker.patch('hoppy.async_consumer.AsyncConsumer')
+
+
+@pytest.fixture(autouse=True)
+def mock_async_publisher(mocker):
+    return mocker.patch('hoppy.async_publisher.AsyncPublisher')
+
+
+def get_client(mock_async_publisher, mock_async_consumer, app_id="test", exchange="exchange", queue="queue",
+               reply_queue="reply_queue", max_latency=3, requeue_attempts=3):
+    client = AsyncHoppyClient("test_client", app_id, pika_params, exchange, queue, reply_queue, max_latency, requeue_attempts)
+    client.async_publisher = mock_async_publisher
+    client.async_consumer = mock_async_consumer
+    return client
+
+
+class TestAsyncHoppyClient:
+    def test_start(self, mock_async_publisher, mock_async_consumer):
+        # given
+        client = get_client(mock_async_publisher, mock_async_consumer)
+
+        # when
+        loop = asyncio.new_event_loop()
+        client.start(loop)
+
+        client.async_publisher.connect.assert_called_once_with(loop)
+        client.async_consumer.connect.assert_called_once_with(loop)
+        logging.info(client.async_publisher.mock_calls)
+
+    def test_stop(self, mock_async_publisher, mock_async_consumer):
+        # Given
+        client = get_client(mock_async_publisher, mock_async_consumer)
+
+        # When
+        client.stop()
+
+        # Then
+        client.async_publisher.stop.assert_called_once()
+        client.async_consumer.stop.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_make_request_and_timeout_reached(self, mock_async_publisher, mock_async_consumer):
+        # Given
+        client = get_client(mock_async_publisher, mock_async_consumer, max_latency=0)
+        request = '{"test":1}'
+
+        # When / Then
+        with pytest.raises(ResponseException):
+            await client.make_request("1", body=request)
+        client.async_publisher.publish_message.assert_called_once_with(request, ANY)
+
+    @pytest.mark.asyncio
+    async def test_make_request_and_correlated_response_received(self, mock_async_publisher, mock_async_consumer,
+                                                                 mocker):
+        # Given
+        client = get_client(mock_async_publisher, mock_async_consumer, max_latency=3)
+        request = '{"test":1}'
+        expected_response = '{"test_response":1}'
+        cor_id = str(uuid.uuid4())
+        mocker.patch('uuid.uuid4', return_value=cor_id)
+        reply_props = pika.BasicProperties(correlation_id=cor_id)
+        deliver_props = pika.spec.Basic.Deliver(delivery_tag=1)
+
+        # When
+        results_future = asyncio.ensure_future(client.make_request('1', request))
+        await asyncio.sleep(0)
+        client._on_reply(None, reply_props, deliver_props, expected_response)
+
+        # Then
+        actual_response = await asyncio.wait_for(results_future, 10)
+        client.async_publisher.publish_message.assert_called_once_with(request, ANY)
+        assert json.loads(expected_response) == actual_response  # actual response is json object
+
+    @pytest.mark.asyncio
+    async def test_make_request_and_non_correlated_response_received(self, mock_async_publisher, mock_async_consumer,
+                                                                     mocker):
+        # Given
+        client = get_client(mock_async_publisher, mock_async_consumer, max_latency=2)
+
+        # Request
+        request = '{"test":1}'
+        request_correlation_id = str(uuid.uuid4())
+
+        # Reply
+        unexpected_response = '{"test_response":1}'
+        reply_correlation_id = str(uuid.uuid4())
+        reply_props = pika.BasicProperties(correlation_id=reply_correlation_id)
+        deliver_props = pika.spec.Basic.Deliver(delivery_tag=1)
+
+        # When
+        mocker.patch('uuid.uuid4', return_value=request_correlation_id)
+        results_future = asyncio.ensure_future(client.make_request('1', request))
+        await asyncio.sleep(0)
+        client._on_reply(None, reply_props, deliver_props, unexpected_response)
+
+        # Then should time out
+        with pytest.raises(ResponseException):
+            await asyncio.wait_for(results_future, 3)
+        client.async_publisher.publish_message.assert_called_once_with(request, ANY)
+        assert request_correlation_id not in client.responses.keys()
+
+        # reply_correlation_id is still in rejected. Limit of response_reject_and_requeue_attempts has not been reached.
+        assert reply_correlation_id in client.rejected.keys()
+
+    @pytest.mark.asyncio
+    async def test_make_request_and_non_correlated_response_received_multiple_times(self,
+                                                                                    mock_async_publisher,
+                                                                                    mock_async_consumer,
+                                                                                    mocker):
+        # Given
+        client = get_client(mock_async_publisher, mock_async_consumer, max_latency=3)
+
+        # Request
+        request = '{"test":1}'
+        request_correlation_id = str(uuid.uuid4())
+
+        # Reply
+        unexpected_response = '{"test_response":1}'
+        reply_correlation_id = str(uuid.uuid4())
+        reply_props = pika.BasicProperties(correlation_id=reply_correlation_id)
+        deliver_props = pika.spec.Basic.Deliver(delivery_tag=1)
+
+        # When
+        mocker.patch('uuid.uuid4', return_value=request_correlation_id)
+        results_future = asyncio.ensure_future(client.make_request('1', request))
+        await asyncio.sleep(0)
+        client._on_reply(None, reply_props, deliver_props, unexpected_response)
+        client._on_reply(None, reply_props, deliver_props, unexpected_response)
+        client._on_reply(None, reply_props, deliver_props, unexpected_response)
+
+        # Then should time out
+        with pytest.raises(ResponseException):
+            await asyncio.wait_for(results_future, 5)
+        client.async_publisher.publish_message.assert_called_once_with(request, ANY)
+        logging.info(client.rejected)
+
+        # reply_correlation_id is not in rejected. Limit of response_reject_and_requeue_attempts has been reached.
+        assert reply_correlation_id not in client.rejected.keys()
+        assert request_correlation_id not in client.responses.keys()
+
+    @pytest.mark.asyncio
+    async def test_make_request_and_correlated_and_non_correlated_response_received(self,
+                                                                                    mock_async_publisher,
+                                                                                    mock_async_consumer,
+                                                                                    mocker):
+        # Given
+        client = get_client(mock_async_publisher, mock_async_consumer, max_latency=3)
+
+        # Request
+        request = '{"test":1}'
+        request_correlation_id = str(uuid.uuid4())
+
+        # Reply
+        expected_response = '{"test_response":1}'
+        expected_response_correlation_id = request_correlation_id
+        expected_response_props = pika.BasicProperties(correlation_id=expected_response_correlation_id)
+        expected_deliver_props = pika.spec.Basic.Deliver(delivery_tag=1)
+
+        unexpected_response = '{"test_response":2}'
+        unexpected_response_correlation_id = str(uuid.uuid4())
+        unexpected_response_props = pika.BasicProperties(correlation_id=unexpected_response_correlation_id)
+        unexpected_deliver_props = pika.spec.Basic.Deliver(delivery_tag=1)
+
+        # When
+        mocker.patch('uuid.uuid4', return_value=request_correlation_id)
+        results_future = asyncio.ensure_future(client.make_request('1', request))
+        await asyncio.sleep(0)
+        client._on_reply(None, unexpected_response_props, unexpected_deliver_props, unexpected_response)
+        client._on_reply(None, expected_response_props, expected_deliver_props, expected_response)
+
+        # Then
+        client.async_publisher.publish_message.assert_called_once_with(request, ANY)
+        actual_response = await asyncio.wait_for(results_future, 10)
+        assert json.loads(expected_response) == actual_response  # actual response is json object
+        assert request_correlation_id not in client.responses.keys()
+
+        # reply_correlation_id is still in rejected. Limit of response_reject_and_requeue_attempts has not been reached.
+        assert unexpected_response_correlation_id in client.rejected.keys()
+
+
+def get_retry_client(mock_async_publisher, mock_async_consumer, app_id="test", exchange="exchange", queue="queue",
+                     reply_queue="reply_queue", max_latency=3, requeue_attempts=3, max_retries=3):
+    client = RetryableAsyncHoppyClient("test_client", app_id, pika_params, exchange, queue, reply_queue, max_latency, requeue_attempts,
+                                       max_retries)
+    client.async_publisher = mock_async_publisher
+    client.async_consumer = mock_async_consumer
+    return client
+
+
+class TestRetryableAsyncHoppyClient:
+
+    @pytest.mark.asyncio
+    async def test_make_request_and_max_retries_reached(self, mock_async_publisher, mock_async_consumer, mocker):
+        # Given
+        client = get_retry_client(mock_async_publisher, mock_async_consumer, max_latency=1, max_retries=2)
+        request = '{"test":1}'
+
+        correlation_id_1 = uuid.uuid4()
+        correlation_id_2 = uuid.uuid4()
+        mocker.patch('uuid.uuid4', side_effect=[correlation_id_1, correlation_id_2])
+        properties_1 = pika.spec.BasicProperties(app_id="test", content_type="application/json", reply_to="reply_queue",
+                                                 correlation_id=str(correlation_id_1))
+        properties_2 = pika.spec.BasicProperties(app_id="test", content_type="application/json", reply_to="reply_queue",
+                                                 correlation_id=str(correlation_id_2))
+        mocker.patch('pika.spec.BasicProperties', side_effect=[properties_1, properties_2])
+
+        # When / Then
+        with pytest.raises(ResponseException):
+            await client.make_request("1", body=request)
+        expected_calls = [call(request, properties_1), call(request, properties_2)]
+        assert str(mock_async_publisher.publish_message.mock_calls).replace('\n', '') == str(expected_calls)
+
+    @pytest.mark.asyncio
+    async def test_make_request_and_initial_attempt_success(self,
+                                                            mock_async_publisher,
+                                                            mock_async_consumer,
+                                                            mocker):
+        # Given
+        client = get_retry_client(mock_async_publisher, mock_async_consumer, max_latency=3, max_retries=2)
+        request = '{"test":1}'
+        expected_response = '{"test_response":1}'
+        cor_id = str(uuid.uuid4())
+        mocker.patch('uuid.uuid4', return_value=cor_id)
+        reply_props = pika.BasicProperties(correlation_id=cor_id)
+        deliver_props = pika.spec.Basic.Deliver(delivery_tag=1)
+
+        # When
+        results_future = asyncio.ensure_future(client.make_request('1', request))
+        await asyncio.sleep(0)
+        client._on_reply(None, reply_props, deliver_props, expected_response)
+
+        # Then
+        actual_response = await asyncio.wait_for(results_future, 10)
+        client.async_publisher.publish_message.assert_called_once_with(request, ANY)
+        assert json.loads(expected_response) == actual_response  # actual response is json object
+
+    @pytest.mark.asyncio
+    async def test_make_request_and_initial_attempt_fails_retry_succeeds(self,
+                                                                         mock_async_publisher,
+                                                                         mock_async_consumer,
+                                                                         mocker):
+        # Given
+        client = get_retry_client(mock_async_publisher, mock_async_consumer, max_latency=5, max_retries=2)
+
+        # Request
+        request = '{"test":1}'
+        correlation_id_1 = uuid.uuid4()
+        correlation_id_2 = uuid.uuid4()
+        mocker.patch('uuid.uuid4', side_effect=[correlation_id_1, correlation_id_2])
+        properties_1 = pika.spec.BasicProperties(app_id="test", content_type="application/json", reply_to="reply_queue",
+                                                 correlation_id=str(correlation_id_1))
+        properties_2 = pika.spec.BasicProperties(app_id="test", content_type="application/json", reply_to="reply_queue",
+                                                 correlation_id=str(correlation_id_2))
+        mocker.patch('pika.spec.BasicProperties', side_effect=[properties_1, properties_2])
+
+        # Response
+        expected_response = '{"test_response":1}'
+        reply_props = pika.BasicProperties(correlation_id=str(correlation_id_2))
+        deliver_props = pika.spec.Basic.Deliver(delivery_tag=1)
+
+        # When
+        mocker.patch('hoppy.async_publisher.AsyncPublisher.publish_message', side_effect=[Exception("Ooops"), None])
+        results_future = asyncio.ensure_future(client.make_request('1', request))
+        await asyncio.sleep(0)
+        client._on_reply(None, reply_props, deliver_props, expected_response)
+
+        # Then
+        actual_response = await asyncio.wait_for(results_future, 10)
+        expected_calls = [call(request, properties_1), call(request, properties_2)]
+        assert str(mock_async_publisher.publish_message.mock_calls).replace('\n', '') == str(expected_calls)
+        assert json.loads(expected_response) == actual_response  # actual response is json object


### PR DESCRIPTION
## What was the problem?
<!-- brief description of how things worked before this PR -->
Current implemention of the hoppy library did not include a way to make requests to a service connected via rabbitMQ.

Associated tickets or Slack threads:
- This is an effort to increase capability of hoppy library for VRO partners in pursuit of this task:
  - department-of-veterans-affairs/abd-vro/issues/2028
  - department-of-veterans-affairs/abd-vro/issues/2063

## How does this fix it?[^1]
This adds the ability to create async publishers, consumers, and an async client uses for blocking request/response. 

## How to test this PR
Pull the PR and install the hoppy library:
1. First create a python virtual environment
2. within `abd-vro` repo, run `cd shared/lib-hoppy`
3. run install command to install locally by running: `pip install .`
4. run `pytest`

<details>
<summary>Optionally, create a program like this to exercise the publisher and consumer:</summary>

```
 import asyncio
import functools
import logging
import sys

from async_consumer import AsyncConsumer
from async_publisher import AsyncPublisher
from hoppy_properties import ExchangeProperties, QueueProperties

logging.basicConfig(
    format="[%(asctime)s] %(levelname)-8s %(message)s",
    level=logging.INFO,
    datefmt="%Y-%m-%d %H:%M:%S",
    stream=sys.stdout,
)


def _on_reply(_channel, properties, delivery_tag, body):
    logging.info(f"Message Rx msg={body}")
    _channel.basic_ack(delivery_tag)


def publish_messages(publisher: AsyncPublisher, msg, count, delay):
    for i in range(count):
        loop.call_later(delay * (i + 1), functools.partial(publish, publisher.publish_message, i, msg))


def publish(publish_function, i, msg):
    publish_function(msg)
    logging.info(f"Message Tx #{i} msg={msg}")


async def close(clients: [AsyncPublisher | AsyncConsumer], delay):
    await asyncio.sleep(delay)
    for client in clients:
        client.stop()


if __name__ == "__main__":
    loop = asyncio.new_event_loop()

    exchange_props = ExchangeProperties("hey", passive_declare=False, auto_delete=False)
    queue_props = QueueProperties("hey", passive_declare=False, auto_delete=False)

    consumer = AsyncConsumer(exchange_properties=exchange_props, queue_properties=queue_props, routing_key="1",
                             reply_callback=_on_reply)
    logging.info(consumer.__dict__)
    consumer.connect(loop)

    publisher = AsyncPublisher(exchange_properties=exchange_props, queue_properties=queue_props, routing_key="1")
    publisher.connect(loop)
    publish_messages(publisher, "yo", 10, 1)

    # task = loop.create_task(close([consumer], 300))
    # task = loop.create_task(close([publisher], 12))
    task = loop.create_task(close([publisher, consumer], 12))
    loop.run_until_complete(task)
```
</details>

[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
