### PR TITLE
Add K8s liveness and readiness (#2314)

### DIFF
--- a/domain-xample/xample-workflows/src/main/resources/application.yml
+++ b/domain-xample/xample-workflows/src/main/resources/application.yml
@@ -20,7 +20,7 @@ spring:
     username: "${RABBITMQ_USERNAME:guest}"
     password: "${RABBITMQ_PASSWORD:guest}"
 
-## Actuator for health check
+## Actuator for health check, liveness, and readiness
 management:
   server:
     port: 10021
@@ -30,6 +30,9 @@ management:
       enabled: true
       probes:
         enabled: true
+      group:
+        liveness.include: livenessState
+        readiness.include: readinessState
 
 # https://stackoverflow.com/questions/36583185/spring-data-jpa-could-not-initialize-proxy-no-session-with-methods-marke
 # Degrades performance but only for this Docker image, which is acceptable

--- a/helm/domain-xample/templates/deployment.yaml
+++ b/helm/domain-xample/templates/deployment.yaml
@@ -21,6 +21,9 @@ spec:
       containers:
         - name: xample-workflows{{ include "vro.containerSuffix" . }}
           image: {{ include "vro.imageRegistryPath" . }}vro-xample-workflows:{{ include "vro.imageTag" . }}
+          ports: {{- toYaml .Values.ports | nindent 12 }}
+          livenessProbe: {{- toYaml .Values.livenessProbe | nindent 12 }}
+          readinessProbe: {{- toYaml .Values.readinessProbe | nindent 12 }}
           env:
             {{- include "vro.commonEnvVars" . | nindent 12 }}
             {{- include "vro.dbClient.envVars" . | nindent 12 }}

--- a/helm/domain-xample/values.yaml
+++ b/helm/domain-xample/values.yaml
@@ -3,6 +3,29 @@ labels:
 
 replicaCount: 1
 
+ports:
+  - name: liveness
+    containerPort: 10021
+    protocol: TCP
+
+livenessProbe:
+  httpGet:
+    path: /actuator/health/liveness
+    port: 10021
+  initialDelaySeconds: 120
+  periodSeconds: 10
+  timeoutSeconds: 10
+  failureThreshold: 3
+
+readinessProbe:
+  httpGet:
+    path: /actuator/health/readiness
+    port: 10021
+  initialDelaySeconds: 120
+  periodSeconds: 10
+  timeoutSeconds: 10
+  failureThreshold: 3
+
 # autoscaling:
 #   enabled: false
 #   minReplicas: 1

--- a/helm/svc-bie-kafka/templates/deployment.yaml
+++ b/helm/svc-bie-kafka/templates/deployment.yaml
@@ -21,6 +21,9 @@ spec:
       containers:
         - name: svc-bie-kafka{{ include "vro.containerSuffix" . }}
           image: {{ include "vro.imageRegistryPath" . }}vro-svc-bie-kafka:{{ include "vro.imageTag" . }}
+          ports: {{- toYaml .Values.ports | nindent 12 }}
+          livenessProbe: {{- toYaml .Values.livenessProbe | nindent 12 }}
+          readinessProbe: {{- toYaml .Values.readinessProbe | nindent 12 }}
           env:
             {{- include "vro.commonEnvVars" . | nindent 12 }}
             {{- include "vro.mqClient.envVars" . | nindent 12 }}

--- a/helm/svc-bie-kafka/values.yaml
+++ b/helm/svc-bie-kafka/values.yaml
@@ -17,6 +17,29 @@ resources:
 
 replicaCount: 1
 
+ports:
+  - name: liveness
+    containerPort: 10301
+    protocol: TCP
+
+livenessProbe:
+  httpGet:
+    path: /actuator/health/liveness
+    port: 10301
+  initialDelaySeconds: 120
+  periodSeconds: 10
+  timeoutSeconds: 10
+  failureThreshold: 3
+
+readinessProbe:
+  httpGet:
+    path: /actuator/health/readiness
+    port: 10301
+  initialDelaySeconds: 120
+  periodSeconds: 10
+  timeoutSeconds: 10
+  failureThreshold: 3
+
 # autoscaling:
 #   enabled: false
 #   minReplicas: 1

--- a/svc-bie-kafka/src/main/resources/application.yaml
+++ b/svc-bie-kafka/src/main/resources/application.yaml
@@ -35,7 +35,7 @@ spring:
 bie:
   kakfa-topic-prefix: "TST_"
 
-## Actuator for health check
+## Actuator for health check, liveness, and readiness
 management:
   server:
     port: 10301
@@ -45,3 +45,6 @@ management:
       enabled: true
       probes:
         enabled: true
+      group:
+        liveness.include: livenessState
+        readiness.include: readinessState


### PR DESCRIPTION
- update helm charts for domain-xample and svc-bie-kafka
- update application.yaml files for domain-xample and svc-bie-kafka
- add liveness and readiness endpoints to application.yaml files


## What was the problem?
Helm charts for domain-xample and svc-bie-kafka missing K8s liveness and readiness configuration

Associated tickets or Slack threads:
- #2314 

## How does this fix it?[^1]
This configures K8s liveness and readiness for domain-xample and svc-bie-kafka helms charts to ensure highest level of visibility and reliability into the health and readiness of platform and partner team services.

## How to test this PR
- Testing with @msnwatson 


[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
