### PR TITLE
Add K8s liveness and readiness to svc-bip-api (#2398)

### DIFF
--- a/helm/svc-bip-api/Chart.yaml
+++ b/helm/svc-bip-api/Chart.yaml
@@ -11,7 +11,7 @@ description: VRO microservice - client for BIP API
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # TODO discuss: How can we enforce or automate incrementing this?
-version: 0.1.3
+version: 0.1.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/helm/svc-bip-api/templates/deployment.yaml
+++ b/helm/svc-bip-api/templates/deployment.yaml
@@ -21,6 +21,9 @@ spec:
       containers:
         - name: svc-bip-api{{ include "vro.containerSuffix" . }}
           image: {{ include "vro.imageRegistryPath" . }}vro-svc-bip-api:{{ include "vro.imageTag" . }}
+          ports: {{- toYaml .Values.ports | nindent 12 }}
+          livenessProbe: {{- toYaml .Values.livenessProbe | nindent 12 }}
+          readinessProbe: {{- toYaml .Values.readinessProbe | nindent 12 }}
           env:
             {{- include "vro.commonEnvVars" . | nindent 12 }}
             {{- include "vro.mqClient.envVars" . | nindent 12 }}

--- a/helm/svc-bip-api/values.yaml
+++ b/helm/svc-bip-api/values.yaml
@@ -11,6 +11,29 @@ resources:
 
 replicaCount: 1
 
+ports:
+  - name: liveness
+    containerPort: 10401
+    protocol: TCP
+
+livenessProbe:
+  httpGet:
+    path: /actuator/health/liveness
+    port: 10401
+  initialDelaySeconds: 120
+  periodSeconds: 10
+  timeoutSeconds: 10
+  failureThreshold: 3
+
+readinessProbe:
+  httpGet:
+    path: /actuator/health/readiness
+    port: 10401
+  initialDelaySeconds: 120
+  periodSeconds: 10
+  timeoutSeconds: 10
+  failureThreshold: 3
+
 # autoscaling:
 #   enabled: false
 #   minReplicas: 1

--- a/helm/svc-lighthouse-api/Chart.yaml
+++ b/helm/svc-lighthouse-api/Chart.yaml
@@ -11,7 +11,7 @@ description: VRO microservice - client for Lighthouse API
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # TODO discuss: How can we enforce or automate incrementing this?
-version: 0.1.3
+version: 0.1.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/helm/svc-lighthouse-api/templates/deployment.yaml
+++ b/helm/svc-lighthouse-api/templates/deployment.yaml
@@ -21,6 +21,9 @@ spec:
       containers:
         - name: svc-lighthouse-api{{ include "vro.containerSuffix" . }}
           image: {{ include "vro.imageRegistryPath" . }}vro-svc-lighthouse-api:{{ include "vro.imageTag" . }}
+          ports: {{- toYaml .Values.ports | nindent 12 }}
+          livenessProbe: {{- toYaml .Values.livenessProbe | nindent 12 }}
+          readinessProbe: {{- toYaml .Values.readinessProbe | nindent 12 }}
           env:
             {{- include "vro.commonEnvVars" . | nindent 12 }}
             {{- include "vro.mqClient.envVars" . | nindent 12 }}

--- a/helm/svc-lighthouse-api/values.yaml
+++ b/helm/svc-lighthouse-api/values.yaml
@@ -11,6 +11,29 @@ resources:
 
 replicaCount: 1
 
+ports:
+  - name: liveness
+    containerPort: 10101
+    protocol: TCP
+
+livenessProbe:
+  httpGet:
+    path: /actuator/health/liveness
+    port: 10101
+  initialDelaySeconds: 120
+  periodSeconds: 10
+  timeoutSeconds: 10
+  failureThreshold: 3
+
+readinessProbe:
+  httpGet:
+    path: /actuator/health/readiness
+    port: 10101
+  initialDelaySeconds: 120
+  periodSeconds: 10
+  timeoutSeconds: 10
+  failureThreshold: 3
+
 # autoscaling:
 #   enabled: false
 #   minReplicas: 1

--- a/svc-bip-api/src/main/resources/application.yaml
+++ b/svc-bip-api/src/main/resources/application.yaml
@@ -36,13 +36,19 @@ updateClaimContentionsQueue: updateClaimContentionsQueue
 putTempStationOfJurisdictionQueue: putTempStationOfJurisdictionQueue
 exchangeName: bipApiExchange
 
+# Actuator for health check, liveness, and readiness
 management:
-  server.port: 10401
+  server:
+    port: 10401
   endpoint:
     health:
       show-details: always
       enabled: true
-      probes.enabled: true
+      probes:
+        enabled: true
+      group:
+        liveness.include: livenessState
+        readiness.include: readinessState
 
 truststore: ${BIP_TRUSTSTORE}
 keystore: ${BIP_KEYSTORE}

--- a/svc-lighthouse-api/src/main/resources/application.yaml
+++ b/svc-lighthouse-api/src/main/resources/application.yaml
@@ -46,19 +46,23 @@ lh:
   clientId: ${LH_ACCESS_CLIENT_ID}
   pemkey: ${LH_PRIVATE_KEY}
 
-## Health
 
+#Actuator for health check, liveness, and readiness
 management:
+  server:
+    port: 10101
   endpoint:
     health:
       show-details: always
       enabled: true
-      probes.enabled: true
-      group.liveness.include: livenessState
-      group.readiness.include: readinessState
+      probes:
+        enabled: true
+      group:
+        liveness.include: livenessState
+        readiness.include: readinessState
 
   endpoints:
     enabled-by-default: false
     web.exposure.include: health
 
-  server.port: 10101
+  


### PR DESCRIPTION
- update helm charts for svc-bip-api
- update application.yaml file for svc-bip-api
- add liveness and readiness endpoints to application.yaml file
- add liveness and readiness configuration in deployment.yaml and value.yaml files
- update chart.yaml version

## What was the problem?
Helm charts for svc-bip-api missing K8s liveness and readiness configuration

Associated tickets or Slack threads:
- #2398 

## How does this fix it?[^1]
This configures K8s liveness and readiness for domain-xample and svc-bie-kafka helms charts to ensure highest level of visibility and reliability into the health and readiness of platform and partner team services.

## How to test this PR
- Verify using Lens that Liveness and Readiness is present/updated in the svc-bip-api dev container
- Verify the ports component of the svc-bip-api dev container has liveness updated
- Verify svc-bip-api dev container status shows running and ready after successful deployment
