### PR TITLE
Modify BIP URL construction to support claimBaseUrl being either a hostname or a url

### DIFF
--- a/domain-rrd/rrd-workflows/src/main/java/gov/va/vro/service/provider/bip/service/BipApiService.java
+++ b/domain-rrd/rrd-workflows/src/main/java/gov/va/vro/service/provider/bip/service/BipApiService.java
@@ -35,8 +35,6 @@ public class BipApiService implements IBipApiService {
   private static final String CONTENTION = "/claims/%s/contentions";
   private static final String SPECIAL_ISSUE_TYPES = "/contentions/special_issue_types";
 
-  private static final String HTTPS = "https://";
-
   @Qualifier("bipCERestTemplate")
   @NonNull
   private final RestTemplate restTemplate;
@@ -48,7 +46,7 @@ public class BipApiService implements IBipApiService {
   @Override
   public BipClaim getClaimDetails(long claimId) throws BipException {
     try {
-      String url = HTTPS + bipApiProps.getClaimBaseUrl() + String.format(CLAIM_DETAILS, claimId);
+      String url = bipApiProps.getClaimRequestUrl(String.format(CLAIM_DETAILS, claimId));
       log.info("call {} to get claim info.", url);
       HttpHeaders headers = getBipHeader();
       HttpEntity<Map<String, String>> httpEntity = new HttpEntity<>(headers);
@@ -99,8 +97,7 @@ public class BipApiService implements IBipApiService {
       throws BipException {
     final String description = status.getDescription();
     try {
-      String url =
-          HTTPS + bipApiProps.getClaimBaseUrl() + String.format(UPDATE_CLAIM_STATUS, claimId);
+      String url = bipApiProps.getClaimRequestUrl(String.format(UPDATE_CLAIM_STATUS, claimId));
       log.info("call {} to update claim status to {}.", url, description);
 
       HttpHeaders headers = getBipHeader();
@@ -123,7 +120,7 @@ public class BipApiService implements IBipApiService {
   @Override
   public List<ClaimContention> getClaimContentions(long claimId) throws BipException {
     try {
-      String url = HTTPS + bipApiProps.getClaimBaseUrl() + String.format(CONTENTION, claimId);
+      String url = bipApiProps.getClaimRequestUrl(String.format(CONTENTION, claimId));
       log.info("Call {} to get claim contention for {}.", url, claimId);
       HttpHeaders headers = getBipHeader();
       HttpEntity<Map<String, String>> httpEntity = new HttpEntity<>(headers);
@@ -152,7 +149,7 @@ public class BipApiService implements IBipApiService {
   public BipUpdateClaimResp updateClaimContention(long claimId, UpdateContentionReq contention)
       throws BipException {
     try {
-      String url = HTTPS + bipApiProps.getClaimBaseUrl() + String.format(CONTENTION, claimId);
+      String url = bipApiProps.getClaimRequestUrl(String.format(CONTENTION, claimId));
       log.info("Call {} to update contention for {}.", url, claimId);
       HttpHeaders headers = getBipHeader();
       String updtContention = mapper.writeValueAsString(contention);
@@ -172,7 +169,7 @@ public class BipApiService implements IBipApiService {
 
   @Override
   public boolean verifySpecialIssueTypes() {
-    String url = HTTPS + bipApiProps.getClaimBaseUrl() + SPECIAL_ISSUE_TYPES;
+    String url = bipApiProps.getClaimRequestUrl(SPECIAL_ISSUE_TYPES);
     log.info("Call {} to get special_issue_types", url);
 
     HttpHeaders headers = getBipHeader();

--- a/svc-bip-api/src/integrationTest/java/gov/va/vro/bip/service/BipResetMockController.java
+++ b/svc-bip-api/src/integrationTest/java/gov/va/vro/bip/service/BipResetMockController.java
@@ -28,7 +28,6 @@ import javax.crypto.spec.SecretKeySpec;
 public class BipResetMockController {
 
   private static final String UPDATES = "/updates/%s";
-  private static final String HTTPS = "https://";
   private static final String JWT_TYPE = "JWT";
 
   @Qualifier("bipCERestTemplate")
@@ -37,7 +36,7 @@ public class BipResetMockController {
   final BipApiProps bipApiProps;
 
   public void resetClaim(long claimId) {
-    String url = HTTPS + bipApiProps.getClaimBaseUrl() + String.format(UPDATES, claimId);
+    String url = bipApiProps.getClaimRequestUrl(String.format(UPDATES, claimId));
 
     try {
       HttpEntity<Object> httpEntity = new HttpEntity<>(null, getBipHeader());

--- a/svc-bip-api/src/main/java/gov/va/vro/bip/service/BipApiProps.java
+++ b/svc-bip-api/src/main/java/gov/va/vro/bip/service/BipApiProps.java
@@ -20,6 +20,8 @@ import java.util.Date;
 @ConfigurationProperties(prefix = "bip")
 public class BipApiProps {
 
+  static final String HTTPS = "https://";
+
   private String claimBaseUrl;
 
   private String claimSecret;
@@ -40,6 +42,13 @@ public class BipApiProps {
 
   private String applicationId;
 
+  public String getClaimRequestUrl(String path) {
+    String baseUrl = this.claimBaseUrl;
+    if (!baseUrl.startsWith("http")) {
+      baseUrl = HTTPS + baseUrl;
+    }
+    return baseUrl + path;
+  }
   /**
    * Creates common Jwt claims.
    *

--- a/svc-bip-api/src/main/java/gov/va/vro/bip/service/BipApiService.java
+++ b/svc-bip-api/src/main/java/gov/va/vro/bip/service/BipApiService.java
@@ -54,8 +54,6 @@ public class BipApiService implements IBipApiService {
   static final String CONTENTION = "/claims/%s/contentions";
   static final String SPECIAL_ISSUE_TYPES = "/contentions/special_issue_types";
 
-  static final String HTTPS = "https://";
-
   static final String JWT_TYPE = "JWT";
 
   @Qualifier("bipCERestTemplate")
@@ -68,7 +66,7 @@ public class BipApiService implements IBipApiService {
 
   @Override
   public GetClaimResponse getClaimDetails(long claimId) {
-    String url = HTTPS + bipApiProps.getClaimBaseUrl() + String.format(CLAIM_DETAILS, claimId);
+    String url = bipApiProps.getClaimRequestUrl(String.format(CLAIM_DETAILS, claimId));
 
     return makeRequest(url, HttpMethod.GET, GetClaimResponse.class);
   }
@@ -76,8 +74,7 @@ public class BipApiService implements IBipApiService {
   @Override
   public PutClaimLifecycleResponse putClaimLifecycleStatus(PutClaimLifecycleRequest request) {
     long claimId = request.getClaimId();
-    String url =
-        HTTPS + bipApiProps.getClaimBaseUrl() + String.format(CLAIM_LIFECYCLE_STATUS, claimId);
+    String url = bipApiProps.getClaimRequestUrl(String.format(CLAIM_LIFECYCLE_STATUS, claimId));
     Map<String, Object> requestBody =
         Map.of("claimLifecycleStatus", request.getClaimLifecycleStatus());
     return makeRequest(url, HttpMethod.PUT, requestBody, PutClaimLifecycleResponse.class);
@@ -85,7 +82,7 @@ public class BipApiService implements IBipApiService {
 
   @Override
   public GetClaimContentionsResponse getClaimContentions(long claimId) {
-    String url = HTTPS + bipApiProps.getClaimBaseUrl() + String.format(CONTENTION, claimId);
+    String url = bipApiProps.getClaimRequestUrl(String.format(CONTENTION, claimId));
 
     return makeRequest(url, HttpMethod.GET, GetClaimContentionsResponse.class);
   }
@@ -94,7 +91,7 @@ public class BipApiService implements IBipApiService {
   public CreateClaimContentionsResponse createClaimContentions(
       CreateClaimContentionsRequest request) {
     long claimId = request.getClaimId();
-    String url = HTTPS + bipApiProps.getClaimBaseUrl() + String.format(CONTENTION, claimId);
+    String url = bipApiProps.getClaimRequestUrl(String.format(CONTENTION, claimId));
     Map<String, Object> requestBody = Map.of("createContentions", request.getCreateContentions());
     return makeRequest(url, HttpMethod.POST, requestBody, CreateClaimContentionsResponse.class);
   }
@@ -103,7 +100,7 @@ public class BipApiService implements IBipApiService {
   public UpdateClaimContentionsResponse updateClaimContentions(
       UpdateClaimContentionsRequest request) {
     long claimId = request.getClaimId();
-    String url = HTTPS + bipApiProps.getClaimBaseUrl() + String.format(CONTENTION, claimId);
+    String url = bipApiProps.getClaimRequestUrl(String.format(CONTENTION, claimId));
     Map<String, Object> requestBody = Map.of("updateContentions", request.getUpdateContentions());
     return makeRequest(url, HttpMethod.PUT, requestBody, UpdateClaimContentionsResponse.class);
   }
@@ -111,7 +108,7 @@ public class BipApiService implements IBipApiService {
   @Override
   public CancelClaimResponse cancelClaim(CancelClaimRequest request) {
     long claimId = request.getClaimId();
-    String url = HTTPS + bipApiProps.getClaimBaseUrl() + String.format(CANCEL_CLAIM, claimId);
+    String url = bipApiProps.getClaimRequestUrl(String.format(CANCEL_CLAIM, claimId));
 
     String lifecycleStatusReasonCode = request.getLifecycleStatusReasonCode();
     String closeReasonText = request.getCloseReasonText();
@@ -128,9 +125,7 @@ public class BipApiService implements IBipApiService {
       PutTempStationOfJurisdictionRequest request) {
     long claimId = request.getClaimId();
     String url =
-        HTTPS
-            + bipApiProps.getClaimBaseUrl()
-            + String.format(TEMP_STATION_OF_JURISDICTION, claimId);
+        bipApiProps.getClaimRequestUrl(String.format(TEMP_STATION_OF_JURISDICTION, claimId));
 
     String tsoj = request.getTempStationOfJurisdiction();
     Map<String, String> requestBody = Map.of("tempStationOfJurisdiction", tsoj);
@@ -188,7 +183,7 @@ public class BipApiService implements IBipApiService {
    * @return true if the API responds with OK status and response.
    */
   public boolean isApiFunctioning() {
-    String url = HTTPS + bipApiProps.getClaimBaseUrl() + SPECIAL_ISSUE_TYPES;
+    String url = bipApiProps.getClaimRequestUrl(SPECIAL_ISSUE_TYPES);
     log.info("Call {} to get special_issue_types", url);
 
     HttpHeaders headers = getBipHeader();


### PR DESCRIPTION
## What was the problem?
With Spring Profiles now active in Dev, I stumbled onto the fact that the claimBaseUrl property we consume as a config setting is in fact a hostname.  Interpretting the config name claimBaseUrl, I mistakenly set the config value to a URL such as https://claims-dev... This results in a duplicate protocol prefix. 

Associated tickets or Slack threads:
- #2298, #2297
- precursor PR - #2328

## How does this fix it?[^1]
This pull request modifies how we consume the claimBaseUrl setting, so that we can safely allow for either specification. 

[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
