### PR TITLE
Support application load balancers from LHDI

### DIFF
--- a/helm/api-gateway/templates/virtual-service.yaml
+++ b/helm/api-gateway/templates/virtual-service.yaml
@@ -7,8 +7,8 @@ spec:
   # Refer to https://animated-carnival-57b3e7f5.pages.github.io/container-platform/routing-traffic/
   hosts: [{{ .Values.global.endpoint }}]
   gateways:
-  - [istio-system/ldx-{{ .Values.global.lhdiCluster }}-1-{{ .Values.global.environment }}-gateway]
-  - [istio-system/ldx-{ { .Values.global.lhdiCluster } }-1-{ { .Values.global.environment } }-alb-gateway]
+  - istio-system/ldx-{{ .Values.global.lhdiCluster }}-1-{{ .Values.global.environment }}-gateway
+  - istio-system/ldx-{ { .Values.global.lhdiCluster } }-1-{ { .Values.global.environment } }-alb-gateway
 
   http:
   - match:

--- a/helm/api-gateway/templates/virtual-service.yaml
+++ b/helm/api-gateway/templates/virtual-service.yaml
@@ -1,12 +1,15 @@
 apiVersion: networking.istio.io/v1beta1
-kind: VirtualService
+kind: \VirtualService
 metadata:
   name: {{ .Values.global.hostnamePrefix }}-api-gateway-virtservice
   labels: {{- toYaml .Values.labels | nindent 4 }}
 spec:
   # Refer to https://animated-carnival-57b3e7f5.pages.github.io/container-platform/routing-traffic/
   hosts: [{{ .Values.global.endpoint }}]
-  gateways: [istio-system/ldx-{{ .Values.global.lhdiCluster }}-1-{{ .Values.global.environment }}-gateway]
+  gateways:
+  - [istio-system/ldx-{{ .Values.global.lhdiCluster }}-1-{{ .Values.global.environment }}-gateway]
+  - [istio-system/ldx-{ { .Values.global.lhdiCluster } }-1-{ { .Values.global.environment } }-alb-gateway]
+
   http:
   - match:
     # Using solution at https://github.com/istio/istio/issues/8076#issuecomment-515278023

--- a/helm/api-gateway/templates/virtual-service.yaml
+++ b/helm/api-gateway/templates/virtual-service.yaml
@@ -8,7 +8,7 @@ spec:
   hosts: [{{ .Values.global.endpoint }}]
   gateways:
   - istio-system/ldx-{{ .Values.global.lhdiCluster }}-1-{{ .Values.global.environment }}-gateway
-  - istio-system/ldx-{ { .Values.global.lhdiCluster } }-1-{ { .Values.global.environment } }-alb-gateway
+  - istio-system/ldx-{{ .Values.global.lhdiCluster }}-1-{{ .Values.global.environment }}-alb-gateway
 
   http:
   - match:

--- a/helm/api-gateway/templates/virtual-service.yaml
+++ b/helm/api-gateway/templates/virtual-service.yaml
@@ -1,5 +1,5 @@
 apiVersion: networking.istio.io/v1beta1
-kind: \VirtualService
+kind: VirtualService
 metadata:
   name: {{ .Values.global.hostnamePrefix }}-api-gateway-virtservice
   labels: {{- toYaml .Values.labels | nindent 4 }}

--- a/helm/domain-cc/templates/virtual-service.yaml
+++ b/helm/domain-cc/templates/virtual-service.yaml
@@ -7,8 +7,8 @@ spec:
   # Refer to https://animated-carnival-57b3e7f5.pages.github.io/container-platform/routing-traffic/
   hosts: [{{ .Values.global.endpoint }}]
   gateways:
-  - [istio-system/ldx-{{ .Values.global.lhdiCluster }}-1-{{ .Values.global.environment }}-gateway]
-  - [istio-system/ldx-{ { .Values.global.lhdiCluster } }-1-{ { .Values.global.environment } }-alb-gateway]
+  - istio-system/ldx-{{ .Values.global.lhdiCluster }}-1-{{ .Values.global.environment }}-gateway
+  - istio-system/ldx-{ { .Values.global.lhdiCluster } }-1-{ { .Values.global.environment } }-alb-gateway
 
   http:
   - match:

--- a/helm/domain-cc/templates/virtual-service.yaml
+++ b/helm/domain-cc/templates/virtual-service.yaml
@@ -6,7 +6,10 @@ metadata:
 spec:
   # Refer to https://animated-carnival-57b3e7f5.pages.github.io/container-platform/routing-traffic/
   hosts: [{{ .Values.global.endpoint }}]
-  gateways: [istio-system/ldx-{{ .Values.global.lhdiCluster }}-1-{{ .Values.global.environment }}-gateway]
+  gateways:
+  - [istio-system/ldx-{{ .Values.global.lhdiCluster }}-1-{{ .Values.global.environment }}-gateway]
+  - [istio-system/ldx-{ { .Values.global.lhdiCluster } }-1-{ { .Values.global.environment } }-alb-gateway]
+
   http:
   - match:
     # Using solution at https://github.com/istio/istio/issues/8076#issuecomment-515278023

--- a/helm/domain-cc/templates/virtual-service.yaml
+++ b/helm/domain-cc/templates/virtual-service.yaml
@@ -8,7 +8,7 @@ spec:
   hosts: [{{ .Values.global.endpoint }}]
   gateways:
   - istio-system/ldx-{{ .Values.global.lhdiCluster }}-1-{{ .Values.global.environment }}-gateway
-  - istio-system/ldx-{ { .Values.global.lhdiCluster } }-1-{ { .Values.global.environment } }-alb-gateway
+  - istio-system/ldx-{{ .Values.global.lhdiCluster }}-1-{{ .Values.global.environment }}-alb-gateway
 
   http:
   - match:

