### PR TITLE
BGS Healthcheck Implementation

### DIFF
--- a/.github/workflows/svc-bgs-api-integration-test.yml
+++ b/.github/workflows/svc-bgs-api-integration-test.yml
@@ -60,46 +60,6 @@ jobs:
           # Quit after 60 seconds
           retries: 30
 
-      # Temporary step added to avoid race condition. Currently, there is no health check in 'svc-bgs-api'; therefore,
-      # at this step, it is unknown if svc-bgs-api has yet to create the 'bgs-api' exchange.
-      - name: 'Create bgs-api exchange'
-        uses: indiesdev/curl@v1.1
-        with:
-          url: 'http://localhost:15672/api/exchanges/%2f/bgs-api'
-          method: 'PUT'
-          basic-auth-token: '${{env.RABBITMQ_BASIC_AUTH}}'
-          body: '{"type":"direct", "durable":true, "auto_delete":true}'
-          accept: 201, 204
-          retries: 3
-          log-response: true
-
-      # Temporary step added to avoid race condition. Currently, there is no health check in 'svc-bgs-api'; therefore,
-      # at this step, it is unknown if svc-bgs-api has yet to create the 'add-note' queue.
-      - name: 'Create add-note queue'
-        uses: indiesdev/curl@v1.1
-        with:
-          url: 'http://localhost:15672/api/queues/%2f/add-note'
-          method: 'PUT'
-          basic-auth-token: '${{env.RABBITMQ_BASIC_AUTH}}'
-          body: '{"durable":true, "auto_delete":true}'
-          accept: 201, 204
-          retries: 3
-          log-response: true
-
-      # Temporary step added to avoid race condition. Currently, there is no health check in 'svc-bgs-api'; therefore,
-      # at this step, it is unknown if svc-bgs-api has yet to create the binding from 'bgs-api' exchange to 'add-note'
-      # queue.
-      - name: 'Create binding for add-note queue to bgs-api exchange'
-        uses: indiesdev/curl@v1.1
-        with:
-          url: 'http://localhost:15672/api/bindings/%2f/e/bgs-api/q/add-note'
-          method: 'POST'
-          basic-auth-token: '${{env.RABBITMQ_BASIC_AUTH}}'
-          body: '{"routing_key":"add-note","arguments":{}}'
-          accept: 201, 204
-          retries: 3
-          log-response: true
-
       - name: 'Create add-note-response queue'
         uses: indiesdev/curl@v1.1
         with:

--- a/.github/workflows/svc-bgs-api-integration-test.yml
+++ b/.github/workflows/svc-bgs-api-integration-test.yml
@@ -60,6 +60,9 @@ jobs:
           # Quit after 60 seconds
           retries: 30
 
+      - name: 'Check for healthy BGS container'
+        run: timeout 60s sh -c 'until docker ps | grep vro-svc-bgs-api-1 | grep -q healthy; do echo "Waiting for container to be healthy..."; sleep 2; done'
+
       - name: 'Create add-note-response queue'
         uses: indiesdev/curl@v1.1
         with:

--- a/.github/workflows/svc-bgs-api-integration-test.yml
+++ b/.github/workflows/svc-bgs-api-integration-test.yml
@@ -61,7 +61,7 @@ jobs:
           retries: 30
 
       - name: 'Check for healthy BGS container'
-        run: timeout 180s sh -c 'until docker ps | grep vro-svc-bgs-api-1 | grep -q healthy; do echo "Waiting for container to be healthy..."; sleep 2; done'
+        run: timeout 180s sh -c 'until docker ps | grep ".*svc-bgs-api.*" | grep -q healthy; do echo "Waiting for container to be healthy..."; sleep 2; done'
 
       - name: 'Create add-note-response queue'
         uses: indiesdev/curl@v1.1

--- a/.github/workflows/svc-bgs-api-integration-test.yml
+++ b/.github/workflows/svc-bgs-api-integration-test.yml
@@ -61,7 +61,7 @@ jobs:
           retries: 30
 
       - name: 'Check for healthy BGS container'
