### PR TITLE
Update codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,3 +4,6 @@
 # Employee Experience Team
 /domain-ee/ @department-of-veterans-affairs/benefits-employee-exp-engineers
 /shared/lib-hoppy/ @department-of-veterans-affairs/benefits-employee-exp-engineers
+
+# Contention Classification Team
+/domain-cc/ @department-of-veterans-affairs/benefits-contention-classification-engineers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,6 @@
 # This will match all files and assign them to the 'benefits-vro-engineers' team when a new PR is created.
 * @department-of-veterans-affairs/benefits-vro-engineers
+
+# Employee Experience Team
+/domain-ee/ @department-of-veterans-affairs/benefits-employee-exp-engineers
+/shared/lib-hoppy/ @department-of-veterans-affairs/benefits-employee-exp-engineers


### PR DESCRIPTION
<!-- Ensure the PR title reflects the feature or bug name -->

## What was the problem?
CC and EE teams may not always be aware of new PRs related to their projects.

## How does this fix it?
Automatically notify @department-of-veterans-affairs/benefits-employee-exp-engineers and @department-of-veterans-affairs/benefits-contention-classification-engineers about PRs for domain-ee and domain-cc code, respectively.
