### PR TITLE
Minor library changes to fix snyk scan failures

### DIFF
--- a/gradle-plugins/src/main/groovy/shared.java.vro-dep-constraints.gradle
+++ b/gradle-plugins/src/main/groovy/shared.java.vro-dep-constraints.gradle
@@ -62,9 +62,7 @@ dependencies {
         implementation 'org.springframework.amqp:spring-amqp:3.0.10'
         implementation 'org.springframework.security:spring-security-config:6.1.5'
 
-        implementation 'com.rabbitmq:amqp-client:5.18.0'
-
-        implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.3'
+        implementation 'com.fasterxml.jackson.core:jackson-databind:2.16.0'
         implementation 'io.projectreactor.netty:reactor-netty-http:1.1.13'
 
 

--- a/mocks/rabbitmq-dev-tools/src/main/kotlin/gov/va/vro/tools/rabbitmq/MessageResponder.kt
+++ b/mocks/rabbitmq-dev-tools/src/main/kotlin/gov/va/vro/tools/rabbitmq/MessageResponder.kt
@@ -1,6 +1,5 @@
 package gov.va.vro.tools.rabbitmq
 
-import com.rabbitmq.client.Channel
 import org.springframework.amqp.AmqpException
 import org.springframework.amqp.core.Message
 import org.springframework.amqp.rabbit.core.RabbitTemplate


### PR DESCRIPTION
## What was the problem?
SecRel failures failing on Snyk scan. Reviewing where else these references were actually used, I was concluding that they could be dropped without any obvious build errors or functional regressions.

Associated tickets or Slack threads:
- #1579 

## How does this fix it?[^1]
Removing unused dependencies will simplify the project and reduce our exposure.

## How to test this 
Keep tabs on the github actions ensuring that these changes do resolve the Snyk failures.


[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
