### PR TITLE
Parameters for db.query out of order.

### DIFF
--- a/domain-ee/ee-ep-merge-app/src/python_src/service/job_store.py
+++ b/domain-ee/ee-ep-merge-app/src/python_src/service/job_store.py
@@ -18,8 +18,8 @@ class JobStore:
     def query(self, states: list[schema.JobState] = schema.JobState.incomplete_states(), offset: int = 1, limit: int = 10) -> \
             list[MergeJob]:
         return self.db.query(MergeJob,
-                             MergeJob.updated_at,
                              MergeJob.state.in_(states) if states else True,
+                             MergeJob.updated_at,
                              offset,
                              limit)
 

--- a/domain-ee/ee-ep-merge-app/tests/service/test_job_store.py
+++ b/domain-ee/ee-ep-merge-app/tests/service/test_job_store.py
@@ -102,14 +102,14 @@ def test_query(db, merge_job, states: list, offset: int, limit: int):
 
     query_args = db.query.call_args[0]
     actual_model = query_args[0]
-    actual_order_by = query_args[1]
-    actual_filter = query_args[2]
+    actual_filter = query_args[1]
+    actual_order_by = query_args[2]
     actual_offset = query_args[3]
     actual_limit = query_args[4]
 
     assert actual_model == model.merge_job.MergeJob
-    assert actual_order_by == model.merge_job.MergeJob.updated_at
     assert actual_filter.compare(model.merge_job.MergeJob.state.in_(states if states else DEFAULT_STATES))
+    assert actual_order_by == model.merge_job.MergeJob.updated_at
     assert actual_offset == offset if offset else DEFAULT_OFFSET
     assert actual_limit == limit if limit else DEFAULT_LIMIT
 


### PR DESCRIPTION
<!-- Ensure the PR title reflects the feature or bug name -->

## What was the problem?
Some parameters used for the database query method in job_store.py were out of order.

## How does this fix it?[^1]
<!-- description of how things will work after this PR -->
Puts the parameters in the correct order and fixes associated tests. 

## How to test this PR
- pull code
- Unit Test:
  - from /domain-ee/ee-ep-merge-app run pytest
- Integration Tests:
  - run [base platform](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Docker-Compose#platform-base)
  - from /domain-ee/ee-ep-merge-app run pytest ./integration
- End to End tests:
  - run this [CI](https://github.com/department-of-veterans-affairs/abd-vro/actions/workflows/ee-ep-merge-end-to-end.yml) action to verify successful integration test
  - run end to end tests locally:
    - run bgs and bip services and mocks:
      - `COMPOSE_PROFILES="bip,bgs" ./gradlew :app:dockerComposeUp`
      - `COMPOSE_PROFILES="bip,bgs" ./gradlew -p mocks :dockerComposeUp`
    - `./gradlew :domain-ee:ee-ep-merge-app:endToEndTest`

[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
