### PR TITLE
Fix CI pipeline 

### DIFF
--- a/domain-xample/xample-workflows/src/test/java/gov/va/vro/routes/xample/DbHelperTest.java
+++ b/domain-xample/xample-workflows/src/test/java/gov/va/vro/routes/xample/DbHelperTest.java
@@ -57,6 +57,7 @@ public class DbHelperTest {
   @Test
   void saveContentionEvent() {
     final BieMessagePayload bieMessagePayload = BieMessagePayloadFactory.create();
+    bieMessagePayload.setVeteranParticipantId(12345L);
     final ContentionEventEntity entity = dbHelper.saveContentionEvent(bieMessagePayload);
 
     assertNotNull(entity);

--- a/domain-xample/xample-workflows/src/test/java/gov/va/vro/routes/xample/DbHelperTest.java
+++ b/domain-xample/xample-workflows/src/test/java/gov/va/vro/routes/xample/DbHelperTest.java
@@ -57,7 +57,6 @@ public class DbHelperTest {
   @Test
   void saveContentionEvent() {
     final BieMessagePayload bieMessagePayload = BieMessagePayloadFactory.create();
-    bieMessagePayload.setVeteranParticipantId(12345L);
     final ContentionEventEntity entity = dbHelper.saveContentionEvent(bieMessagePayload);
 
     assertNotNull(entity);

--- a/mocks/rabbitmq-dev-tools/src/main/kotlin/gov/va/vro/tools/rabbitmq/MessageRequester.kt
+++ b/mocks/rabbitmq-dev-tools/src/main/kotlin/gov/va/vro/tools/rabbitmq/MessageRequester.kt
@@ -22,8 +22,7 @@ class MessageRequester(
     rabbitTemplate.sendAndReceive(exchangeName, routingKey, message)?.let { response ->
       log.info("Got response")
       helper.interpretBody(response)
-    }
-      ?: log.info { "No response" }
+    } ?: log.info { "No response" }
 
     // Destroy so it doesn't try to reconnect
     rabbitTemplate.destroy()

--- a/shared/persistence-model/src/main/java/gov/va/vro/persistence/model/ContentionEventEntity.java
+++ b/shared/persistence-model/src/main/java/gov/va/vro/persistence/model/ContentionEventEntity.java
@@ -72,7 +72,7 @@ public class ContentionEventEntity extends BaseEntity {
   private String journalStatusTypeCode;
 
   @Column(name = "veteran_participant_id")
-  private long veteranParticipantId;
+  private Long veteranParticipantId;
 
   @Column(name = "event_details")
   private String eventDetails;


### PR DESCRIPTION
## What was the problem?
DBHelper was erroring out when looking for a primitive long value on veteranparticipantId.

The fix is to

1. Change to Long wrapper class
2. Create a condition around setting veteranParticipantId
3. Make the test set 12345L on the veteranParticipantId.


[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
