### PR TITLE
Legacy option for OpenSSL

### DIFF
--- a/svc-bgs-api/docker-entrypoint.sh
+++ b/svc-bgs-api/docker-entrypoint.sh
@@ -14,10 +14,20 @@ cd "$CERTS_PATH" || exit 10
 # shellcheck disable=SC2223
 [ "$BIP_PASSWORD" ] && { : ${PWD_ARG:=-password pass:$BIP_PASSWORD}; }
 
-[ "$BIP_KEYSTORE" ] && [ "$BIP_TRUSTSTORE" ] && {
-    echo "$BIP_KEYSTORE"   | base64 -d > keystore.p12
-    echo "$BIP_TRUSTSTORE" | base64 -d > truststore.p12
-}
+# Checks that openssl is installed
+openssl version
+
+#[ "$BIP_KEYSTORE" ] && [ "$BIP_TRUSTSTORE" ] && {
+#    echo "$BIP_KEYSTORE"   | base64 -d > keystore.p12
+#    echo "$BIP_TRUSTSTORE" | base64 -d > truststore.p12
+#
+#    # shellcheck disable=SC2086
+#    openssl pkcs12 ${PWD_ARG} -in keystore.p12   -out tls_bip.crt -nokeys || exit 2
+#    # shellcheck disable=SC2086
+#    openssl pkcs12 ${PWD_ARG} -in keystore.p12   -out tls.key -nocerts -nodes || exit 3
+#    # shellcheck disable=SC2086
+#    openssl pkcs12 ${PWD_ARG} -in truststore.p12 -out va_all.crt || exit 4
+#}
 
 cd "$CURR_DIR" || exit 11
 

--- a/svc-bgs-api/docker-entrypoint.sh
+++ b/svc-bgs-api/docker-entrypoint.sh
@@ -22,11 +22,11 @@ openssl version
     echo "$BIP_TRUSTSTORE" | base64 -d > truststore.p12
 
     # shellcheck disable=SC2086
-    openssl pkcs12 ${PWD_ARG} -in keystore.p12   -out tls_bip.crt -nokeys || exit 2
+    openssl pkcs12 ${PWD_ARG} -in keystore.p12   -out tls_bip.crt -nokeys -legacy || exit 2
     # shellcheck disable=SC2086
-    openssl pkcs12 ${PWD_ARG} -in keystore.p12   -out tls.key -nocerts -nodes || exit 3
+    openssl pkcs12 ${PWD_ARG} -in keystore.p12   -out tls.key -nocerts -nodes -legacy || exit 3
     # shellcheck disable=SC2086
-    openssl pkcs12 ${PWD_ARG} -in truststore.p12 -out va_all.crt || exit 4
+    openssl pkcs12 ${PWD_ARG} -in truststore.p12 -out va_all.crt -legacy || exit 4
 }
 
 cd "$CURR_DIR" || exit 11

--- a/svc-bgs-api/docker-entrypoint.sh
+++ b/svc-bgs-api/docker-entrypoint.sh
@@ -17,17 +17,17 @@ cd "$CERTS_PATH" || exit 10
 # Checks that openssl is installed
 openssl version
 
-#[ "$BIP_KEYSTORE" ] && [ "$BIP_TRUSTSTORE" ] && {
-#    echo "$BIP_KEYSTORE"   | base64 -d > keystore.p12
-#    echo "$BIP_TRUSTSTORE" | base64 -d > truststore.p12
-#
-#    # shellcheck disable=SC2086
-#    openssl pkcs12 ${PWD_ARG} -in keystore.p12   -out tls_bip.crt -nokeys || exit 2
-#    # shellcheck disable=SC2086
-#    openssl pkcs12 ${PWD_ARG} -in keystore.p12   -out tls.key -nocerts -nodes || exit 3
-#    # shellcheck disable=SC2086
-#    openssl pkcs12 ${PWD_ARG} -in truststore.p12 -out va_all.crt || exit 4
-#}
+[ "$BIP_KEYSTORE" ] && [ "$BIP_TRUSTSTORE" ] && {
+    echo "$BIP_KEYSTORE"   | base64 -d > keystore.p12
+    echo "$BIP_TRUSTSTORE" | base64 -d > truststore.p12
+
+    # shellcheck disable=SC2086
+    openssl pkcs12 ${PWD_ARG} -in keystore.p12   -out tls_bip.crt -nokeys || exit 2
+    # shellcheck disable=SC2086
+    openssl pkcs12 ${PWD_ARG} -in keystore.p12   -out tls.key -nocerts -nodes || exit 3
+    # shellcheck disable=SC2086
+    openssl pkcs12 ${PWD_ARG} -in truststore.p12 -out va_all.crt || exit 4
+}
 
 cd "$CURR_DIR" || exit 11
 


### PR DESCRIPTION
<!-- Ensure the PR title reflects the feature or bug name -->

## What was the problem?
<!-- brief description of how things worked before this PR -->
Certificates use a format which is no supported by default on the latest version of OpenSSL.

Associated tickets or Slack threads:
- #2462 

## How does this fix it?[^1]
<!-- description of how things will work after this PR -->
- Adds legacy commandline argument to `openssl` commands in startup

## How to test this PR
- Deployed to LHDI using custom branch deployment workflow


[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
