### PR TITLE
Updated getClaimDetails endpoint

### DIFF
--- a/svc-bip-api/src/integrationTest/java/gov/va/vro/bip/BaseIntegrationTest.java
+++ b/svc-bip-api/src/integrationTest/java/gov/va/vro/bip/BaseIntegrationTest.java
@@ -6,11 +6,8 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 
 import gov.va.vro.bip.model.BipPayloadRequest;
 import gov.va.vro.bip.model.BipPayloadResponse;
-import gov.va.vro.bip.service.BipApiService;
-import gov.va.vro.bip.service.RabbitMqController;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.springframework.amqp.rabbit.core.RabbitAdmin;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -24,9 +21,6 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 @ExtendWith(SpringExtension.class)
 @Slf4j
 public class BaseIntegrationTest {
-  @Autowired private BipApiService service;
-  @Autowired private RabbitMqController controller;
-  @Autowired private RabbitAdmin rabbitAdmin;
   @Autowired protected RabbitTemplate rabbitTemplate;
 
   protected static final long CLAIM_ID_200 = 1000L;

--- a/svc-bip-api/src/integrationTest/java/gov/va/vro/bip/GetClaimDetailsTest.java
+++ b/svc-bip-api/src/integrationTest/java/gov/va/vro/bip/GetClaimDetailsTest.java
@@ -1,0 +1,30 @@
+package gov.va.vro.bip;
+
+import gov.va.vro.bip.model.claim.GetClaimRequest;
+import gov.va.vro.bip.model.claim.GetClaimResponse;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+
+class GetClaimDetailsTest extends BaseIntegrationTest {
+
+  @Test
+  void testGetClaim_200() {
+    GetClaimRequest request = GetClaimRequest.builder().claimId(CLAIM_ID_200).build();
+    GetClaimResponse response = sendAndReceive(getClaimDetailsQueue, request);
+    assertBaseResponseIs200(response);
+  }
+
+  @Test
+  void testGetClaim_404() {
+    GetClaimRequest request = GetClaimRequest.builder().claimId(CLAIM_ID_404).build();
+    GetClaimResponse response = sendAndReceive(getClaimDetailsQueue, request);
+    assertBaseResponseIsNot2xx(response, HttpStatus.NOT_FOUND);
+  }
+
+  @Test
+  void testGetClaim_500() {
+    GetClaimRequest request = GetClaimRequest.builder().claimId(CLAIM_ID_500).build();
+    GetClaimResponse response = sendAndReceive(getClaimDetailsQueue, request);
+    assertBaseResponseIsNot2xx(response, HttpStatus.INTERNAL_SERVER_ERROR);
+  }
+}

--- a/svc-bip-api/src/integrationTest/java/gov/va/vro/bip/RabbitMqIntegrationTest.java
+++ b/svc-bip-api/src/integrationTest/java/gov/va/vro/bip/RabbitMqIntegrationTest.java
@@ -2,7 +2,6 @@ package gov.va.vro.bip;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import gov.va.vro.bip.model.BipClaimResp;
 import gov.va.vro.bip.model.BipCloseClaimPayload;
 import gov.va.vro.bip.model.BipCloseClaimReason;
 import gov.va.vro.bip.model.BipCloseClaimResp;
@@ -13,8 +12,6 @@ import gov.va.vro.bip.model.RequestForUpdateClaimStatus;
 import gov.va.vro.bip.model.UpdateContention;
 import gov.va.vro.bip.model.UpdateContentionModel;
 import gov.va.vro.bip.model.UpdateContentionReq;
-import gov.va.vro.bip.service.BipApiService;
-import gov.va.vro.bip.service.RabbitMqController;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Assertions;
@@ -35,8 +32,6 @@ import java.util.List;
 @ExtendWith(SpringExtension.class)
 @Slf4j
 class RabbitMqIntegrationTest {
-  @Autowired BipApiService service;
-  @Autowired RabbitMqController controller;
   @Autowired RabbitTemplate rabbitTemplate;
 
   @Value("${exchangeName}")
@@ -57,19 +52,6 @@ class RabbitMqIntegrationTest {
         (BipUpdateClaimResp) rabbitTemplate.convertSendAndReceive(exchangeName, qName, request);
 
     assertResponseIsSuccess(response);
-  }
-
-  @Test
-  void testGetClaimDetails(@Value("${getClaimDetailsQueue}") String qName) {
-    BipClaimResp response =
-        (BipClaimResp) rabbitTemplate.convertSendAndReceive(exchangeName, qName, CLAIM_ID1);
-
-    Assertions.assertNotNull(response);
-    Assertions.assertEquals(200, response.statusCode);
-    Assertions.assertEquals(CLAIM_ID1, response.getClaim().getClaimId());
-    Assertions.assertEquals("Gathering of Evidence", response.getClaim().getPhase());
-    Assertions.assertEquals("Ready for Decision", response.getClaim().getClaimLifecycleStatus());
-    Assertions.assertNotNull(response.getClaim().getTempStationOfJurisdiction());
   }
 
   @Test

--- a/svc-bip-api/src/main/java/gov/va/vro/bip/model/claim/GetClaimRequest.java
+++ b/svc-bip-api/src/main/java/gov/va/vro/bip/model/claim/GetClaimRequest.java
@@ -1,0 +1,17 @@
+package gov.va.vro.bip.model.claim;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import gov.va.vro.bip.model.BipPayloadRequest;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class GetClaimRequest implements BipPayloadRequest {
+  @JsonProperty("claimId")
+  private long claimId;
+}

--- a/svc-bip-api/src/main/java/gov/va/vro/bip/model/claim/GetClaimResponse.java
+++ b/svc-bip-api/src/main/java/gov/va/vro/bip/model/claim/GetClaimResponse.java
@@ -1,22 +1,18 @@
-package gov.va.vro.bip.model.contentions;
+package gov.va.vro.bip.model.claim;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import gov.va.vro.bip.model.BipClaim;
 import gov.va.vro.bip.model.BipPayloadResponse;
-import gov.va.vro.bip.model.ClaimContention;
 import lombok.Getter;
 import lombok.experimental.SuperBuilder;
 import lombok.extern.jackson.Jacksonized;
-
-import java.util.List;
 
 @Getter
 @Jacksonized
 @SuperBuilder(toBuilder = true)
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
-public class GetClaimContentionsResponse extends BipPayloadResponse {
-  @JsonProperty("contentions")
-  private final List<ClaimContention> contentions;
+public class GetClaimResponse extends BipPayloadResponse {
+  private BipClaim claim;
 }

--- a/svc-bip-api/src/main/java/gov/va/vro/bip/service/IBipApiService.java
+++ b/svc-bip-api/src/main/java/gov/va/vro/bip/service/IBipApiService.java
@@ -1,11 +1,11 @@
 package gov.va.vro.bip.service;
 
-import gov.va.vro.bip.model.BipClaimResp;
 import gov.va.vro.bip.model.BipCloseClaimPayload;
 import gov.va.vro.bip.model.BipCloseClaimResp;
 import gov.va.vro.bip.model.BipUpdateClaimResp;
 import gov.va.vro.bip.model.ClaimStatus;
 import gov.va.vro.bip.model.UpdateContentionReq;
+import gov.va.vro.bip.model.claim.GetClaimResponse;
 import gov.va.vro.bip.model.contentions.GetClaimContentionsResponse;
 import gov.va.vro.bip.model.tsoj.PutTempStationOfJurisdictionRequest;
 import gov.va.vro.bip.model.tsoj.PutTempStationOfJurisdictionResponse;
@@ -24,7 +24,7 @@ public interface IBipApiService {
    * @return a BipClaim object.
    * @throws BipException error occurs.
    */
-  BipClaimResp getClaimDetails(long collectionId);
+  GetClaimResponse getClaimDetails(long collectionId);
 
   /**
    * Updates claim status to RFD.

--- a/svc-bip-api/src/main/java/gov/va/vro/bip/service/RabbitMqController.java
+++ b/svc-bip-api/src/main/java/gov/va/vro/bip/service/RabbitMqController.java
@@ -1,11 +1,12 @@
 package gov.va.vro.bip.service;
 
-import gov.va.vro.bip.model.BipClaimResp;
 import gov.va.vro.bip.model.BipCloseClaimPayload;
 import gov.va.vro.bip.model.BipCloseClaimResp;
 import gov.va.vro.bip.model.BipUpdateClaimResp;
 import gov.va.vro.bip.model.RequestForUpdateClaimStatus;
 import gov.va.vro.bip.model.UpdateContentionModel;
+import gov.va.vro.bip.model.claim.GetClaimRequest;
+import gov.va.vro.bip.model.claim.GetClaimResponse;
 import gov.va.vro.bip.model.contentions.GetClaimContentionsRequest;
 import gov.va.vro.bip.model.contentions.GetClaimContentionsResponse;
 import gov.va.vro.bip.model.tsoj.PutTempStationOfJurisdictionRequest;
@@ -23,8 +24,8 @@ public class RabbitMqController {
   final BipApiService service;
 
   @RabbitListener(queues = "getClaimDetailsQueue", errorHandler = "bipRequestErrorHandler")
-  BipClaimResp getClaimDetails(long collectionId) {
-    return service.getClaimDetails(collectionId);
+  GetClaimResponse getClaimDetails(GetClaimRequest request) {
+    return service.getClaimDetails(request.getClaimId());
   }
 
   @RabbitListener(queues = "setClaimToRfdStatusQueue", errorHandler = "bipRequestErrorHandler")

--- a/svc-bip-api/src/test/resources/bip-test-data/response_500.json
+++ b/svc-bip-api/src/test/resources/bip-test-data/response_500.json
@@ -1,0 +1,12 @@
+{
+  "messages": [
+    {
+      "timestamp": "2023-02-06T18:10:59.288",
+      "key": "bip.vetservices.internalServerError",
+      "severity": "FATAL",
+      "status": "500",
+      "text": "internal server error",
+      "httpStatus": "INTERNAL_SERVER_ERROR"
+    }
+  ]
+}


### PR DESCRIPTION
<!-- Ensure the PR title reflects the feature or bug name -->
Implements the getClaimDetails endpoint as more of a passthrough implementation of the response received from the BIP API. This class refactors the return object used by the BipApiService and the return object of the corresponding RabbitListener. 
This PR is similar to the updates implemented in PR #2165 for the getClaimContentions endpoint.

## What was the problem?
<!-- brief description of how things worked before this PR -->
Current implementation does not explicitly return the exact content and responses received from the BIP API. It obfuscates all non 2xx responses and returns a 500 to the client over rabbitmq. 

Associated tickets or Slack threads:
- #2165
- #2091 
- [slack thread](https://dsva.slack.com/archives/C01Q7979Z7D/p1698274813957249)


## How does this fix it?[^1]
<!-- description of how things will work after this PR -->
This PR creates a new pattern for the structure of returned objects. This allows all responses (good (2xx) or bad(not 2xx)) from BIP API to be returned to client of `svc-bip-api`. This structure also allows returning 500s as a response when `svc-bip-api` is the culprit of the error. See diagram below for implementation of getClaimContentions endpoint:

<img width="600" alt="image" src="https://github.com/department-of-veterans-affairs/abd-vro/assets/135860892/8efe4313-21a2-48e7-8da9-8d7ea1342b93">


## How to test this PR
- Run the unit tests via `./gradlew :svc-bip-api:check`
- Start the platform base docker containers to start RabbitMq and start the BIP Mock container (see [Docker Compose](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Docker-Compose))
  - run the integration tests via `./gradlew :svc-bip-api:integrationTest`
  - build and compose the `svc-bip-api` docker and run a test by:
     - create a new queue on the `bip-api` exchange called `response`
     - open to the rabbitmq console to the [getClaimDetailsQueue](http://localhost:15672/#/queues/%2F/getClaimDetailsQueue) 
     - publish a message with the body `{"claimId":1010}` and add a message property called `reply_to` with the value `response`
     - open the response queue page and perform the get message action
     - verify it is a 200 and the response is the mocked response


[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
