### PR TITLE
fixed eventType null issue and added unit tests

### DIFF
--- a/svc-bie-kafka/src/main/java/gov/va/vro/services/bie/utils/BieMessageUtils.java
+++ b/svc-bie-kafka/src/main/java/gov/va/vro/services/bie/utils/BieMessageUtils.java
@@ -20,6 +20,8 @@ public class BieMessageUtils {
       ContentionEvent contentionEvent, GenericRecord genericRecord) {
     BieMessagePayload payload = BieMessagePayload.builder().status(200).build();
 
+    payload.setEventType(contentionEvent);
+
     for (Field field : BieMessagePayload.class.getDeclaredFields()) {
       String fieldName = field.getName();
 

--- a/svc-bie-kafka/src/test/java/gov/va/vro/services/bie/utils/BieMessageUtilsTest.java
+++ b/svc-bie-kafka/src/test/java/gov/va/vro/services/bie/utils/BieMessageUtilsTest.java
@@ -77,6 +77,7 @@ class BieMessageUtilsTest {
     assertEquals("ClassificationName", actualPayload.getContentionClassificationName());
     assertEquals("DiagnosticCode", actualPayload.getDiagnosticTypeCode());
     assertEquals(Long.valueOf(1616161616L), actualPayload.getDateAdded());
+    assertEquals(ContentionEvent.CONTENTION_ASSOCIATED_TO_CLAIM, actualPayload.getEventType());
   }
 
   @Test
@@ -92,6 +93,7 @@ class BieMessageUtilsTest {
     assertEquals("ClassificationName", actualPayload.getContentionClassificationName());
     assertEquals("DiagnosticCode", actualPayload.getDiagnosticTypeCode());
     assertEquals(Long.valueOf(1616161616L), actualPayload.getDateAdded());
+    assertEquals(ContentionEvent.CONTENTION_CLASSIFIED, actualPayload.getEventType());
   }
 
   @Test
@@ -100,6 +102,7 @@ class BieMessageUtilsTest {
         BieMessageUtils.processBieMessagePayloadFields(
             ContentionEvent.CONTENTION_COMPLETED, genericRecord);
     testCommonFields(actualPayload);
+    assertEquals(ContentionEvent.CONTENTION_COMPLETED, actualPayload.getEventType());
   }
 
   @Test
@@ -108,6 +111,7 @@ class BieMessageUtilsTest {
         BieMessageUtils.processBieMessagePayloadFields(
             ContentionEvent.CONTENTION_DELETED, genericRecord);
     testCommonFields(actualPayload);
+    assertEquals(ContentionEvent.CONTENTION_DELETED, actualPayload.getEventType());
   }
 
   @Test
@@ -129,6 +133,7 @@ class BieMessageUtilsTest {
     assertEquals(Long.valueOf(1616161616L), actualPayload.getDateAdded());
     assertEquals(Long.valueOf(1616171717L), actualPayload.getDateCompleted());
     assertEquals(Long.valueOf(1616181818L), actualPayload.getDateUpdated());
+    assertEquals(ContentionEvent.CONTENTION_UPDATED, actualPayload.getEventType());
   }
 
   private void testCommonFields(BieMessagePayload actualPayload) {


### PR DESCRIPTION
<!-- Ensure the PR title reflects the feature or bug name -->

## What was the problem?
Currently, the event type is not set and appears as null in the logs, making it impossible to identify the Kafka event type from which the payload originates

Associated tickets or Slack threads:
- #2487 

## How does this fix it?[^1]
- added code to set the `eventType`
- added unit test to verify the field has been set correctly

## How to test this PR
- verify in unit test ` ./gradlew svc-bie-kafka:test`
- verify the `eventType` field value in dev pod log


[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
