### PR TITLE
Final Fix to svc-bgs-api K8s readiness probe (2417)

### DIFF
--- a/helm/svc-bgs-api/Chart.yaml
+++ b/helm/svc-bgs-api/Chart.yaml
@@ -11,7 +11,7 @@ description: VRO microservice - client for BGS API
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # TODO discuss: How can we enforce or automate incrementing this?
-version: 0.1.4
+version: 0.1.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/helm/svc-bgs-api/templates/deployment.yaml
+++ b/helm/svc-bgs-api/templates/deployment.yaml
@@ -21,6 +21,7 @@ spec:
       containers:
         - name: svc-bgs-api{{ include "vro.containerSuffix" . }}
           image: {{ include "vro.imageRegistryPath" . }}vro-svc-bgs-api:{{ include "vro.imageTag" . }}
+          startupProbe: {{- toYaml .Values.startupProbe | nindent 12 }}
           livenessProbe: {{- toYaml .Values.livenessProbe | nindent 12 }}
           readinessProbe: {{- toYaml .Values.readinessProbe | nindent 12 }}
           env:

--- a/helm/svc-bgs-api/values.yaml
+++ b/helm/svc-bgs-api/values.yaml
@@ -11,6 +11,17 @@ resources:
 
 replicaCount: 1
 
+startupProbe:
+  exec:
+    command:
+    - /bin/sh
+    - -c
+    - bundle exec ruby /app/healthcheck/startup_script.rb  
+  initialDelaySeconds: 120  
+  periodSeconds: 10
+  timeoutSeconds: 10
+  failureThreshold: 30  
+
 livenessProbe:
   exec:
     command:

