### PR TITLE
Update update-platform GH action

### DIFF
--- a/.github/workflows/update-deployment-platform.yml
+++ b/.github/workflows/update-deployment-platform.yml
@@ -30,21 +30,13 @@ on:
       rabbitmq:
         description: 'RabbitMQ image tag'
         required: true
-        default: 3
-        type: choice
-        options:
-        - latest
-        - 3
-        - (disable)
+        default: 'latest'
+        type: string
       redis:
         description: 'Redis image tag'
         required: true
-        default: 7
-        type: choice
-        options:
-        - latest
-        - 7
-        - (disable)
+        default: 'latest'
+        type: string
 
   # Allow other workflows to call this one
   workflow_call:

--- a/build.gradle
+++ b/build.gradle
@@ -101,15 +101,7 @@ scmVersion {
   localOnly = true
   useHighestVersion = true
 
-  def postgresDockerfileContent=file("${project.rootDir}/postgres/Dockerfile").getText()
-  def matcher = (postgresDockerfileContent =~ /FROM postgres:(.+)/)
-  def postgresBaseImageVersion = matcher.getCount() > 0 ? matcher[0][1] : "latest"
-  Map<String, Object> platformHelmValues = new org.yaml.snakeyaml.Yaml().load(file("${project.rootDir}/helm/platform/values.yaml").text)
   def helmChartAppVersions = [
-    // These rarely change
-    'postgres'   : postgresBaseImageVersion, // extracted from Dockerfile
-    'redis'      : (String) platformHelmValues.get("redis-chart").get("imageTag"),
-    'rabbitmq'   : (String) platformHelmValues.get("rabbitmq-chart").get("imageTag"),
 
     // These change often (i.e., with each release)
     // A null value will result in the currentVersion being used
@@ -118,6 +110,8 @@ scmVersion {
     'vro-app'    : null,
     'svc-bgs-api': null,
     'svc-lighthouse-api': null,
+    'redis'      : null,
+    'rabbitmq'   : null,
     // Once stable, set a version and move to previous section
     'domain-cc'  : null,
     'domain-ee'  : null,

--- a/helm/platform/values.yaml
+++ b/helm/platform/values.yaml
@@ -5,12 +5,6 @@ rabbitmq:
 redis:
   enabled: true
 
-rabbitmq-chart:
-  imageTag: "3"
-
-redis-chart:
-  imageTag: "7"
-
 global:
   # Persistent Volumes
   pv:

--- a/scripts/image_versions.src
+++ b/scripts/image_versions.src
@@ -5,9 +5,6 @@
 # - image publishing to GHCR (see .github/actions/publish-images/action.yml)
 # - Helm chart deployments to LHDI (see .github/workflows/update-deployment.yml)
 
-# These versions are treated specially because we don't modify the base image
-: ${RABBITMQ_VER:=3}
-: ${REDIS_VER:=7}
 # Manually pin these images; they don't need to be automatically updated
 # Use the `export myimage_VER="v1.2.3"` syntax so that they will be ignored by `image-version.sh`
 # export console_VER="v3.2.5"


### PR DESCRIPTION
<!-- Ensure the PR title reflects the feature or bug name -->

## What was the problem?
<!-- brief description of how things worked before this PR -->
The GH workflow still used the image tags from third-party images but we no longer use those.

## How does this fix it?[^1]
<!-- description of how things will work after this PR -->
Converts the update-platform workflow to follow the same pattern as our workflows for deployments.

## How to test this PR
- Use the modified workflow to deploy a specified version of the platform (completed successfully)


[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