-        run: timeout 60s sh -c 'until docker ps | grep vro-svc-bgs-api-1 | grep -q healthy; do echo "Waiting for container to be healthy..."; sleep 2; done'
+        run: timeout 180s sh -c 'until docker ps | grep vro-svc-bgs-api-1 | grep -q healthy; do echo "Waiting for container to be healthy..."; sleep 2; done'
 
       - name: 'Create add-note-response queue'
         uses: indiesdev/curl@v1.1

--- a/svc-bgs-api/Dockerfile
+++ b/svc-bgs-api/Dockerfile
@@ -35,5 +35,4 @@ ENTRYPOINT ["/app/entrypoint-wrapper.sh"]
 
 ARG HEALTHCHECK_PORT_ARG=8080
 ENV HEALTHCHECK_PORT=${HEALTHCHECK_PORT_ARG}
-# TODO: add healthcheck for Ruby microservice
-# HEALTHCHECK CMD curl --fail http://localhost:${HEALTHCHECK_PORT}/actuator/health || exit 1
+HEALTHCHECK CMD bundle exec ruby healthcheck/healthcheck.rb

--- a/svc-bgs-api/src/config/constants.rb
+++ b/svc-bgs-api/src/config/constants.rb
@@ -1,0 +1,15 @@
+# Contains constant definitions for queues, exchanges, and fields
+
+BUNNY_ARGS = {
+  host: ENV['RABBITMQ_PLACEHOLDERS_HOST'] || "localhost",
+  user: ENV['RABBITMQ_USERNAME'] || "guest",
+  password: ENV['RABBITMQ_PASSWORD'] || "guest"
+}
+
+CAMEL_MQ_PROPERTIES = { durable: true, auto_delete: true }
+
+BGS_EXCHANGE_NAME = "bgs-api"
+
+HEALTHCHECK_REPLY_QUEUE = "healthcheck-reply"
+HEALTHCHECK_QUEUE = "healthcheck"
+ADD_NOTE_QUEUE = "add-note"

--- a/svc-bgs-api/src/healthcheck/healthcheck.rb
+++ b/svc-bgs-api/src/healthcheck/healthcheck.rb
@@ -1,0 +1,29 @@
+# Inspired by the README at https://github.com/ruby-amqp/bunny
+
+require 'bunny'
+
+BUNNY_ARGS = {
+  host: ENV['RABBITMQ_PLACEHOLDERS_HOST'].presence || "localhost",
+  user: ENV['RABBITMQ_USERNAME'].presence || "guest",
+  password: ENV['RABBITMQ_PASSWORD'].presence || "guest"
+}
+
+REPLY_EXCHANGE = "bgs-api"
+REPLY_QUEUE = "healthcheck-reply"
+
+conn = Bunny.new(BUNNY_ARGS)
+conn.start
+
+ch = conn.create_channel
+ch.confirm_select
+
+r = ch.queue(REPLY_EXCHANGE, REPLY_QUEUE)
+
+q  = ch.queue("bgs-api", "healthcheck")
+q.publish("{health: check}", :reply_to => REPLY_QUEUE)
+
+delivery_info, properties, payload = r.pop
+
+if payload.status_code != 200 {
+    raise "svc-bgs-api healthcheck failed"
+}


### PR DESCRIPTION
<!-- Ensure the PR title reflects the feature or bug name -->

## What was the problem?
<!-- brief description of how things worked before this PR -->
BGS did not have a healthcheck implemented which required a lot of extra steps in our integration testing and also obfuscated visibility into the health of the container

Associated tickets or Slack threads:
- #2172

## How does this fix it?[^1]
<!-- description of how things will work after this PR -->
- Implements a healthcheck using a new RabbitMQ queue which just responds to a message with a 200 code. This subscriber that does this answering will start at the same time as all our other subscribers.

## How to test this PR
- Build the latest docker images, spin up the BGS container and wait for a healthy status to be reported by the docker runner.
- Passing integration tests


[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
