### PR TITLE
Update helm chart versions (#2314)

### DIFF
--- a/helm/domain-xample/Chart.yaml
+++ b/helm/domain-xample/Chart.yaml
@@ -11,7 +11,7 @@ description: Workflows and microservices for the Xample domain
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # TODO discuss: How can we enforce or automate incrementing this?
-version: 0.2.0
+version: 0.2.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/helm/svc-bie-kafka/Chart.yaml
+++ b/helm/svc-bie-kafka/Chart.yaml
@@ -11,7 +11,7 @@ description: VRO microservice - client for BIE Kafka
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # TODO discuss: How can we enforce or automate incrementing this?
-version: 0.1.3
+version: 0.1.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.


### PR DESCRIPTION
- update domain-xample chart.yaml from 0.2.0 to 0.2.1
- update svc-bie-kafka chart.yaml from 0.1.3 to 0.1.4

## What was the problem?
Incrementing the chart.yaml versions when changes were made. 

Associated tickets or Slack threads:
- #2314 

## How does this fix it?[^1]
- chart.yaml versions for domain-xample and svc-bie-kafka will be up to date

## How to test this PR
- Verify on Lens that Version updated
