### PR TITLE
Introduce annotations to handle the fields exclusive to only certain kafka topic names

### DIFF
--- a/domain-xample/xample-workflows/src/main/java/gov/va/vro/routes/xample/DbHelper.java
+++ b/domain-xample/xample-workflows/src/main/java/gov/va/vro/routes/xample/DbHelper.java
@@ -17,6 +17,7 @@ import org.springframework.stereotype.Component;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.util.Optional;
 
 @Slf4j
 @Component
@@ -65,7 +66,8 @@ public class DbHelper {
     contentionEventEntity.setDateCompleted(convertTime(bieMessagePayload.getDateCompleted()));
     contentionEventEntity.setDateUpdated(convertTime(bieMessagePayload.getDateUpdated()));
     contentionEventEntity.setActorStation(bieMessagePayload.getActorStation());
-    contentionEventEntity.setAutomationIndicator(bieMessagePayload.getAutomationIndicator());
+    contentionEventEntity.setAutomationIndicator(
+        Optional.ofNullable(bieMessagePayload.getAutomationIndicator()).orElse(false));
     contentionEventEntity.setBenefitClaimTypeCode(bieMessagePayload.getBenefitClaimTypeCode());
     contentionEventEntity.setContentionStatusTypeCode(
         bieMessagePayload.getContentionStatusTypeCode());

--- a/shared/lib-bie-kafka/src/main/java/gov/va/vro/model/biekafka/BieMessagePayload.java
+++ b/shared/lib-bie-kafka/src/main/java/gov/va/vro/model/biekafka/BieMessagePayload.java
@@ -12,34 +12,80 @@ import lombok.*;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @EqualsAndHashCode
 public class BieMessagePayload {
-  // these are vro fields
+  // These are VRO fields
   @Ignore private Integer status;
   @Ignore private String statusMessage;
   @Ignore private ContentionEvent eventType;
   @Ignore private Long notifiedAt;
   @Ignore private String description;
 
-  // populated from kafka topic payload
-  private String benefitClaimTypeCode;
-  private String actorStation;
-  private String details;
-  private Long veteranParticipantId;
+  // Fields without the @TargetEvents annotation are included in all five Kafka topics
   private Long claimId;
   private Long contentionId;
-  private String contentionTypeCode;
-  private String contentionClassificationName;
-  private String diagnosticTypeCode;
   private String actionName;
   private String actionResultName;
   private Boolean automationIndicator;
+  private String contentionTypeCode;
   private String contentionStatusTypeCode;
   private String currentLifecycleStatus;
   private Long eventTime;
 
+  // populated from kafka topic payload
+  @TargetEvents({
+    "CONTENTION_BIE_CONTENTION_ASSOCIATED_TO_CLAIM_V02",
+    "CONTENTION_BIE_CONTENTION_CLASSIFIED_V02",
+    "CONTENTION_BIE_CONTENTION_UPDATED_V02"
+  })
+  private String benefitClaimTypeCode;
+
+  @TargetEvents({
+    "CONTENTION_BIE_CONTENTION_ASSOCIATED_TO_CLAIM_V02",
+    "CONTENTION_BIE_CONTENTION_CLASSIFIED_V02",
+    "CONTENTION_BIE_CONTENTION_UPDATED_V02"
+  })
+  private String actorStation;
+
+  @TargetEvents({
+    "CONTENTION_BIE_CONTENTION_ASSOCIATED_TO_CLAIM_V02",
+    "CONTENTION_BIE_CONTENTION_CLASSIFIED_V02",
+    "CONTENTION_BIE_CONTENTION_UPDATED_V02"
+  })
+  private String details;
+
+  @TargetEvents({
+    "CONTENTION_BIE_CONTENTION_ASSOCIATED_TO_CLAIM_V02",
+    "CONTENTION_BIE_CONTENTION_CLASSIFIED_V02",
+    "CONTENTION_BIE_CONTENTION_UPDATED_V02"
+  })
+  private Long veteranParticipantId;
+
+  @TargetEvents({
+    "CONTENTION_BIE_CONTENTION_ASSOCIATED_TO_CLAIM_V02",
+    "CONTENTION_BIE_CONTENTION_CLASSIFIED_V02",
+    "CONTENTION_BIE_CONTENTION_UPDATED_V02"
+  })
+  private String contentionClassificationName;
+
+  @TargetEvents({
+    "CONTENTION_BIE_CONTENTION_ASSOCIATED_TO_CLAIM_V02",
+    "CONTENTION_BIE_CONTENTION_CLASSIFIED_V02",
+    "CONTENTION_BIE_CONTENTION_UPDATED_V02"
+  })
+  private String diagnosticTypeCode;
+
   @TargetEvents({"CONTENTION_BIE_CONTENTION_UPDATED_V02"})
   private String journalStatusTypeCode;
 
+  @TargetEvents({
+    "CONTENTION_BIE_CONTENTION_ASSOCIATED_TO_CLAIM_V02",
+    "CONTENTION_BIE_CONTENTION_CLASSIFIED_V02",
+    "CONTENTION_BIE_CONTENTION_UPDATED_V02"
+  })
   private Long dateAdded;
+
+  @TargetEvents({"CONTENTION_BIE_CONTENTION_UPDATED_V02"})
   private Long dateCompleted;
+
+  @TargetEvents({"CONTENTION_BIE_CONTENTION_UPDATED_V02"})
   private Long dateUpdated;
 }

--- a/shared/lib-bie-kafka/src/main/java/gov/va/vro/model/biekafka/BieMessagePayload.java
+++ b/shared/lib-bie-kafka/src/main/java/gov/va/vro/model/biekafka/BieMessagePayload.java
@@ -1,6 +1,8 @@
 package gov.va.vro.model.biekafka;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import gov.va.vro.model.biekafka.annotation.Ignore;
+import gov.va.vro.model.biekafka.annotation.TargetEvents;
 import lombok.*;
 
 @Setter
@@ -11,10 +13,16 @@ import lombok.*;
 @EqualsAndHashCode
 public class BieMessagePayload {
   // these are vro fields
+  @Ignore
   private Integer status;
+  @Ignore
   private String statusMessage;
+  @Ignore
   private ContentionEvent eventType;
+  @Ignore
   private Long notifiedAt;
+  @Ignore
+  private String description;
 
   // populated from kafka topic payload
   private String benefitClaimTypeCode;
@@ -32,7 +40,8 @@ public class BieMessagePayload {
   private String contentionStatusTypeCode;
   private String currentLifecycleStatus;
   private Long eventTime;
-  private String description;
+
+  @TargetEvents({"CONTENTION_BIE_CONTENTION_UPDATED_V02"})
   private String journalStatusTypeCode;
   private Long dateAdded;
   private Long dateCompleted;

--- a/shared/lib-bie-kafka/src/main/java/gov/va/vro/model/biekafka/BieMessagePayload.java
+++ b/shared/lib-bie-kafka/src/main/java/gov/va/vro/model/biekafka/BieMessagePayload.java
@@ -13,16 +13,11 @@ import lombok.*;
 @EqualsAndHashCode
 public class BieMessagePayload {
   // these are vro fields
-  @Ignore
-  private Integer status;
-  @Ignore
-  private String statusMessage;
-  @Ignore
-  private ContentionEvent eventType;
-  @Ignore
-  private Long notifiedAt;
-  @Ignore
-  private String description;
+  @Ignore private Integer status;
+  @Ignore private String statusMessage;
+  @Ignore private ContentionEvent eventType;
+  @Ignore private Long notifiedAt;
+  @Ignore private String description;
 
   // populated from kafka topic payload
   private String benefitClaimTypeCode;
@@ -43,6 +38,7 @@ public class BieMessagePayload {
 
   @TargetEvents({"CONTENTION_BIE_CONTENTION_UPDATED_V02"})
   private String journalStatusTypeCode;
+
   private Long dateAdded;
   private Long dateCompleted;
   private Long dateUpdated;

--- a/shared/lib-bie-kafka/src/main/java/gov/va/vro/model/biekafka/annotation/Ignore.java
+++ b/shared/lib-bie-kafka/src/main/java/gov/va/vro/model/biekafka/annotation/Ignore.java
@@ -4,12 +4,12 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+
 /**
- * This annotation is used to mark fields that should be ignored when fetching
- * from a GenericRecord.
+ * This annotation is used to mark fields that should be ignored when fetching from a GenericRecord.
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.FIELD)
 public @interface Ignore {
-    // No value needed
+  // No value needed
 }

--- a/shared/lib-bie-kafka/src/main/java/gov/va/vro/model/biekafka/annotation/Ignore.java
+++ b/shared/lib-bie-kafka/src/main/java/gov/va/vro/model/biekafka/annotation/Ignore.java
@@ -1,0 +1,12 @@
+package gov.va.vro.model.biekafka.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface Ignore {
+    // No value needed
+}

--- a/shared/lib-bie-kafka/src/main/java/gov/va/vro/model/biekafka/annotation/Ignore.java
+++ b/shared/lib-bie-kafka/src/main/java/gov/va/vro/model/biekafka/annotation/Ignore.java
@@ -4,7 +4,10 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-
+/**
+ * This annotation is used to mark fields that should be ignored when fetching
+ * from a GenericRecord.
+ */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.FIELD)
 public @interface Ignore {

--- a/shared/lib-bie-kafka/src/main/java/gov/va/vro/model/biekafka/annotation/TargetEvents.java
+++ b/shared/lib-bie-kafka/src/main/java/gov/va/vro/model/biekafka/annotation/TargetEvents.java
@@ -6,8 +6,8 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * This annotation is used to define a field that is exclusive to certain contention
- * classification events. Valid values are derived from the topic names in the ContentionEvent enum.
+ * This annotation is used to define a field that is exclusive to certain contention classification
+ * events. Valid values are derived from the topic names in the ContentionEvent enum.
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.FIELD) // This ensures the annotation is only used on fields

--- a/shared/lib-bie-kafka/src/main/java/gov/va/vro/model/biekafka/annotation/TargetEvents.java
+++ b/shared/lib-bie-kafka/src/main/java/gov/va/vro/model/biekafka/annotation/TargetEvents.java
@@ -6,9 +6,8 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * TODO: this annotation can be used for the new description field that only exists in
- * ContentionUpdated and ContentionDeleted kafka events This annotation is used to define field that
- * is exclusive to certain contention classification events,
+ * This annotation is used to define field tha is exclusive to certain contention
+ * classification events. Valid values are from ContentionEvent enum topic names
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.FIELD) // This ensures the annotation is only used on fields

--- a/shared/lib-bie-kafka/src/main/java/gov/va/vro/model/biekafka/annotation/TargetEvents.java
+++ b/shared/lib-bie-kafka/src/main/java/gov/va/vro/model/biekafka/annotation/TargetEvents.java
@@ -6,8 +6,8 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * This annotation is used to define field tha is exclusive to certain contention
- * classification events. Valid values are from ContentionEvent enum topic names
+ * This annotation is used to define a field that is exclusive to certain contention
+ * classification events. Valid values are derived from the topic names in the ContentionEvent enum.
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.FIELD) // This ensures the annotation is only used on fields

--- a/svc-bie-kafka/src/main/java/gov/va/vro/services/bie/service/kafka/KafkaConsumer.java
+++ b/svc-bie-kafka/src/main/java/gov/va/vro/services/bie/service/kafka/KafkaConsumer.java
@@ -59,9 +59,9 @@ public class KafkaConsumer {
   private BieMessagePayload handleGenericRecord(ConsumerRecord<String, Object> record) {
     GenericRecord messageValue = (GenericRecord) record.value();
 
-    BieMessagePayload payload = BieMessageUtils.processBieMessagePayloadFields(messageValue);
-    payload.setEventType(
-        ContentionEvent.valueOf(ContentionEvent.mapTopicToEvent(record.topic()).toString()));
+    ContentionEvent contentionEvent = ContentionEvent.valueOf(ContentionEvent.mapTopicToEvent(record.topic()).toString());
+    BieMessagePayload payload = BieMessageUtils.processBieMessagePayloadFields(contentionEvent, messageValue);
+
     payload.setNotifiedAt(record.timestamp());
 
     return payload;

--- a/svc-bie-kafka/src/main/java/gov/va/vro/services/bie/service/kafka/KafkaConsumer.java
+++ b/svc-bie-kafka/src/main/java/gov/va/vro/services/bie/service/kafka/KafkaConsumer.java
@@ -59,8 +59,10 @@ public class KafkaConsumer {
   private BieMessagePayload handleGenericRecord(ConsumerRecord<String, Object> record) {
     GenericRecord messageValue = (GenericRecord) record.value();
 
-    ContentionEvent contentionEvent = ContentionEvent.valueOf(ContentionEvent.mapTopicToEvent(record.topic()).toString());
-    BieMessagePayload payload = BieMessageUtils.processBieMessagePayloadFields(contentionEvent, messageValue);
+    ContentionEvent contentionEvent =
+        ContentionEvent.valueOf(ContentionEvent.mapTopicToEvent(record.topic()).toString());
+    BieMessagePayload payload =
+        BieMessageUtils.processBieMessagePayloadFields(contentionEvent, messageValue);
 
     payload.setNotifiedAt(record.timestamp());
 

--- a/svc-bie-kafka/src/main/java/gov/va/vro/services/bie/utils/BieMessageUtils.java
+++ b/svc-bie-kafka/src/main/java/gov/va/vro/services/bie/utils/BieMessageUtils.java
@@ -1,65 +1,84 @@
 package gov.va.vro.services.bie.utils;
 
 import gov.va.vro.model.biekafka.BieMessagePayload;
+import gov.va.vro.model.biekafka.ContentionEvent;
+import gov.va.vro.model.biekafka.annotation.Ignore;
+import gov.va.vro.model.biekafka.annotation.TargetEvents;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.avro.generic.GenericRecord;
 import org.springframework.util.StringUtils;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 @Slf4j
 public class BieMessageUtils {
-  private static final Set<String> IGNORED_FIELDS = new HashSet<>();
-
-  static {
-    // Add the names of fields to be ignored
-    IGNORED_FIELDS.add("status");
-    IGNORED_FIELDS.add("statusMessage");
-    IGNORED_FIELDS.add("eventType");
-    IGNORED_FIELDS.add("notifiedAt");
-    // description field disabled for now until BIE added and deployed the new kafka schema in dev
-    IGNORED_FIELDS.add("description");
-  }
-
-  public static BieMessagePayload processBieMessagePayloadFields(GenericRecord genericRecord) {
+  public static BieMessagePayload processBieMessagePayloadFields(ContentionEvent contentionEvent, GenericRecord genericRecord) {
     BieMessagePayload payload = BieMessagePayload.builder().status(200).build();
 
     for (Field field : BieMessagePayload.class.getDeclaredFields()) {
       String fieldName = field.getName();
 
-      // Skip the field if it's in the ignored list
-      if (IGNORED_FIELDS.contains(fieldName)) {
+      // Skip the field if it has @Ignore annotation or is null
+      if (field.isAnnotationPresent(Ignore.class)) {
         continue;
       }
 
-      String capitalizedFieldName = StringUtils.capitalize(fieldName);
-      Object value = genericRecord.get(capitalizedFieldName);
+      if (field.isAnnotationPresent(TargetEvents.class)) {
+        String[] annotationValues = field.getAnnotation(TargetEvents.class).value();
 
-      if (value == null) {
-        continue; // Skip setting the field if the value is null
-      }
-
-      try {
-        String setterMethodName = "set" + capitalizedFieldName;
-        Method setterMethod = BieMessagePayload.class.getMethod(setterMethodName, field.getType());
-
-        if (field.getType().isAssignableFrom(value.getClass())) {
-          setterMethod.invoke(payload, value);
-        } else {
-          log.warn(
-              "Type mismatch for field '{}'. Expected type: '{}', Actual value: '{}'",
-              fieldName,
-              field.getType().getSimpleName(),
-              value);
+        if (!isValidTopicNames(annotationValues)) {
+          throw new IllegalArgumentException("Invalid topic names in annotation for field: " + fieldName);
         }
-      } catch (Exception e) {
-        log.error("Error setting value for field '{}': {}", fieldName, e.getMessage(), e);
+
+        boolean matchedTopicName = Arrays.stream(annotationValues).anyMatch(v -> v.equals(contentionEvent.getTopicName()));
+
+        if(matchedTopicName) {
+          invokeSetterMethod(payload, field, genericRecord);
+        }
+      } else {
+        invokeSetterMethod(payload, field, genericRecord);
       }
     }
 
     return payload;
+  }
+
+  private static void invokeSetterMethod(BieMessagePayload payload, Field field, GenericRecord genericRecord) {
+    String fieldName = field.getName();
+    String capitalizedFieldName = StringUtils.capitalize(fieldName);
+    Object value = genericRecord.get(capitalizedFieldName);
+    String setterMethodName = "set" + capitalizedFieldName;
+
+    // if GenericRecord doesn't have the value, we do not process further
+    if(value == null) return;
+
+    try {
+      Method setterMethod = BieMessagePayload.class.getMethod(setterMethodName, field.getType());
+
+      if (field.getType().isAssignableFrom(value.getClass())) {
+        setterMethod.invoke(payload, value);
+      } else {
+        log.warn(
+                "Type mismatch for field '{}'. Expected type: '{}', Actual value: '{}'",
+                fieldName,
+                field.getType().getSimpleName(),
+                value);
+      }
+    } catch (Exception e) {
+      log.error("Error setting value for field '{}': {}", fieldName, e.getMessage(), e);
+    }
+  }
+
+  private static boolean isValidTopicNames(String[] topicNames) {
+    Set<String> validTopicNames = Arrays.stream(ContentionEvent.values())
+            .map(ContentionEvent::getTopicName)
+            .collect(Collectors.toSet());
+
+    return Arrays.stream(topicNames).allMatch(validTopicNames::contains);
   }
 }

--- a/svc-bie-kafka/src/main/resources/application-dev.yaml
+++ b/svc-bie-kafka/src/main/resources/application-dev.yaml
@@ -11,7 +11,7 @@ spring:
       schema.registry.ssl.truststore.password: "${BIE_KAFKA_TRUSTSTORE_PASSWORD}"
       schema.registry.ssl.truststore.type: "PKCS12"
     consumer:
-      group-id: "${BIE_KAFKA_PLACEHOLDERS_GROUP_ID:vro-bie-tst-vro-3}"
+      group-id: "${BIE_KAFKA_PLACEHOLDERS_GROUP_ID:vro-bie-tst-vro-1}"
       key-deserializer: "org.apache.kafka.common.serialization.StringDeserializer"
       value-deserializer: "io.confluent.kafka.serializers.KafkaAvroDeserializer"
       properties:

--- a/svc-bie-kafka/src/test/java/gov/va/vro/services/bie/utils/BieMessageUtilsTest.java
+++ b/svc-bie-kafka/src/test/java/gov/va/vro/services/bie/utils/BieMessageUtilsTest.java
@@ -1,7 +1,6 @@
 package gov.va.vro.services.bie.utils;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.when;
 
 import gov.va.vro.model.biekafka.BieMessagePayload;
 import gov.va.vro.model.biekafka.ContentionEvent;
@@ -10,6 +9,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
@@ -21,31 +21,55 @@ class BieMessageUtilsTest {
   @BeforeEach
   void setUp() {
     // Set up a GenericRecord with test data
-    when(genericRecord.get("BenefitClaimTypeCode")).thenReturn("TypeCode123");
-    when(genericRecord.get("ActorStation")).thenReturn("Station456");
-    when(genericRecord.get("Details")).thenReturn("Some details");
-    when(genericRecord.get("VeteranParticipantId")).thenReturn(12345L); // Example Long value
-    when(genericRecord.get("ClaimId")).thenReturn(67890L); // Example Long value
-    when(genericRecord.get("ContentionId")).thenReturn(11223L); // Example Long value
-    when(genericRecord.get("ContentionTypeCode")).thenReturn("TypeCode456");
-    when(genericRecord.get("ContentionClassificationName")).thenReturn("ClassificationName");
-    when(genericRecord.get("DiagnosticTypeCode")).thenReturn("DiagnosticCode");
-    when(genericRecord.get("ActionName")).thenReturn("SomeAction");
-    when(genericRecord.get("ActionResultName")).thenReturn("ActionResult");
-    when(genericRecord.get("AutomationIndicator")).thenReturn(true); // boolean value
-    when(genericRecord.get("ContentionStatusTypeCode")).thenReturn("StatusTypeCode");
-    when(genericRecord.get("CurrentLifecycleStatus")).thenReturn("LifecycleStatus");
-    when(genericRecord.get("EventTime")).thenReturn(1616151616L); // Example Long value
-    when(genericRecord.get("JournalStatusTypeCode")).thenReturn("JournalStatusCode");
-    when(genericRecord.get("DateAdded")).thenReturn(1616161616L); // Example Long value
-    when(genericRecord.get("DateCompleted")).thenReturn(1616171717L); // Example Long value
-    when(genericRecord.get("DateUpdated")).thenReturn(1616181818L); // Example Long value
+    Mockito.lenient().when(genericRecord.get("BenefitClaimTypeCode")).thenReturn("TypeCode123");
+    Mockito.lenient().when(genericRecord.get("ActorStation")).thenReturn("Station456");
+    Mockito.lenient().when(genericRecord.get("Details")).thenReturn("Some details");
+    Mockito.lenient()
+        .when(genericRecord.get("VeteranParticipantId"))
+        .thenReturn(12345L); // Example Long value
+    Mockito.lenient().when(genericRecord.get("ClaimId")).thenReturn(67890L); // Example Long value
+    Mockito.lenient()
+        .when(genericRecord.get("ContentionId"))
+        .thenReturn(11223L); // Example Long value
+    Mockito.lenient().when(genericRecord.get("ContentionTypeCode")).thenReturn("TypeCode456");
+    Mockito.lenient()
+        .when(genericRecord.get("ContentionClassificationName"))
+        .thenReturn("ClassificationName");
+    Mockito.lenient().when(genericRecord.get("DiagnosticTypeCode")).thenReturn("DiagnosticCode");
+    Mockito.lenient().when(genericRecord.get("ActionName")).thenReturn("SomeAction");
+    Mockito.lenient().when(genericRecord.get("ActionResultName")).thenReturn("ActionResult");
+    Mockito.lenient()
+        .when(genericRecord.get("AutomationIndicator"))
+        .thenReturn(true); // boolean value
+    Mockito.lenient()
+        .when(genericRecord.get("ContentionStatusTypeCode"))
+        .thenReturn("StatusTypeCode");
+    Mockito.lenient()
+        .when(genericRecord.get("CurrentLifecycleStatus"))
+        .thenReturn("LifecycleStatus");
+    Mockito.lenient()
+        .when(genericRecord.get("EventTime"))
+        .thenReturn(1616151616L); // Example Long value
+    Mockito.lenient()
+        .when(genericRecord.get("JournalStatusTypeCode"))
+        .thenReturn("JournalStatusCode");
+    Mockito.lenient()
+        .when(genericRecord.get("DateAdded"))
+        .thenReturn(1616161616L); // Example Long value
+    Mockito.lenient()
+        .when(genericRecord.get("DateCompleted"))
+        .thenReturn(1616171717L); // Example Long value
+    Mockito.lenient()
+        .when(genericRecord.get("DateUpdated"))
+        .thenReturn(1616181818L); // Example Long value
   }
 
   @Test
-  void testProcessBieMessagePayloadFields() {
+  void testProcessPayload() {
     // Process the mocked GenericRecord to create a BieMessagePayload
-    BieMessagePayload actualPayload = BieMessageUtils.processBieMessagePayloadFields(ContentionEvent.CONTENTION_ASSOCIATED_TO_CLAIM, genericRecord);
+    BieMessagePayload actualPayload =
+        BieMessageUtils.processBieMessagePayloadFields(
+            ContentionEvent.CONTENTION_ASSOCIATED_TO_CLAIM, genericRecord);
 
     // Assert that the fields in the actualPayload match the mocked values
     assertEquals("TypeCode123", actualPayload.getBenefitClaimTypeCode());
@@ -63,9 +87,20 @@ class BieMessageUtilsTest {
     assertEquals("StatusTypeCode", actualPayload.getContentionStatusTypeCode());
     assertEquals("LifecycleStatus", actualPayload.getCurrentLifecycleStatus());
     assertEquals(Long.valueOf(1616151616L), actualPayload.getEventTime());
-    assertEquals("JournalStatusCode", actualPayload.getJournalStatusTypeCode());
+    assertNull(actualPayload.getJournalStatusTypeCode());
     assertEquals(Long.valueOf(1616161616L), actualPayload.getDateAdded());
     assertEquals(Long.valueOf(1616171717L), actualPayload.getDateCompleted());
     assertEquals(Long.valueOf(1616181818L), actualPayload.getDateUpdated());
+  }
+
+  @Test
+  void testProcessPayloadForContentionUpdatedEvent() {
+    // Process the mocked GenericRecord to create a BieMessagePayload
+    BieMessagePayload actualPayload =
+        BieMessageUtils.processBieMessagePayloadFields(
+            ContentionEvent.CONTENTION_UPDATED, genericRecord);
+
+    // Assert that the fields in the actualPayload match the mocked values
+    assertEquals("JournalStatusCode", actualPayload.getJournalStatusTypeCode());
   }
 }

--- a/svc-bie-kafka/src/test/java/gov/va/vro/services/bie/utils/BieMessageUtilsTest.java
+++ b/svc-bie-kafka/src/test/java/gov/va/vro/services/bie/utils/BieMessageUtilsTest.java
@@ -67,8 +67,8 @@ class BieMessageUtilsTest {
   @Test
   void testContentionAssociatedToClaimEvent() {
     BieMessagePayload actualPayload =
-            BieMessageUtils.processBieMessagePayloadFields(
-                    ContentionEvent.CONTENTION_ASSOCIATED_TO_CLAIM, genericRecord);
+        BieMessageUtils.processBieMessagePayloadFields(
+            ContentionEvent.CONTENTION_ASSOCIATED_TO_CLAIM, genericRecord);
     testCommonFields(actualPayload);
     assertEquals("TypeCode123", actualPayload.getBenefitClaimTypeCode());
     assertEquals("Station456", actualPayload.getActorStation());
@@ -82,8 +82,8 @@ class BieMessageUtilsTest {
   @Test
   void testContentionClassifiedEvent() {
     BieMessagePayload actualPayload =
-            BieMessageUtils.processBieMessagePayloadFields(
-                    ContentionEvent.CONTENTION_CLASSIFIED, genericRecord);
+        BieMessageUtils.processBieMessagePayloadFields(
+            ContentionEvent.CONTENTION_CLASSIFIED, genericRecord);
     testCommonFields(actualPayload);
     assertEquals("TypeCode123", actualPayload.getBenefitClaimTypeCode());
     assertEquals("Station456", actualPayload.getActorStation());
@@ -97,16 +97,16 @@ class BieMessageUtilsTest {
   @Test
   void testContentionCompletedEvent() {
     BieMessagePayload actualPayload =
-            BieMessageUtils.processBieMessagePayloadFields(
-                    ContentionEvent.CONTENTION_COMPLETED, genericRecord);
+        BieMessageUtils.processBieMessagePayloadFields(
+            ContentionEvent.CONTENTION_COMPLETED, genericRecord);
     testCommonFields(actualPayload);
   }
 
   @Test
   void testContentionDeletedEvent() {
     BieMessagePayload actualPayload =
-            BieMessageUtils.processBieMessagePayloadFields(
-                    ContentionEvent.CONTENTION_DELETED, genericRecord);
+        BieMessageUtils.processBieMessagePayloadFields(
+            ContentionEvent.CONTENTION_DELETED, genericRecord);
     testCommonFields(actualPayload);
   }
 

--- a/svc-bie-kafka/src/test/java/gov/va/vro/services/bie/utils/BieMessageUtilsTest.java
+++ b/svc-bie-kafka/src/test/java/gov/va/vro/services/bie/utils/BieMessageUtilsTest.java
@@ -65,42 +65,81 @@ class BieMessageUtilsTest {
   }
 
   @Test
-  void testProcessPayload() {
-    // Process the mocked GenericRecord to create a BieMessagePayload
+  void testContentionAssociatedToClaimEvent() {
     BieMessagePayload actualPayload =
-        BieMessageUtils.processBieMessagePayloadFields(
-            ContentionEvent.CONTENTION_ASSOCIATED_TO_CLAIM, genericRecord);
-
-    // Assert that the fields in the actualPayload match the mocked values
+            BieMessageUtils.processBieMessagePayloadFields(
+                    ContentionEvent.CONTENTION_ASSOCIATED_TO_CLAIM, genericRecord);
+    testCommonFields(actualPayload);
     assertEquals("TypeCode123", actualPayload.getBenefitClaimTypeCode());
     assertEquals("Station456", actualPayload.getActorStation());
     assertEquals("Some details", actualPayload.getDetails());
     assertEquals(Long.valueOf(12345L), actualPayload.getVeteranParticipantId());
-    assertEquals(Long.valueOf(67890L), actualPayload.getClaimId());
-    assertEquals(Long.valueOf(11223L), actualPayload.getContentionId());
-    assertEquals("TypeCode456", actualPayload.getContentionTypeCode());
     assertEquals("ClassificationName", actualPayload.getContentionClassificationName());
     assertEquals("DiagnosticCode", actualPayload.getDiagnosticTypeCode());
-    assertEquals("SomeAction", actualPayload.getActionName());
-    assertEquals("ActionResult", actualPayload.getActionResultName());
-    assertTrue(actualPayload.getAutomationIndicator());
-    assertEquals("StatusTypeCode", actualPayload.getContentionStatusTypeCode());
-    assertEquals("LifecycleStatus", actualPayload.getCurrentLifecycleStatus());
-    assertEquals(Long.valueOf(1616151616L), actualPayload.getEventTime());
-    assertNull(actualPayload.getJournalStatusTypeCode());
     assertEquals(Long.valueOf(1616161616L), actualPayload.getDateAdded());
-    assertEquals(Long.valueOf(1616171717L), actualPayload.getDateCompleted());
-    assertEquals(Long.valueOf(1616181818L), actualPayload.getDateUpdated());
   }
 
   @Test
-  void testProcessPayloadForContentionUpdatedEvent() {
+  void testContentionClassifiedEvent() {
+    BieMessagePayload actualPayload =
+            BieMessageUtils.processBieMessagePayloadFields(
+                    ContentionEvent.CONTENTION_CLASSIFIED, genericRecord);
+    testCommonFields(actualPayload);
+    assertEquals("TypeCode123", actualPayload.getBenefitClaimTypeCode());
+    assertEquals("Station456", actualPayload.getActorStation());
+    assertEquals("Some details", actualPayload.getDetails());
+    assertEquals(Long.valueOf(12345L), actualPayload.getVeteranParticipantId());
+    assertEquals("ClassificationName", actualPayload.getContentionClassificationName());
+    assertEquals("DiagnosticCode", actualPayload.getDiagnosticTypeCode());
+    assertEquals(Long.valueOf(1616161616L), actualPayload.getDateAdded());
+  }
+
+  @Test
+  void testContentionCompletedEvent() {
+    BieMessagePayload actualPayload =
+            BieMessageUtils.processBieMessagePayloadFields(
+                    ContentionEvent.CONTENTION_COMPLETED, genericRecord);
+    testCommonFields(actualPayload);
+  }
+
+  @Test
+  void testContentionDeletedEvent() {
+    BieMessagePayload actualPayload =
+            BieMessageUtils.processBieMessagePayloadFields(
+                    ContentionEvent.CONTENTION_DELETED, genericRecord);
+    testCommonFields(actualPayload);
+  }
+
+  @Test
+  void testContentionUpdatedEvent() {
     // Process the mocked GenericRecord to create a BieMessagePayload
     BieMessagePayload actualPayload =
         BieMessageUtils.processBieMessagePayloadFields(
             ContentionEvent.CONTENTION_UPDATED, genericRecord);
 
-    // Assert that the fields in the actualPayload match the mocked values
+    testCommonFields(actualPayload);
+
+    assertEquals("TypeCode123", actualPayload.getBenefitClaimTypeCode());
     assertEquals("JournalStatusCode", actualPayload.getJournalStatusTypeCode());
+    assertEquals("Station456", actualPayload.getActorStation());
+    assertEquals("Some details", actualPayload.getDetails());
+    assertEquals(Long.valueOf(12345L), actualPayload.getVeteranParticipantId());
+    assertEquals("ClassificationName", actualPayload.getContentionClassificationName());
+    assertEquals("DiagnosticCode", actualPayload.getDiagnosticTypeCode());
+    assertEquals(Long.valueOf(1616161616L), actualPayload.getDateAdded());
+    assertEquals(Long.valueOf(1616171717L), actualPayload.getDateCompleted());
+    assertEquals(Long.valueOf(1616181818L), actualPayload.getDateUpdated());
+  }
+
+  private void testCommonFields(BieMessagePayload actualPayload) {
+    assertEquals(Long.valueOf(67890L), actualPayload.getClaimId());
+    assertEquals(Long.valueOf(11223L), actualPayload.getContentionId());
+    assertEquals("SomeAction", actualPayload.getActionName());
+    assertEquals("ActionResult", actualPayload.getActionResultName());
+    assertTrue(actualPayload.getAutomationIndicator());
+    assertEquals("TypeCode456", actualPayload.getContentionTypeCode());
+    assertEquals("StatusTypeCode", actualPayload.getContentionStatusTypeCode());
+    assertEquals("LifecycleStatus", actualPayload.getCurrentLifecycleStatus());
+    assertEquals(Long.valueOf(1616151616L), actualPayload.getEventTime());
   }
 }

--- a/svc-bie-kafka/src/test/java/gov/va/vro/services/bie/utils/BieMessageUtilsTest.java
+++ b/svc-bie-kafka/src/test/java/gov/va/vro/services/bie/utils/BieMessageUtilsTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.when;
 
 import gov.va.vro.model.biekafka.BieMessagePayload;
+import gov.va.vro.model.biekafka.ContentionEvent;
 import org.apache.avro.generic.GenericRecord;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -44,7 +45,7 @@ class BieMessageUtilsTest {
   @Test
   void testProcessBieMessagePayloadFields() {
     // Process the mocked GenericRecord to create a BieMessagePayload
-    BieMessagePayload actualPayload = BieMessageUtils.processBieMessagePayloadFields(genericRecord);
+    BieMessagePayload actualPayload = BieMessageUtils.processBieMessagePayloadFields(ContentionEvent.CONTENTION_ASSOCIATED_TO_CLAIM, genericRecord);
 
     // Assert that the fields in the actualPayload match the mocked values
     assertEquals("TypeCode123", actualPayload.getBenefitClaimTypeCode());


### PR DESCRIPTION
## What was the problem?
Currently, we try to fetch all field values in `BieMessagePayload` class from `GenericRecord`. Due to some fields that are not commonly shared from all kafka topics we listen to, it causes exceptions when the `GenericRecord` does not have the field value available.

Associated tickets or Slack threads:
- #2346 

## How does this fix it?[^1]
Introduced two new annotations that support the definition of exclusive fields for Kafka topic event names. This approach will reduce the amount of repetitive and tedious code required when transferring data from GenericRecord to our own `BieMessagePayload` objects. Most of the heavy lifting is now handled by the `BieMessageUtils` class.
- `@Ignore` - mark fields that should be ignored when fetching from a GenericRecord.
- `@TargetEvents` - is used to define a field that is exclusive to certain contention classification events. Valid values are derived from the topic names in the ContentionEvent enum.

## How to test this PR
- `source scripts/kafka-service.sh`
- `./gradlew svc-bie-kafka:test --rerun `
- `./gradlew svc-bie-kafka:integrationTest --rerun`


[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
