### PR TITLE
Fix K8s lliveness probe for BGS-api

### DIFF
--- a/helm/svc-bgs-api/templates/deployment.yaml
+++ b/helm/svc-bgs-api/templates/deployment.yaml
@@ -21,7 +21,6 @@ spec:
       containers:
         - name: svc-bgs-api{{ include "vro.containerSuffix" . }}
           image: {{ include "vro.imageRegistryPath" . }}vro-svc-bgs-api:{{ include "vro.imageTag" . }}
-          ports: {{- toYaml .Values.ports | nindent 12 }}
           livenessProbe: {{- toYaml .Values.livenessProbe | nindent 12 }}
           readinessProbe: {{- toYaml .Values.readinessProbe | nindent 12 }}
           env:

--- a/helm/svc-bgs-api/values.yaml
+++ b/helm/svc-bgs-api/values.yaml
@@ -14,8 +14,9 @@ replicaCount: 1
 livenessProbe:
   exec:
     command:
-    - ruby
-    - /app/healthcheck/liveness_script.rb
+    - /bin/sh
+    - -c
+    - bundle exec ruby /app/healthcheck/liveness_script.rb
   initialDelaySeconds: 120
   periodSeconds: 10
   timeoutSeconds: 10
@@ -24,8 +25,9 @@ livenessProbe:
 readinessProbe:
   exec:
     command:
-    - ruby
-    - /app/healthcheck/readiness_script.rb
+    - /bin/sh
+    - -c
+    - bundle exec ruby /app/healthcheck/readiness_script.rb
   initialDelaySeconds: 120
   periodSeconds: 10
   timeoutSeconds: 10

--- a/svc-bgs-api/src/Gemfile
+++ b/svc-bgs-api/src/Gemfile
@@ -7,10 +7,6 @@ gem 'cgi', '~> 0.3.6' # Address CVE-2021-41819
 gem 'bunny', '>= 2.13.0'
 gem 'activesupport', '~> 6.0'
 gem 'bgs_ext', git: 'https://github.com/department-of-veterans-affairs/bgs-ext.git', require: 'bgs'
-gem 'base64'
-gem 'bigdecimal'
-gem 'nkf'
-gem 'mutex_m'
 
 group :development, :test do
   gem 'rspec'

--- a/svc-bgs-api/src/Gemfile
+++ b/svc-bgs-api/src/Gemfile
@@ -7,6 +7,10 @@ gem 'cgi', '~> 0.3.6' # Address CVE-2021-41819
 gem 'bunny', '>= 2.13.0'
 gem 'activesupport', '~> 6.0'
 gem 'bgs_ext', git: 'https://github.com/department-of-veterans-affairs/bgs-ext.git', require: 'bgs'
+gem 'base64'
+gem 'bigdecimal'
+gem 'nkf'
+gem 'mutex_m'
 
 group :development, :test do
   gem 'rspec'

--- a/svc-bgs-api/src/healthcheck/liveness_script.rb
+++ b/svc-bgs-api/src/healthcheck/liveness_script.rb
@@ -6,7 +6,7 @@ require_relative '../config/constants'
 
 def check_rabbitmq_connection
   subscriber = RabbitSubscriber.new(BUNNY_ARGS)
-  subscriber.connected?
+  subscriber.rabbitmq_connected?
 rescue StandardError => e
   puts "RabbitMQ connection check failed: #{e.message}"
   false

--- a/svc-bgs-api/src/healthcheck/readiness_script.rb
+++ b/svc-bgs-api/src/healthcheck/readiness_script.rb
@@ -15,7 +15,7 @@ end
 
 def bgs_service_available?
   client = BgsClient.new
-  client.bgs_available
+  client.bgs_available?
 rescue StandardError => e
   puts "BGS service availability check failed: #{e.message}"
   false

--- a/svc-bgs-api/src/healthcheck/readiness_script.rb
+++ b/svc-bgs-api/src/healthcheck/readiness_script.rb
@@ -7,7 +7,7 @@ require_relative '../lib/bgs_client'
 
 def rabbitmq_connection_active?
   subscriber = RabbitSubscriber.new(BUNNY_ARGS)
-  subscriber.connected?
+  subscriber.rabbitmq_connected?
 rescue StandardError => e
   puts "RabbitMQ connection check failed: #{e.message}"
   false

--- a/svc-bgs-api/src/lib/bgs_client.rb
+++ b/svc-bgs-api/src/lib/bgs_client.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'active_support/time'
+require 'active_support/core_ext/object/blank'
 require 'bgs'
 
 # patch bgs_ext with a createNote implementation that follows our spec better
@@ -69,16 +70,6 @@ class BgsClient
     end
   end
 
-  # Method to check BGS service availability. It makes use of the vro_participant_id method to check if BGS service is 
-  # reachable and responding. This method should return a participant ID if the service is available.
-  def bgs_available?
-    participant_id = vro_participant_id
-    vro_participant_id.present?
-  rescue StandardError => e
-    puts "BGS-api availability check failed: #{e.message}"
-    false
-  end
-
   def create_claim_notes(claim_id:, notes:)
     note_hashes = notes.map do |note|
       { claim_id: claim_id, txt: note, user_id: vro_participant_id }
@@ -89,5 +80,15 @@ class BgsClient
   def create_veteran_note(claim_id: nil, participant_id: nil, note:)
     participant_id ||= bgs.benefit_claims.find_bnft_claim(claim_id: claim_id)[:bnft_claim_dto][:ptcpnt_vet_id]
     bgs.notes.create_note(participant_id: participant_id, txt: note, user_id: vro_participant_id)
+  end
+
+  # Method to check BGS service availability. It makes use of the vro_participant_id method to check if BGS service is 
+  # reachable and responding. This method should return a participant ID if the service is available.
+  def bgs_available?
+    participant_id = vro_participant_id
+    vro_participant_id.present?
+  rescue StandardError => e
+    puts "BGS-api availability check failed: #{e.message}"
+    false
   end
 end

--- a/svc-bgs-api/src/lib/rabbit_subscriber.rb
+++ b/svc-bgs-api/src/lib/rabbit_subscriber.rb
@@ -26,6 +26,10 @@ class RabbitSubscriber
     end
   end
 
+  def rabbitmq_connected?
+    @connection && @connection.open?
+  end
+
   def close
     @connection.close
   end


### PR DESCRIPTION
## What was the problem?
Liveness probe failure blocking bgs-api deployment and restarting continously

Associated tickets or Slack threads:
- #2417 

## How does this fix it?[^1]
Bgs-api pod does't restart and doesn't block deployments. 

## How to test this PR
- Check Lens and confirm that bgs-api pod doesn't restart