### PR TITLE
Update abd-vro--project-work-ticket.md to match new VRO ticket template

### DIFF
--- a/.github/ISSUE_TEMPLATE/abd-vro--project-work-ticket.md
+++ b/.github/ISSUE_TEMPLATE/abd-vro--project-work-ticket.md
@@ -6,22 +6,20 @@ labels: ''
 assignees: ''
 
 ---
+### Description
+_Is this connected to a bigger project? Is there a deadline? Label the story as appropriate._
 
-<!-- Template items below are optional but encouraged -->
+### Why, What is the value? 
 
-**User Story**
-
-As a (persona), I want (behavior), so that (goal).
-
-**Acceptance Criteria**
+### Dependencies
+_List all (internal and external) and use #XXXX to link related work._ 
+ 
+### Acceptance Criteria 
+_Include non functional requirements, e.g. for design when are reviews/collaboration scheduled?_ 
 
 1. _Acceptance criteria 1_
 2. _Acceptance criteria 2_
 3. _Acceptance criteria 3_
 
-**Not included in this work**
-
-A note about things that should not be considered necessary.
-
-**Notes about work**
-- _(links to documentation, resources, code, etc that might inform the person doing the work)_
+### Notes / Documentation
+_Share relevant information that might inform the person doing the work, note anything out of scope, link to relevant resources, documentation, code, or artifacts_ 


### PR DESCRIPTION
## What was the problem?
We have a new template for VRO tickets captured in a draft issue: https://github.com/orgs/department-of-veterans-affairs/projects/871/views/1?pane=issue&itemId=43257981 but not yet reflected in the default issue template for the repo. This PR updates the default issue template to match the template in the draft issue. 

Associated tickets or Slack threads:
- [#?](https://github.com/orgs/department-of-veterans-affairs/projects/871/views/1?pane=issue&itemId=43257981)

## How does this fix it?[^1]
I updated the .md to include the same content as the draft issue template.

## How to test this PR
- Verify that the the updates to abd-vro--project-work-ticket.md match the fields in the default issue template: https://github.com/orgs/department-of-veterans-affairs/projects/871/views/1?pane=issue&itemId=43257981


[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
