### PR TITLE
#2297 - Applying final claimsBaseUrl updates having confirmed the environment mapping

### DIFF
--- a/svc-bgs-api/src/config/settings.yml
+++ b/svc-bgs-api/src/config/settings.yml
@@ -16,7 +16,7 @@ dev:
     client_station_id: 281
     client_username: VROSYSACCT
     log: true
-    base_url: http://beplinktest.vba.va.gov
+    base_url: http://bepdev.vba.va.gov
 
 qa:
   bgs:
@@ -24,7 +24,7 @@ qa:
     client_station_id: 281
     client_username: VROSYSACCT
     log: true
-    base_url: http://beplinktest.vba.va.gov
+    base_url: http://bepprep.vba.va.gov
 
 sandbox:
   bgs:

--- a/svc-bip-api/src/main/resources/application-qa.yaml
+++ b/svc-bip-api/src/main/resources/application-qa.yaml
@@ -1,6 +1,6 @@
 
 bip:
-  claimBaseUrl: "https://claims-uat.stage.bip.va.gov/api/v1"
+  claimBaseUrl: "https://claims-preprod.prod.bip.va.gov/api/v1"
   applicationId: "${BIP_APPLICATION_ID:VRO}"
   stationId: "${BIP_STATION_ID:456}"
   env: qa

--- a/svc-bip-api/src/main/resources/application-sandbox.yaml
+++ b/svc-bip-api/src/main/resources/application-sandbox.yaml
@@ -1,6 +1,6 @@
 
 bip:
-  claimBaseUrl: "https://claims-demo.stage.bip.va.gov"
+  claimBaseUrl: "https://claims-uat.stage.bip.va.gov/api/v1"
   applicationId: "${BIP_APPLICATION_ID:VRO}"
   stationId: "${BIP_STATION_ID:456}"
   env: sandbox


### PR DESCRIPTION
This PR applies the final claimsBaseUrl updates, having confirmed the environment mapping with BIP API team and EE. The final mapping has been documented in slack: https://dsva.slack.com/docs/T03FECE8V/F06F9KGGE3U

## What was the problem?
Sandbox and QA configs had incorrect claimsBaseUrl mappings.

Associated tickets or Slack threads:
- #2297 

## How does this fix it?[^1]
claimsBaseUrl setting is now using the correct environment mapping.

## How to test this PR
- The test plan is documented just below the environment mapping: https://dsva.slack.com/docs/T03FECE8V/F06F9KGGE3U


[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
