### PR TITLE
Add Ruby method to check BGS-api availability (2417)

### DIFF
--- a/svc-bgs-api/src/lib/bgs_client.rb
+++ b/svc-bgs-api/src/lib/bgs_client.rb
@@ -69,6 +69,17 @@ class BgsClient
     end
   end
 
+   # Method to check BGS service availability. It makes use of the vro_participant_id method to check if BGS service is 
+  # reachable and responding. This method should return a participant ID if the service is available.
+  def check_bgs_availability
+    participant_id = vro_participant_id
+    !participant_id.nil? && participant_id.is_a?(String) && !participant_id.empty?
+  rescue StandardError => e
+    puts "BGS-api availability check failed: #{e.message}"
+    false
+    end
+  end
+
   def create_claim_notes(claim_id:, notes:)
     note_hashes = notes.map do |note|
       { claim_id: claim_id, txt: note, user_id: vro_participant_id }

--- a/svc-bgs-api/src/lib/bgs_client.rb
+++ b/svc-bgs-api/src/lib/bgs_client.rb
@@ -77,7 +77,6 @@ class BgsClient
   rescue StandardError => e
     puts "BGS-api availability check failed: #{e.message}"
     false
-    end
   end
 
   def create_claim_notes(claim_id:, notes:)


### PR DESCRIPTION
## What was the problem?
Ruby method for check_bgs_availability not configured in bgs_client.rb file. This is how we plan on checking bgs-api availability and this information is used by the k8s readiness probe. 

Associated tickets or Slack threads:
- #2417 

How to test this PR
Follow steps as described in this PR: **https://github.com/department-of-veterans-affairs/abd-vro/pull/2508**
