### PR TITLE
#2381 Map VRO prod-test to BIP preprod

### DIFF
--- a/svc-bip-api/src/main/resources/application-prod-test.yaml
+++ b/svc-bip-api/src/main/resources/application-prod-test.yaml
@@ -1,6 +1,6 @@
 
 bip:
-  claimBaseUrl: "https://claims-prodtest.prod.bip.va.gov/api/v1"
+  claimBaseUrl: "https://claims-preprod.prod.bip.va.gov/api/v1"
   applicationId: "${BIP_APPLICATION_ID:VRO}"
   stationId: "${BIP_STATION_ID:456}"
   env: prod-test


### PR DESCRIPTION
Updates config for BIP, such that, our prod-test will use BIP preppro

Associated tickets or Slack threads:
- #2381 

## How does this fix it?[^1]
uses Spring's config overlay to change the claimBaseUrl property to use the correct BIP hostname

[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
