### PR TITLE
update actuator readiness urls

### DIFF
--- a/.github/workflows/bie-kafka-end2end-test.yml
+++ b/.github/workflows/bie-kafka-end2end-test.yml
@@ -89,7 +89,7 @@ jobs:
       - name: 'Wait for xample-workflow to be ready'
         uses: nev7n/wait_for_response@v1
         with:
-          url: 'http://localhost:10021/actuator/health'
+          url: 'http://localhost:10021/actuator/health/readiness'
           responseCode: 200
           # Retry every 2 seconds
           interval: 2000
@@ -99,7 +99,7 @@ jobs:
       - name: 'Wait for svc-bie-kafka to be ready'
         uses: nev7n/wait_for_response@v1
         with:
-          url: 'http://localhost:10301/actuator/health'
+          url: 'http://localhost:10301/actuator/health/readiness'
           responseCode: 200
           # Retry every 2 seconds
           interval: 2000


### PR DESCRIPTION
<!-- Ensure the PR title reflects the feature or bug name -->

## What was the problem?
update existing actuator health check to use the latest readiness urls


## How to test this PR
- run integration test


[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