--- a/svc-bgs-api/Dockerfile
+++ b/svc-bgs-api/Dockerfile
@@ -33,9 +33,12 @@ RUN chmod +x ./*.sh && chown -R tron /app
 # Copy health check scripts
 COPY healthcheck/liveness_script.rb /app/healthcheck/liveness_script.rb
 COPY healthcheck/readiness_script.rb /app/healthcheck/readiness_script.rb
+COPY healthcheck/startup_script.rb /app/healthcheck/startup_script.rb
 
 # Make scripts executable
-RUN chmod +x /app/healthcheck/liveness_script.rb && chmod +x /app/healthcheck/readiness_script.rb
+RUN chmod +x /app/healthcheck/liveness_script.rb \ 
+    && chmod +x /app/healthcheck/readiness_script.rb \
+    && chmod +x /app/healthcheck/startup_script.rb
 
 USER tron
 ENTRYPOINT ["/app/entrypoint-wrapper.sh"]

--- a/svc-bgs-api/src/Gemfile
+++ b/svc-bgs-api/src/Gemfile
@@ -6,7 +6,7 @@ ruby "~> 3.3.0"
 gem 'cgi', '~> 0.3.6' # Address CVE-2021-41819
 gem 'bunny', '>= 2.13.0'
 gem 'activesupport', '~> 6.0'
-gem 'bgs_ext', git: 'https://github.com/department-of-veterans-affairs/bgs-ext.git', require: DIR['lib/bgs']
+gem 'bgs_ext', git: 'https://github.com/department-of-veterans-affairs/bgs-ext.git', require: 'bgs'
 
 group :development, :test do
   gem 'rspec'

--- a/svc-bgs-api/src/Gemfile
+++ b/svc-bgs-api/src/Gemfile
@@ -6,7 +6,7 @@ ruby "~> 3.3.0"
 gem 'cgi', '~> 0.3.6' # Address CVE-2021-41819
 gem 'bunny', '>= 2.13.0'
 gem 'activesupport', '~> 6.0'
-gem 'bgs_ext', git: 'https://github.com/department-of-veterans-affairs/bgs-ext.git', require: 'lib/bgs'
+gem 'bgs_ext', git: 'https://github.com/department-of-veterans-affairs/bgs-ext.git', require: DIR['lib/bgs']
 
 group :development, :test do
   gem 'rspec'

--- a/svc-bgs-api/src/Gemfile
+++ b/svc-bgs-api/src/Gemfile
@@ -6,7 +6,7 @@ ruby "~> 3.3.0"
 gem 'cgi', '~> 0.3.6' # Address CVE-2021-41819
 gem 'bunny', '>= 2.13.0'
 gem 'activesupport', '~> 6.0'
-gem 'bgs_ext', git: 'https://github.com/department-of-veterans-affairs/bgs-ext.git', require: 'bgs'
+gem 'bgs_ext', git: 'https://github.com/department-of-veterans-affairs/bgs-ext.git', require: 'lib/bgs'
 
 group :development, :test do
   gem 'rspec'

--- a/svc-bgs-api/src/healthcheck/liveness_script.rb
+++ b/svc-bgs-api/src/healthcheck/liveness_script.rb
@@ -4,17 +4,26 @@
 require_relative '../lib/rabbit_subscriber'
 require_relative '../config/constants'
 
+def log(message)
+  puts "[Liveness Check]: #{message}"
+end
+
 def check_rabbitmq_connection
-  subscriber = RabbitSubscriber.new(BUNNY_ARGS)
-  subscriber.rabbitmq_connected?
-rescue StandardError => e
-  puts "RabbitMQ connection check failed: #{e.message}"
-  false
+  begin
+    subscriber = RabbitSubscriber.new(BUNNY_ARGS)
+    connected = subscriber.rabbitmq_connected?
+    log("RabbitMQ connectivity check: #{connected ? 'Success' : 'Failure'}")
+    connected
+  rescue => e
+    log("RabbitMQ check failed: #{e.message}")
+    false
+  end
 end
 
 if check_rabbitmq_connection
+  log("Liveness check passed!")
   exit 0
 else
-  puts "Liveness check failed"
+  log("Liveness check failed!")
   exit 1
 end

--- a/svc-bgs-api/src/healthcheck/liveness_script.rb
+++ b/svc-bgs-api/src/healthcheck/liveness_script.rb
@@ -1,29 +1,33 @@
 # This script is used by the K8S Liveness probe to check the connection between RabbitMQ and BGS-api thereby verifying 
 # that the BGS-api application is running and able to perform its basic functions. 
 
+require 'logger'
 require_relative '../lib/rabbit_subscriber'
 require_relative '../config/constants'
 
+# Initializes logger
+$logger = Logger.new(STDOUT)
+$logger.level = Logger::INFO
+$logger.info('Logger initialized')
+
 def log(message)
-  puts "[Liveness Check]: #{message}"
+  $logger.info("[Liveness Check]: #{message}")
 end
 
 def check_rabbitmq_connection
-  begin
-    subscriber = RabbitSubscriber.new(BUNNY_ARGS)
-    connected = subscriber.rabbitmq_connected?
-    log("RabbitMQ connectivity check: #{connected ? 'Success' : 'Failure'}")
-    connected
+  subscriber = RabbitSubscriber.new(BUNNY_ARGS)
+  connected = subscriber.rabbitmq_connected?
+  log "RabbitMQ connectivity check: #{connected ? 'Success' : 'Failure'}"
+  connected
   rescue => e
-    log("RabbitMQ check failed: #{e.message}")
+    log "RabbitMQ check failed: #{e.message}"
     false
   end
-end
 
 if check_rabbitmq_connection
-  log("Liveness check passed!")
-  exit 0
+  log "Liveness check passed!"
+  exit(0)
 else
-  log("Liveness check failed!")
-  exit 1
+  log "Liveness check failed!"
+  exit(1)
 end

--- a/svc-bgs-api/src/healthcheck/readiness_script.rb
+++ b/svc-bgs-api/src/healthcheck/readiness_script.rb
@@ -57,6 +57,7 @@ def perform_readiness_checks
   end
 end
 
+
 unless perform_readiness_checks
   exit(1)
 end

--- a/svc-bgs-api/src/healthcheck/readiness_script.rb
+++ b/svc-bgs-api/src/healthcheck/readiness_script.rb
@@ -50,10 +50,10 @@ def perform_readiness_checks
   rabbitmq_ok = rabbitmq_connection_active?
   if bgs_config_ok && rabbitmq_ok
     log "Readiness checks passed!"
-    return true
+    true
   else
     log "Readiness checks failed!"
-    return false
+    false
   end
 end
 

--- a/svc-bgs-api/src/healthcheck/readiness_script.rb
+++ b/svc-bgs-api/src/healthcheck/readiness_script.rb
@@ -1,30 +1,62 @@
-# This script is used by the K8S Readiness probe to check the availability of the BGS-api service as well as the status of RabbitMQ thereby verifying 
-# that the BGS-api application is ready to perform its basic functions. 
+# This script is used by the K8S Readiness probe to check the availability of the BGS-api service. Specifically, it checks
+# the configuration of bgs-api environment and application as well as confirms the service is ready. It also checks the status 
+# of RabbitMQ thereby verifying that the BGS-api application is ready to perform its basic functions. 
 
+require 'logger'
 require_relative '../lib/rabbit_subscriber'
 require_relative '../config/constants'
-require_relative '../lib/bgs_client'
+require_relative '../config/setup'
+
+# Initializes logger
+$logger = Logger.new(STDOUT)
+$logger.level = Logger::INFO
+$logger.info('Logger initialized')
+
+def log(message)
+  $logger.info("[Readiness Check]: #{message}")
+end
 
 def rabbitmq_connection_active?
-  subscriber = RabbitSubscriber.new(BUNNY_ARGS)
-  subscriber.rabbitmq_connected?
-rescue StandardError => e
-  puts "RabbitMQ connection check failed: #{e.message}"
-  false
+  begin
+    subscriber = RabbitSubscriber.new(BUNNY_ARGS)
+    connected = subscriber.rabbitmq_connected?
+    log("RabbitMQ connectivity check: #{connected ? 'Success' : 'Failure'}")
+    connected
+  rescue => e
+    log("RabbitMQ check failed: #{e.message}")    
+    false
+  end
 end
 
-def bgs_service_available?
-  client = BgsClient.new
-  client.bgs_available?
-rescue StandardError => e
-  puts "BGS service availability check failed: #{e.message}"
-  false
+# Function to check if BGS settings are correctly loaded and configured
+def check_bgs_configuration
+  bgs_settings = SETTINGS['bgs']
+  
+  # Check if all required BGS settings in the settings.yml file are present
+  required_keys = %w[application client_station_id client_username log base_url]
+  missing_keys = required_keys.select { |key| bgs_settings[key].nil? || bgs_settings[key].to_s.empty? }
+  
+  if missing_keys.empty?
+    log "BGS configuration loaded successfully."
+    true
+  else
+    log "Missing BGS configuration keys: #{missing_keys.join(', ')}"
+    false
+  end
 end
 
-if rabbitmq_connection_active? && bgs_service_available?
-  exit 0
-else
-  puts "Readiness check failed"
-  exit 1
+def perform_readiness_checks
+  bgs_config_ok = check_bgs_configuration
+  rabbitmq_ok = rabbitmq_connection_active?
+  if bgs_config_ok && rabbitmq_ok
+    log "Readiness checks passed!"
+    return true
+  else
+    log "Readiness checks failed!"
+    return false
+  end
 end
 
+unless perform_readiness_checks
+  exit(1)
+end

--- a/svc-bgs-api/src/healthcheck/startup_script.rb
+++ b/svc-bgs-api/src/healthcheck/startup_script.rb
@@ -1,0 +1,46 @@
+# This script is used by the K8S Startup probe to check the availability of the BGS-api service. Specifically, it checks
+# the configuration of bgs-api environment and application and prevents liveness probe to be starting early.  
+
+require 'logger'
+require_relative '../config/setup'
+
+# Initializes logger
+$logger = Logger.new(STDOUT)
+$logger.level = Logger::INFO
+$logger.info('Logger initialized')
+
+def log(message)
+  $logger.info("[Startup probe Check]: #{message}")
+end
+
+# Function to check if BGS settings are correctly loaded and configured
+def check_bgs_configuration
+    bgs_settings = SETTINGS['bgs']
+    
+    # Check if all required BGS settings in the settings.yml file are present
+    required_keys = %w[application client_station_id client_username log base_url]
+    missing_keys = required_keys.select { |key| bgs_settings[key].nil? || bgs_settings[key].to_s.empty? }
+    
+    if missing_keys.empty?
+      log "BGS configuration loaded successfully."
+      true
+    else
+      log "Missing BGS configuration keys: #{missing_keys.join(', ')}"
+      false
+    end
+  end
+  
+  def perform_startup_checks
+    bgs_config_ok = check_bgs_configuration
+    if bgs_config_ok
+      log "Startup probe checks passed!"
+      true
+    else
+      log "Startup probe checks failed!"
+      false
+    end
+  end
+ 
+  unless perform_startup_checks
+    exit(1)
+  end

--- a/svc-bgs-api/src/healthcheck/startup_script.rb
+++ b/svc-bgs-api/src/healthcheck/startup_script.rb
@@ -30,17 +30,17 @@ def check_bgs_configuration
     end
   end
   
-  def perform_startup_checks
-    bgs_config_ok = check_bgs_configuration
-    if bgs_config_ok
-      log "Startup probe checks passed!"
-      true
-    else
-      log "Startup probe checks failed!"
-      false
-    end
+def perform_startup_checks
+  bgs_config_ok = check_bgs_configuration
+  if bgs_config_ok
+    log "Startup probe checks passed!"
+    true
+  else
+    log "Startup probe checks failed!"
+    false
   end
+end
  
-  unless perform_startup_checks
-    exit(1)
-  end
+unless perform_startup_checks
+  exit(1)
+end

--- a/svc-bgs-api/src/lib/bgs_client.rb
+++ b/svc-bgs-api/src/lib/bgs_client.rb
@@ -81,14 +81,4 @@ class BgsClient
     participant_id ||= bgs.benefit_claims.find_bnft_claim(claim_id: claim_id)[:bnft_claim_dto][:ptcpnt_vet_id]
     bgs.notes.create_note(participant_id: participant_id, txt: note, user_id: vro_participant_id)
   end
-
-  # Method to check BGS service availability. It makes use of the vro_participant_id method to check if BGS service is 
-  # reachable and responding. This method should return a participant ID if the service is available.
-  def bgs_available?
-    participant_id = vro_participant_id
-    vro_participant_id.present?
-  rescue StandardError => e
-    puts "BGS-api availability check failed: #{e.message}"
-    false
-  end
 end


### PR DESCRIPTION
## What was the problem?
Implementing K8s Liveness and Readiness on BGS-api (Ruby application)

Associated tickets or Slack threads:
- #2417

## How does this fix it?[^1]
This configures K8s liveness, and readiness for svc-bgs-api to ensure highest level of visibility and reliability into the health and readiness of platform and partner team services. Also added a K8s startup probe to prevent liveness probe from failing prior to sv-bgs-api app is ready. 

## How to test this PR
- Locally:
        - Get into svc-bgs-api container on Docker Desktop and run the following commands:
        - To check Startup: **bundle exec ruby healthcheck/startup_script.rb**
        - To check Liveness: **bundle exec ruby healthcheck/liveness_script.rb**
        - To check readiness: **bundle exec ruby healthcheck/readiness_script.rb**
        - Stop RabbitMQ container and run these command again (the liveness and readiness probes will fail)
