### PR TITLE
 Add actuator readiness URL for svc-bip-api 

### DIFF
--- a/.github/workflows/svc-bip-api-integration-test.yml
+++ b/.github/workflows/svc-bip-api-integration-test.yml
@@ -66,6 +66,16 @@ jobs:
           timeout: 2000
           # Quit after 60 seconds
           retries: 30
+          
+      - name: 'Wait for svc-bip-api to be ready'
+        uses: nev7n/wait_for_response@v1
+        with:
+          url: 'http://localhost:10401/actuator/health/readiness'
+          responseCode: 200
+          # Retry every 2 seconds
+          interval: 2000
+          # Quit after 60 seconds
+          timeout: 60000
 
       - name: 'Wait for containers to start'
         run: sleep 60s

--- a/helm/svc-bip-api/Chart.yaml
+++ b/helm/svc-bip-api/Chart.yaml
@@ -11,7 +11,7 @@ description: VRO microservice - client for BIP API
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # TODO discuss: How can we enforce or automate incrementing this?
-version: 0.1.3
+version: 0.1.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/helm/svc-bip-api/templates/deployment.yaml
+++ b/helm/svc-bip-api/templates/deployment.yaml
@@ -21,6 +21,9 @@ spec:
       containers:
         - name: svc-bip-api{{ include "vro.containerSuffix" . }}
           image: {{ include "vro.imageRegistryPath" . }}vro-svc-bip-api:{{ include "vro.imageTag" . }}
+          ports: {{- toYaml .Values.ports | nindent 12 }}
+          livenessProbe: {{- toYaml .Values.livenessProbe | nindent 12 }}
+          readinessProbe: {{- toYaml .Values.readinessProbe | nindent 12 }}
           env:
             {{- include "vro.commonEnvVars" . | nindent 12 }}
             {{- include "vro.mqClient.envVars" . | nindent 12 }}

--- a/helm/svc-bip-api/values.yaml
+++ b/helm/svc-bip-api/values.yaml
@@ -11,6 +11,29 @@ resources:
 
 replicaCount: 1
 
+ports:
+  - name: liveness
+    containerPort: 10401
+    protocol: TCP
+
+livenessProbe:
+  httpGet:
+    path: /actuator/health/liveness
+    port: 10401
+  initialDelaySeconds: 120
+  periodSeconds: 10
+  timeoutSeconds: 10
+  failureThreshold: 3
+
+readinessProbe:
+  httpGet:
+    path: /actuator/health/readiness
+    port: 10401
+  initialDelaySeconds: 120
+  periodSeconds: 10
+  timeoutSeconds: 10
+  failureThreshold: 3
+
 # autoscaling:
 #   enabled: false
 #   minReplicas: 1

--- a/helm/svc-lighthouse-api/Chart.yaml
+++ b/helm/svc-lighthouse-api/Chart.yaml
@@ -11,7 +11,7 @@ description: VRO microservice - client for Lighthouse API
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # TODO discuss: How can we enforce or automate incrementing this?
-version: 0.1.3
+version: 0.1.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/helm/svc-lighthouse-api/templates/deployment.yaml
+++ b/helm/svc-lighthouse-api/templates/deployment.yaml
@@ -21,6 +21,9 @@ spec:
       containers:
         - name: svc-lighthouse-api{{ include "vro.containerSuffix" . }}
           image: {{ include "vro.imageRegistryPath" . }}vro-svc-lighthouse-api:{{ include "vro.imageTag" . }}
+          ports: {{- toYaml .Values.ports | nindent 12 }}
+          livenessProbe: {{- toYaml .Values.livenessProbe | nindent 12 }}
+          readinessProbe: {{- toYaml .Values.readinessProbe | nindent 12 }}
           env:
             {{- include "vro.commonEnvVars" . | nindent 12 }}
             {{- include "vro.mqClient.envVars" . | nindent 12 }}

--- a/helm/svc-lighthouse-api/values.yaml
+++ b/helm/svc-lighthouse-api/values.yaml
@@ -11,6 +11,29 @@ resources:
 
 replicaCount: 1
 
+ports:
+  - name: liveness
+    containerPort: 10101
+    protocol: TCP
+
+livenessProbe:
+  httpGet:
+    path: /actuator/health/liveness
+    port: 10101
+  initialDelaySeconds: 120
+  periodSeconds: 10
+  timeoutSeconds: 10
+  failureThreshold: 3
+
+readinessProbe:
+  httpGet:
+    path: /actuator/health/readiness
+    port: 10101
+  initialDelaySeconds: 120
+  periodSeconds: 10
+  timeoutSeconds: 10
+  failureThreshold: 3
+
 # autoscaling:
 #   enabled: false
 #   minReplicas: 1

--- a/svc-bip-api/src/main/resources/application.yaml
+++ b/svc-bip-api/src/main/resources/application.yaml
@@ -36,13 +36,19 @@ updateClaimContentionsQueue: updateClaimContentionsQueue
 putTempStationOfJurisdictionQueue: putTempStationOfJurisdictionQueue
 exchangeName: bipApiExchange
 
+# Actuator for health check, liveness, and readiness
 management:
-  server.port: 10401
+  server:
+    port: 10401
   endpoint:
     health:
       show-details: always
       enabled: true
-      probes.enabled: true
+      probes:
+        enabled: true
+      group:
+        liveness.include: livenessState
+        readiness.include: readinessState
 
 truststore: ${BIP_TRUSTSTORE}
 keystore: ${BIP_KEYSTORE}

--- a/svc-lighthouse-api/src/main/resources/application.yaml
+++ b/svc-lighthouse-api/src/main/resources/application.yaml
@@ -46,19 +46,23 @@ lh:
   clientId: ${LH_ACCESS_CLIENT_ID}
   pemkey: ${LH_PRIVATE_KEY}
 
-## Health
 
+#Actuator for health check, liveness, and readiness
 management:
+  server:
+    port: 10101
   endpoint:
     health:
       show-details: always
       enabled: true
-      probes.enabled: true
-      group.liveness.include: livenessState
-      group.readiness.include: readinessState
+      probes:
+        enabled: true
+      group:
+        liveness.include: livenessState
+        readiness.include: readinessState
 
   endpoints:
     enabled-by-default: false
     web.exposure.include: health
 
-  server.port: 10101
+  


### PR DESCRIPTION
## What was the problem?
Add actuator health check to use the latest readiness urls

Associated tickets or Slack threads:
- #2398 

## How does this fix it?[^1]
Creates an endpoint for readiness for svc-bip-api

## How to test this PR
- Run integration test