### PR TITLE
Feature - endpoints for multi contention + vbms claim_id logging

### DIFF
--- a/domain-cc/cc-app/src/python_src/api.py
+++ b/domain-cc/cc-app/src/python_src/api.py
@@ -14,6 +14,7 @@ from .pydantic_models import (
 from .util.brd_classification_codes import get_classification_name
 from .util.logging_dropdown_selections import build_logging_table
 from .util.lookup_table import ConditionDropdownLookupTable, DiagnosticCodeLookupTable
+from .util.sanitize import sanitize
 
 dc_lookup_table = DiagnosticCodeLookupTable()
 dropdown_lookup_table = ConditionDropdownLookupTable()
@@ -94,7 +95,6 @@ def do_get_classification(
 
 
 def generate_flattened_claim(contention_text, diagnostic_code, multi_contention_claim):
-    print(f"got dc: {diagnostic_code}")
     return FlattenedSingleIssueClaim(
         claim_id=multi_contention_claim.va_gov_claim_id,
         form526_submission_id=multi_contention_claim.va_gov_form526_submission_id,
@@ -109,7 +109,9 @@ def classifier_v1(
     claim: FlattenedSingleIssueClaim,
 ) -> Optional[PredictedClassification]:
     logging.info(
-        f"claim_id: {claim.va_gov_claim_id}, form526_submission_id: {claim.va_gov_form526_submission_id}"
+        sanitize(
+            f"claim_id: {claim.va_gov_claim_id}, form526_submission_id: {claim.va_gov_form526_submission_id}"
+        )
     )
     return do_get_classification(claim)
 
@@ -144,7 +146,9 @@ def classifier_v2(
         classifications.append(classification)
 
     logging.info(
-        f"claim_id: {multi_contention_claim.claim_id}, form526_submission_id: {multi_contention_claim.form526_submission_id}"
+        sanitize(
+            f"claim_id: {multi_contention_claim.claim_id}, form526_submission_id: {multi_contention_claim.form526_submission_id}"
+        )
     )
     logging.info(f"contention_log_info: {contention_log_info}")
 

--- a/domain-cc/cc-app/src/python_src/api.py
+++ b/domain-cc/cc-app/src/python_src/api.py
@@ -5,6 +5,7 @@ from typing import Optional
 from fastapi import FastAPI, HTTPException
 
 from .pydantic_models import (
+    ClassifierResponse,
     FlattenedSingleIssueClaim,
     PredictedClassification,
     VaGovClaim,
@@ -113,9 +114,7 @@ def classifier_v1(
 
 
 @app.post("/classifier/v2")
-def classifier_v2(
-    multi_contention_claim: VaGovClaim,
-) -> dict:  # TODO include response type for this
+def classifier_v2(multi_contention_claim: VaGovClaim,) -> ClassifierResponse:
     contention_log_info = []
     classifications = []
     for contention in multi_contention_claim.contentions:
@@ -145,7 +144,5 @@ def classifier_v2(
         f"claim_id: {multi_contention_claim.claim_id}, form526_submission_id: {multi_contention_claim.form526_submission_id}"
     )
     logging.info(f"contention_log_info: {contention_log_info}")
-    response = {
-        "classifications": classifications,
-    }
-    return response
+
+    return ClassifierResponse(classifications=classifications)

--- a/domain-cc/cc-app/src/python_src/api.py
+++ b/domain-cc/cc-app/src/python_src/api.py
@@ -96,8 +96,8 @@ def do_get_classification(
 def generate_flattened_claim(contention_text, diagnostic_code, multi_contention_claim):
     print(f"got dc: {diagnostic_code}")
     return FlattenedSingleIssueClaim(
-        claim_id=multi_contention_claim.claim_id,
-        form526_submission_id=multi_contention_claim.form526_submission_id,
+        claim_id=multi_contention_claim.va_gov_claim_id,
+        form526_submission_id=multi_contention_claim.va_gov_form526_submission_id,
         diagnostic_code=diagnostic_code,
         claim_type=multi_contention_claim.claim_type,
         contention_text=contention_text,
@@ -109,7 +109,7 @@ def classifier_v1(
     claim: FlattenedSingleIssueClaim,
 ) -> Optional[PredictedClassification]:
     logging.info(
-        f"claim_id: {claim.claim_id}, form526_submission_id: {claim.form526_submission_id}"
+        f"claim_id: {claim.va_gov_claim_id}, form526_submission_id: {claim.va_gov_form526_submission_id}"
     )
     return do_get_classification(claim)
 

--- a/domain-cc/cc-app/src/python_src/api.py
+++ b/domain-cc/cc-app/src/python_src/api.py
@@ -92,6 +92,7 @@ def do_get_classification(
 
 
 def generate_flattened_claim(contention_text, diagnostic_code, multi_contention_claim):
+    print(f"got dc: {diagnostic_code}")
     return FlattenedSingleIssueClaim(
         claim_id=multi_contention_claim.claim_id,
         form526_submission_id=multi_contention_claim.form526_submission_id,

--- a/domain-cc/cc-app/src/python_src/api.py
+++ b/domain-cc/cc-app/src/python_src/api.py
@@ -1,10 +1,10 @@
 import logging
 import sys
-from typing import Optional
+from typing import List, Optional
 
 from fastapi import FastAPI, HTTPException
 
-from .pydantic_models import Claim, PredictedClassification
+from .pydantic_models import Claim, FlattenedSingleIssueClaim, PredictedClassification
 from .util.brd_classification_codes import get_classification_name
 from .util.logging_dropdown_selections import build_logging_table
 from .util.lookup_table import ConditionDropdownLookupTable, DiagnosticCodeLookupTable
@@ -47,8 +47,9 @@ def get_health_status():
     return {"status": "ok"}
 
 
-@app.post("/classifier")
-def get_classification(claim: Claim) -> Optional[PredictedClassification]:
+def do_get_classification(
+    claim: FlattenedSingleIssueClaim,
+) -> Optional[PredictedClassification]:
     logging.info(
         f"claim_id: {claim.claim_id}, form526_submission_id: {claim.form526_submission_id}"
     )
@@ -88,3 +89,16 @@ def get_classification(claim: Claim) -> Optional[PredictedClassification]:
 
     logging.info(f"classification: {classification}")
     return classification
+
+
+@app.post("/classifier")
+def get_classification(
+    claim: FlattenedSingleIssueClaim,
+) -> Optional[PredictedClassification]:
+    return do_get_classification(claim)
+
+
+def classify_claim(
+    multi_contention_claim: Claim,
+) -> Optional[List[PredictedClassification]]:
+    pass

--- a/domain-cc/cc-app/src/python_src/api.py
+++ b/domain-cc/cc-app/src/python_src/api.py
@@ -1,6 +1,6 @@
 import logging
 import sys
-from typing import List, Optional
+from typing import Optional
 
 from fastapi import FastAPI, HTTPException
 
@@ -114,7 +114,7 @@ def classifier_v1(
 @app.post("/classifier/v2")
 def classifier_v2(
     multi_contention_claim: VaGovClaim,
-) -> List[Optional[PredictedClassification]]:
+) -> dict:  # TODO include response type for this
     contention_log_info = []
     classifications = []
     for contention in multi_contention_claim.contentions:
@@ -144,4 +144,7 @@ def classifier_v2(
         f"claim_id: {multi_contention_claim.claim_id}, form526_submission_id: {multi_contention_claim.form526_submission_id}"
     )
     logging.info(f"contention_log_info: {contention_log_info}")
-    return classifications
+    response = {
+        "classifications": classifications,
+    }
+    return response

--- a/domain-cc/cc-app/src/python_src/api.py
+++ b/domain-cc/cc-app/src/python_src/api.py
@@ -5,6 +5,7 @@ from typing import Optional
 from fastapi import FastAPI, HTTPException
 
 from .pydantic_models import (
+    ClaimLinkInfo,
     ClassifierResponse,
     FlattenedSingleIssueClaim,
     PredictedClassification,
@@ -114,7 +115,9 @@ def classifier_v1(
 
 
 @app.post("/classifier/v2")
-def classifier_v2(multi_contention_claim: VaGovClaim,) -> ClassifierResponse:
+def classifier_v2(
+    multi_contention_claim: VaGovClaim,
+) -> ClassifierResponse:
     contention_log_info = []
     classifications = []
     for contention in multi_contention_claim.contentions:
@@ -146,3 +149,17 @@ def classifier_v2(multi_contention_claim: VaGovClaim,) -> ClassifierResponse:
     logging.info(f"contention_log_info: {contention_log_info}")
 
     return ClassifierResponse(classifications=classifications)
+
+
+@app.post("/claim-linker")
+def link_vbms_claim_id(claim_link_info: ClaimLinkInfo):
+    logging.info(
+        {
+            "message": "linking claims",
+            "va_gov_claim_id": claim_link_info.va_gov_claim_id,
+            "vbms_claim_id": claim_link_info.vbms_claim_id,
+        }
+    )
+    return {
+        "success": True,
+    }

--- a/domain-cc/cc-app/src/python_src/pydantic_models.py
+++ b/domain-cc/cc-app/src/python_src/pydantic_models.py
@@ -1,6 +1,7 @@
-from typing import List, Optional
+from typing import Optional
 
 from pydantic import BaseModel, root_validator
+from pydantic.types import conlist
 
 
 class FlattenedSingleIssueClaim(BaseModel):
@@ -25,16 +26,16 @@ class FlattenedSingleIssueClaim(BaseModel):
 class Contention(BaseModel):
     vbms_contention_id: int
     contention_text: str
-
-
-class Claim(BaseModel):
-    va_gov_claim_id: int
-    va_gov_form526_submission_id: int
-    vbms_claim_id: int
     diagnostic_code: Optional[int]  # only required for claim_type: "claim_for_increase"
+
+
+class VaGovClaim(BaseModel):
+    claim_id: int
+    form526_submission_id: int
+    # vbms_claim_id: int
     claim_type: str = "claim_for_increase"
 
-    contentions: List[Contention]
+    contentions: conlist(Contention, min_items=1)
 
 
 class PredictedClassification(BaseModel):

--- a/domain-cc/cc-app/src/python_src/pydantic_models.py
+++ b/domain-cc/cc-app/src/python_src/pydantic_models.py
@@ -1,5 +1,6 @@
 from typing import Optional
 
+from fastapi import HTTPException
 from pydantic import BaseModel, root_validator
 from pydantic.types import conlist
 
@@ -17,8 +18,8 @@ class FlattenedSingleIssueClaim(BaseModel):
         diagnostic_code = values.get("diagnostic_code")
 
         if claim_type == "claim_for_increase" and diagnostic_code is None:
-            raise ValueError(
-                "diagnostic_code is required for claim_type claim_for_increase"
+            raise HTTPException(
+                422, "diagnostic_code is required for claim_type claim_for_increase"
             )
         return values
 
@@ -31,8 +32,7 @@ class Contention(BaseModel):
 class VaGovClaim(BaseModel):
     claim_id: int
     form526_submission_id: int
-    # vbms_claim_id: int
-    claim_type: str = "claim_for_increase"
+    claim_type: str  # "claim_for_increase" or "new"
 
     contentions: conlist(Contention, min_items=1)
 

--- a/domain-cc/cc-app/src/python_src/pydantic_models.py
+++ b/domain-cc/cc-app/src/python_src/pydantic_models.py
@@ -1,9 +1,9 @@
-from typing import Optional
+from typing import List, Optional
 
 from pydantic import BaseModel, root_validator
 
 
-class Claim(BaseModel):
+class FlattenedSingleIssueClaim(BaseModel):
     claim_id: int
     form526_submission_id: int
     diagnostic_code: Optional[int]  # only required for claim_type: "claim_for_increase"
@@ -20,6 +20,21 @@ class Claim(BaseModel):
                 "diagnostic_code is required for claim_type claim_for_increase"
             )
         return values
+
+
+class Contention(BaseModel):
+    vbms_contention_id: int
+    contention_text: str
+
+
+class Claim(BaseModel):
+    va_gov_claim_id: int
+    va_gov_form526_submission_id: int
+    vbms_claim_id: int
+    diagnostic_code: Optional[int]  # only required for claim_type: "claim_for_increase"
+    claim_type: str = "claim_for_increase"
+
+    contentions: List[Contention]
 
 
 class PredictedClassification(BaseModel):

--- a/domain-cc/cc-app/src/python_src/pydantic_models.py
+++ b/domain-cc/cc-app/src/python_src/pydantic_models.py
@@ -42,3 +42,7 @@ class PredictedClassification(BaseModel):
 
     classification_code: int
     classification_name: str
+
+
+class ClassifierResponse(BaseModel):
+    classifications: conlist(PredictedClassification, min_items=1)

--- a/domain-cc/cc-app/src/python_src/pydantic_models.py
+++ b/domain-cc/cc-app/src/python_src/pydantic_models.py
@@ -24,7 +24,6 @@ class FlattenedSingleIssueClaim(BaseModel):
 
 
 class Contention(BaseModel):
-    vbms_contention_id: int
     contention_text: str
     diagnostic_code: Optional[int]  # only required for claim_type: "claim_for_increase"
 

--- a/domain-cc/cc-app/src/python_src/pydantic_models.py
+++ b/domain-cc/cc-app/src/python_src/pydantic_models.py
@@ -6,8 +6,8 @@ from pydantic.types import conlist
 
 
 class FlattenedSingleIssueClaim(BaseModel):
-    claim_id: int
-    form526_submission_id: int
+    va_gov_claim_id: int
+    va_gov_form526_submission_id: int
     diagnostic_code: Optional[int]  # only required for claim_type: "claim_for_increase"
     claim_type: str = "claim_for_increase"
     contention_text: Optional[str]  # marked optional to retain compatibility with v1

--- a/domain-cc/cc-app/src/python_src/pydantic_models.py
+++ b/domain-cc/cc-app/src/python_src/pydantic_models.py
@@ -46,3 +46,10 @@ class PredictedClassification(BaseModel):
 
 class ClassifierResponse(BaseModel):
     classifications: conlist(PredictedClassification, min_items=1)
+
+
+class ClaimLinkInfo(BaseModel):
+    """used for connecting claims to each other in order to track contention changes downstream"""
+
+    va_gov_claim_id: int
+    vbms_claim_id: int

--- a/domain-cc/cc-app/src/python_src/util/sanitizer.py
+++ b/domain-cc/cc-app/src/python_src/util/sanitizer.py
@@ -1,0 +1,4 @@
+def sanitize(obj) -> str:
+    if isinstance(obj, list):
+        return str([sanitize(item) for item in obj])
+    return str(obj).replace("\r\n", "").replace("\n", "")

--- a/domain-cc/cc-app/tests/conftest.py
+++ b/domain-cc/cc-app/tests/conftest.py
@@ -4,6 +4,10 @@ import pytest
 from fastapi.testclient import TestClient
 from src.python_src.api import app
 
+ASTRAGALECTOMY_CLASSIFICATION = {
+    "classification_code": 8991,
+    "classification_name": "Musculoskeletal - Ankle",
+}
 TUBERCULOSIS_CLASSIFICATION = {
     "diagnostic_code": 7710,
     "classification_code": 6890,

--- a/domain-cc/cc-app/tests/test_api.py
+++ b/domain-cc/cc-app/tests/test_api.py
@@ -109,11 +109,5 @@ def test_v4_table_diagnostic_code(client: TestClient):
 
     response = client.post("/classifier", json=json_post_dict)
     assert response.status_code == 200
-    assert (
-        response.json()["classification_code"]
-        == 8920
-    )
-    assert (
-        response.json()["classification_name"]
-        == 'Adhesions - Digestive'
-    )
+    assert response.json()["classification_code"] == 8920
+    assert response.json()["classification_name"] == "Adhesions - Digestive"

--- a/domain-cc/cc-app/tests/test_classifier_v2.py
+++ b/domain-cc/cc-app/tests/test_classifier_v2.py
@@ -167,3 +167,17 @@ def test_contention_text_required(client: TestClient):
     }
     response = client.post("/classifier/v2", json=json_post_dict)
     assert response.status_code == 422
+
+
+def test_claim_ids_logged(client: TestClient, caplog):
+    json_post_dict = {
+        "va_gov_claim_id": 100,
+        "vbms_claim_id": 200,
+    }
+    client.post("/claim-linker", json=json_post_dict)
+    expected_claim_link_json = {
+        "message": "linking claims",
+        "va_gov_claim_id": 100,
+        "vbms_claim_id": 200,
+    }
+    assert eval(caplog.records[0].message) == expected_claim_link_json

--- a/domain-cc/cc-app/tests/test_classifier_v2.py
+++ b/domain-cc/cc-app/tests/test_classifier_v2.py
@@ -1,0 +1,169 @@
+from fastapi.testclient import TestClient
+
+from .conftest import (
+    ASTRAGALECTOMY_CLASSIFICATION,
+    BENIGN_GROWTH_BRAIN_CLASSIFICATION,
+    TUBERCULOSIS_CLASSIFICATION,
+)
+
+
+def test_single_issue_cfi(client: TestClient):
+    json_post_dict = {
+        "diagnostic_code": TUBERCULOSIS_CLASSIFICATION["diagnostic_code"],
+        "claim_id": 100,
+        "form526_submission_id": 500,
+        "claim_type": "claim_for_increase",
+        "contentions": [
+            {
+                "diagnostic_code": TUBERCULOSIS_CLASSIFICATION["diagnostic_code"],
+                "contention_text": "Tuberculosis",
+            }
+        ],
+    }
+
+    response = client.post("/classifier/v2", json=json_post_dict)
+    classification = response.json()["classifications"][0]
+    assert response.status_code == 200
+    assert (
+        classification["classification_code"]
+        == TUBERCULOSIS_CLASSIFICATION["classification_code"]
+    )
+    assert (
+        classification["classification_name"]
+        == TUBERCULOSIS_CLASSIFICATION["classification_name"]
+    )
+
+
+def test_dc_required_for_cfi(client: TestClient):
+    json_post_dict = {
+        "diagnostic_code": TUBERCULOSIS_CLASSIFICATION["diagnostic_code"],
+        "claim_id": 100,
+        "form526_submission_id": 500,
+        "claim_type": "claim_for_increase",
+        "contentions": [
+            {
+                "diagnostic_code": None,
+                "contention_text": "Tuberculosis",
+            }
+        ],
+    }
+    response = client.post("/classifier/v2", json=json_post_dict)
+    assert response.status_code == 422
+
+
+def test_multi_issue_cfi(client: TestClient):
+    json_post_dict = {
+        "diagnostic_code": TUBERCULOSIS_CLASSIFICATION["diagnostic_code"],
+        "claim_id": 100,
+        "form526_submission_id": 500,
+        "claim_type": "claim_for_increase",
+        "contentions": [
+            {
+                "diagnostic_code": TUBERCULOSIS_CLASSIFICATION["diagnostic_code"],
+                "contention_text": "Tuberculosis",
+            },
+            {
+                "diagnostic_code": BENIGN_GROWTH_BRAIN_CLASSIFICATION[
+                    "diagnostic_code"
+                ],
+                "contention_text": "benign growth stuff",
+            },
+        ],
+    }
+
+    response = client.post("/classifier/v2", json=json_post_dict)
+    first, second = response.json()["classifications"]
+    assert response.status_code == 200
+    assert (
+        first["classification_code"]
+        == TUBERCULOSIS_CLASSIFICATION["classification_code"]
+    )
+    assert (
+        first["classification_name"]
+        == TUBERCULOSIS_CLASSIFICATION["classification_name"]
+    )
+    assert (
+        second["classification_code"]
+        == BENIGN_GROWTH_BRAIN_CLASSIFICATION["classification_code"]
+    )
+    assert (
+        second["classification_name"]
+        == BENIGN_GROWTH_BRAIN_CLASSIFICATION["classification_name"]
+    )
+
+
+def test_single_issue_new(client: TestClient):
+    json_post_dict = {
+        "diagnostic_code": TUBERCULOSIS_CLASSIFICATION["diagnostic_code"],
+        "claim_id": 100,
+        "form526_submission_id": 500,
+        "claim_type": "new",
+        "contentions": [
+            {
+                "contention_text": "Tuberculosis",
+            }
+        ],
+    }
+    response = client.post("/classifier/v2", json=json_post_dict)
+    classification = response.json()["classifications"][0]
+    assert response.status_code == 200
+    assert (
+        classification["classification_code"]
+        == TUBERCULOSIS_CLASSIFICATION["classification_code"]
+    )
+    assert (
+        classification["classification_name"]
+        == TUBERCULOSIS_CLASSIFICATION["classification_name"]
+    )
+
+
+def test_multi_issue_new(client: TestClient):
+    json_post_dict = {
+        "diagnostic_code": TUBERCULOSIS_CLASSIFICATION["diagnostic_code"],
+        "claim_id": 100,
+        "form526_submission_id": 500,
+        "claim_type": "new",
+        "contentions": [
+            {
+                "contention_text": "Tuberculosis",
+            },
+            {
+                "contention_text": "astragalectomy or talectomy (removal of talus bone in ankle), right",
+            },
+        ],
+    }
+    response = client.post("/classifier/v2", json=json_post_dict)
+    first, second = response.json()["classifications"]
+    assert response.status_code == 200
+    assert (
+        first["classification_code"]
+        == TUBERCULOSIS_CLASSIFICATION["classification_code"]
+    )
+    assert (
+        first["classification_name"]
+        == TUBERCULOSIS_CLASSIFICATION["classification_name"]
+    )
+    assert (
+        second["classification_code"]
+        == ASTRAGALECTOMY_CLASSIFICATION["classification_code"]
+    )
+    assert (
+        second["classification_name"]
+        == ASTRAGALECTOMY_CLASSIFICATION["classification_name"]
+    )
+
+
+def test_contention_text_required(client: TestClient):
+    json_post_dict = {
+        "diagnostic_code": TUBERCULOSIS_CLASSIFICATION["diagnostic_code"],
+        "claim_id": 100,
+        "form526_submission_id": 500,
+        "claim_type": "new",
+        "contentions": [
+            {
+                "contention_text": None,
+            },
+        ],
+    }
+    response = client.post("/classifier/v2", json=json_post_dict)
+    assert response.status_code == 422


### PR DESCRIPTION
<!-- Ensure the PR title reflects the feature or bug name -->

## What was the problem?
<!-- brief description of how things worked before this PR -->
 - Contention Classification `/classifier` endpoint only accepts single-issue claims.
 - Also, VA.gov claim id is collected from `/classifier`, but VBMS id for the claim is not saved or linked to the va.gov claim presently.

Associated tickets or Slack threads:
- https://github.com/department-of-veterans-affairs/vagov-claim-classification/issues/152

## How does this fix it?[^1]
<!-- description of how things will work after this PR -->
 - added `/classifier/v2` with different input format, including `"contentions"` array
 - added second endpoint for linking claim ids `/claim-linker`
 
## Additional junk
 - moved some existing code to improve readability, I think?
 - do_get_classification() now handles logic for checking the lookup table, instead of the endpoints themselves
 - added `deprecated=True` to `/classifier` which greys it out in the documentation
 - renamed previous pydantic model from `Claim` to `FlattenedSingleIssueClaim` in order to be more explicit
 - added new pydantic models for inputs/outputs of `/classifier/v2`

## How to test this PR
- Tests added to `domain-cc/cc-app/tests/test_classifier_v2.py`
- `pytest`
- additionally, running the code locally, API can be tested manually via POST request


[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
