### PR TITLE
Upgrade svc-bgs-api to Alpine3.18

### DIFF
--- a/svc-bgs-api/Dockerfile
+++ b/svc-bgs-api/Dockerfile
@@ -1,10 +1,10 @@
-FROM ruby:3.2.2-alpine3.16
+FROM ruby:3.2.2-alpine3.18
 
  # Bundler needs git, and ruby-dev curl-dev build-base to make native gems
  # https://www.cloudbees.com/blog/build-minimal-docker-container-ruby-apps
 
 # hadolint ignore=DL3018
-RUN apk update && apk upgrade && apk --no-cache add git ruby-dev=3.1.4-r0 curl-dev build-base=0.5-r3 openssl && rm -rf /var/cache/apk/*
+RUN apk update && apk upgrade && apk --no-cache add git ruby-dev=3.2.2-r0 curl-dev build-base=0.5-r3 openssl && rm -rf /var/cache/apk/*
 
 WORKDIR /app
 


### PR DESCRIPTION
Minor SecRel finding with Alpine 3.16 base image, best practice to move to 3.18.