--- a/helm/domain-ee/templates/virtual-service.yaml
+++ b/helm/domain-ee/templates/virtual-service.yaml
@@ -7,8 +7,8 @@ spec:
   # Refer to https://animated-carnival-57b3e7f5.pages.github.io/container-platform/routing-traffic/
   hosts: [{{ .Values.global.endpoint }}]
   gateways:
-  - [istio-system/ldx-{{ .Values.global.lhdiCluster }}-1-{{ .Values.global.environment }}-gateway]
-  - [istio-system/ldx-{ { .Values.global.lhdiCluster } }-1-{ { .Values.global.environment } }-alb-gateway]
+  - istio-system/ldx-{{ .Values.global.lhdiCluster }}-1-{{ .Values.global.environment }}-gateway
+  - istio-system/ldx-{ { .Values.global.lhdiCluster } }-1-{ { .Values.global.environment } }-alb-gateway
 
   http:
   - match:

--- a/helm/domain-ee/templates/virtual-service.yaml
+++ b/helm/domain-ee/templates/virtual-service.yaml
@@ -6,7 +6,10 @@ metadata:
 spec:
   # Refer to https://animated-carnival-57b3e7f5.pages.github.io/container-platform/routing-traffic/
   hosts: [{{ .Values.global.endpoint }}]
-  gateways: [istio-system/ldx-{{ .Values.global.lhdiCluster }}-1-{{ .Values.global.environment }}-gateway]
+  gateways:
+  - [istio-system/ldx-{{ .Values.global.lhdiCluster }}-1-{{ .Values.global.environment }}-gateway]
+  - [istio-system/ldx-{ { .Values.global.lhdiCluster } }-1-{ { .Values.global.environment } }-alb-gateway]
+
   http:
   - match:
     # Using solution at https://github.com/istio/istio/issues/8076#issuecomment-515278023

--- a/helm/domain-ee/templates/virtual-service.yaml
+++ b/helm/domain-ee/templates/virtual-service.yaml
@@ -8,7 +8,7 @@ spec:
   hosts: [{{ .Values.global.endpoint }}]
   gateways:
   - istio-system/ldx-{{ .Values.global.lhdiCluster }}-1-{{ .Values.global.environment }}-gateway
-  - istio-system/ldx-{ { .Values.global.lhdiCluster } }-1-{ { .Values.global.environment } }-alb-gateway
+  - istio-system/ldx-{{ .Values.global.lhdiCluster }}-1-{{ .Values.global.environment }}-alb-gateway
 
   http:
   - match:

--- a/helm/vro-app/templates/virtual-service.yaml
+++ b/helm/vro-app/templates/virtual-service.yaml
@@ -7,8 +7,8 @@ spec:
   # Refer to https://animated-carnival-57b3e7f5.pages.github.io/container-platform/routing-traffic/
   hosts: [{{ .Values.global.endpoint }}]
   gateways:
-  - [istio-system/ldx-{{ .Values.global.lhdiCluster }}-1-{{ .Values.global.environment }}-gateway]
-  - [istio-system/ldx-{ { .Values.global.lhdiCluster } }-1-{ { .Values.global.environment } }-alb-gateway]
+  - istio-system/ldx-{{ .Values.global.lhdiCluster }}-1-{{ .Values.global.environment }}-gateway
+  - istio-system/ldx-{ { .Values.global.lhdiCluster } }-1-{ { .Values.global.environment } }-alb-gateway
 
   http:
   - match:

--- a/helm/vro-app/templates/virtual-service.yaml
+++ b/helm/vro-app/templates/virtual-service.yaml
@@ -6,7 +6,10 @@ metadata:
 spec:
   # Refer to https://animated-carnival-57b3e7f5.pages.github.io/container-platform/routing-traffic/
   hosts: [{{ .Values.global.endpoint }}]
-  gateways: [istio-system/ldx-{{ .Values.global.lhdiCluster }}-1-{{ .Values.global.environment }}-gateway]
+  gateways:
+  - [istio-system/ldx-{{ .Values.global.lhdiCluster }}-1-{{ .Values.global.environment }}-gateway]
+  - [istio-system/ldx-{ { .Values.global.lhdiCluster } }-1-{ { .Values.global.environment } }-alb-gateway]
+
   http:
   - match:
     # Using solution at https://github.com/istio/istio/issues/8076#issuecomment-515278023

--- a/helm/vro-app/templates/virtual-service.yaml
+++ b/helm/vro-app/templates/virtual-service.yaml
@@ -8,7 +8,7 @@ spec:
   hosts: [{{ .Values.global.endpoint }}]
   gateways:
   - istio-system/ldx-{{ .Values.global.lhdiCluster }}-1-{{ .Values.global.environment }}-gateway
-  - istio-system/ldx-{ { .Values.global.lhdiCluster } }-1-{ { .Values.global.environment } }-alb-gateway
+  - istio-system/ldx-{{ .Values.global.lhdiCluster }}-1-{{ .Values.global.environment }}-alb-gateway
 
   http:
   - match:


### PR DESCRIPTION
<!-- Ensure the PR title reflects the feature or bug name -->

## What was the problem?
<!-- brief description of how things worked before this PR -->
LHDI will be moving to support application load balancers and our K8s VirtualService resources were not configured to support traffic from the new gateways

Associated tickets or Slack threads:
- #1987 

## How does this fix it?[^1]
<!-- description of how things will work after this PR -->
Adds a new gateway per the ticket spec 

## How to test this PR
- Test deployment in lower environments


[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
