### PR TITLE
Add virtual_host to hoppy config

### DIFF
--- a/shared/lib-hoppy/hoppy/base_queue_client.py
+++ b/shared/lib-hoppy/hoppy/base_queue_client.py
@@ -77,6 +77,7 @@ class BaseQueueClient(ABC):
         return ConnectionParameters(
             host=self.config['host'],
             port=self.config['port'],
+            virtual_host=self.config['virtual_host'],
             credentials=credentials)
 
     def _initialize_connection_session(self):

--- a/shared/lib-hoppy/hoppy/config.py
+++ b/shared/lib-hoppy/hoppy/config.py
@@ -5,6 +5,7 @@ RABBITMQ_CONFIG = {
     "username": os.environ.get("RABBITMQ_PLACEHOLDERS_USERNAME") or "guest",
     "password": os.environ.get("RABBITMQ_PLACEHOLDERS_USERPASSWORD") or "guest",
     "port": int(os.environ.get("RABBITMQ_PORT") or 5672),
+    "virtual_host": os.environ.get("RABBITMQ_VHOST") or "/",
     "retry_limit": int(os.environ.get("RABBITMQ_RETRY_LIMIT") or 3),
     "timeout": int(os.environ.get("RABBITMQ_TIMEOUT") or 60 * 60 * 3),  # 3 hours
     "initial_reconnect_delay": int(os.environ.get("RABBITMQ_INITIAL_RECONNECT_DELAY") or 0),


### PR DESCRIPTION
<!-- Ensure the PR title reflects the feature or bug name -->

## What was the problem?
On certain dev environments (e.g. GitHub Codespaces), the default vhost name of `/` can result in some unexpected behavior, such as consumers timing out in integration tests and 404s in the RabbitMQ management console when attempting to view exchange/connection details.

Associated threads:
- https://stackoverflow.com/questions/54707566/rabbitmq-management-404-when-loading-a-queue-or-exchange

## How does this fix it?[^1]
<!-- description of how things will work after this PR -->
Allow developers in affected environments to specify an alternate name by setting the `RABBITMQ_VHOST` environment variable. If unspecified, maintain the default vhost name (`/`).

## How to test this PR
- In docker-compose.yml, set the `RABBITMQ_DEFAULT_VHOST` environment variable for `rabbitmq-service`  to some value (e.g. `vh`):
```yml
  rabbitmq-service:
...
    environment:
...
      RABBITMQ_DEFAULT_VHOST: vh
```
- Set `RABBITMQ_VHOST` to the same value on the machine running your test suites
- Run test suites for hoppy and apps that use hoppy


[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
