### PR TITLE
BIP Need Not Decode Base64 Postfixed Attributes When Attributes are assigned from Vault 

### DIFF
--- a/svc-bip-api/src/main/java/gov/va/vro/bip/config/BipApiConfig.java
+++ b/svc-bip-api/src/main/java/gov/va/vro/bip/config/BipApiConfig.java
@@ -28,7 +28,6 @@ import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateException;
 import java.util.Base64;
-
 import javax.net.ssl.SSLContext;
 
 /**
@@ -64,7 +63,7 @@ public class BipApiConfig {
       throws KeyStoreException, IOException, NoSuchAlgorithmException, CertificateException {
     KeyStore keyStore = KeyStore.getInstance("PKCS12");
     String noSpaceBase64 = base64.replaceAll("\\s+", "");
-    byte[] decodedBytes = new byte[] { };
+    byte[] decodedBytes = new byte[] {};
     try {
       decodedBytes = Base64.getDecoder().decode(noSpaceBase64);
     } catch (IllegalArgumentException e) {

--- a/svc-bip-api/src/main/java/gov/va/vro/bip/config/BipApiConfig.java
+++ b/svc-bip-api/src/main/java/gov/va/vro/bip/config/BipApiConfig.java
@@ -27,6 +27,8 @@ import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateException;
+import java.util.Base64;
+
 import javax.net.ssl.SSLContext;
 
 /**
@@ -62,7 +64,12 @@ public class BipApiConfig {
       throws KeyStoreException, IOException, NoSuchAlgorithmException, CertificateException {
     KeyStore keyStore = KeyStore.getInstance("PKCS12");
     String noSpaceBase64 = base64.replaceAll("\\s+", "");
-    byte[] decodedBytes = java.util.Base64.getDecoder().decode(noSpaceBase64);
+    byte[] decodedBytes = new byte[] { };
+    try {
+      decodedBytes = Base64.getDecoder().decode(noSpaceBase64);
+    } catch (IllegalArgumentException e) {
+      decodedBytes = noSpaceBase64.getBytes();
+    }
     InputStream stream = new ByteArrayInputStream(decodedBytes);
     keyStore.load(stream, password.toCharArray());
     stream.close();


### PR DESCRIPTION
As our secret setting github action runner reads from vault, secret attributes that end with _BASE64, experience a transformation that is easily missed. The [set-k8s-secrets.sh script](https://github.com/department-of-veterans-affairs/abd-vro/blob/1af4443d64a3d8231258d4e814c4931d9aa7fc59/.github/runner/set-k8s-secrets.sh) will automatically decode them, passing the decoded values as attributes no longer containing the BASE64 postfix

## What was the problem?
The problem is that the keystore and truststore as configured in Vault is inconsistent with truststore and keystore attributes.  In some cases we store BIP_KEYSTORE_BASE64, and that attribute gets transformed in the set-k8s-secret.sh script. In this case, the attribute will get decoded in the bash script and the container will receive a BIP_KEYSTORE attribute containing the. decoded value.

Associated tickets or Slack threads:
- #2242 

## How does this fix it?[^1]
The code catches failed base64 decoding, and attempts to the raw value.

## How to test this PR
- Deploy to LHDI dev and confirm that crashloopbackoff is resolved.


[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
