### PR TITLE
fix xample-workflow unit test null pointer exception

### DIFF
--- a/domain-xample/xample-workflows/src/main/java/gov/va/vro/routes/xample/DbHelper.java
+++ b/domain-xample/xample-workflows/src/main/java/gov/va/vro/routes/xample/DbHelper.java
@@ -17,6 +17,7 @@ import org.springframework.stereotype.Component;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.util.Optional;
 
 @Slf4j
 @Component
@@ -65,7 +66,7 @@ public class DbHelper {
     contentionEventEntity.setDateCompleted(convertTime(bieMessagePayload.getDateCompleted()));
     contentionEventEntity.setDateUpdated(convertTime(bieMessagePayload.getDateUpdated()));
     contentionEventEntity.setActorStation(bieMessagePayload.getActorStation());
-    contentionEventEntity.setAutomationIndicator(bieMessagePayload.getAutomationIndicator());
+    contentionEventEntity.setAutomationIndicator(Optional.ofNullable(bieMessagePayload.getAutomationIndicator()).orElse(false));
     contentionEventEntity.setBenefitClaimTypeCode(bieMessagePayload.getBenefitClaimTypeCode());
     contentionEventEntity.setContentionStatusTypeCode(
         bieMessagePayload.getContentionStatusTypeCode());

--- a/domain-xample/xample-workflows/src/main/java/gov/va/vro/routes/xample/DbHelper.java
+++ b/domain-xample/xample-workflows/src/main/java/gov/va/vro/routes/xample/DbHelper.java
@@ -66,7 +66,8 @@ public class DbHelper {
     contentionEventEntity.setDateCompleted(convertTime(bieMessagePayload.getDateCompleted()));
     contentionEventEntity.setDateUpdated(convertTime(bieMessagePayload.getDateUpdated()));
     contentionEventEntity.setActorStation(bieMessagePayload.getActorStation());
-    contentionEventEntity.setAutomationIndicator(Optional.ofNullable(bieMessagePayload.getAutomationIndicator()).orElse(false));
+    contentionEventEntity.setAutomationIndicator(
+        Optional.ofNullable(bieMessagePayload.getAutomationIndicator()).orElse(false));
     contentionEventEntity.setBenefitClaimTypeCode(bieMessagePayload.getBenefitClaimTypeCode());
     contentionEventEntity.setContentionStatusTypeCode(
         bieMessagePayload.getContentionStatusTypeCode());


### PR DESCRIPTION
<!-- Ensure the PR title reflects the feature or bug name -->

## What was the problem?
in `Dbhelper.saveContentionEvent` function one of the attribute Boolean type was null and was not handled properly.

Associated tickets or Slack threads:
- NA

## How does this fix it?[^1]
Used Optional to turn false if the boolean object is null

## How to test this PR
- run `git push --set-upstream origin workflow-unit-test-fix` locally


[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
