### PR TITLE
Switched DogStatsD for datadog_api_client to submit metrics

### DIFF
--- a/domain-ee/docker-compose.yml
+++ b/domain-ee/docker-compose.yml
@@ -38,7 +38,8 @@ x-postgres-vars: &postgres-vars
   POSTGRES_SCHEMA: ${POSTGRES_SCHEMA}
 
 x-datadog-vars: &datadog-vars
-  DD_DOGSTATSD_DISABLE: ${DD_DOGSTATSD_DISABLE}
+  DD_SITE: ${DD_SITE}
+  DD_API_KEY: ${DD_API_KEY}
 
 services:
   # Containers with the `svc-` prefix are microservices to support domain workflows.

--- a/domain-ee/ee-ep-merge-app/src/python_src/api.py
+++ b/domain-ee/ee-ep-merge-app/src/python_src/api.py
@@ -5,7 +5,6 @@ from contextlib import asynccontextmanager
 from typing import Annotated
 from uuid import UUID, uuid4
 
-import util.metric_logger as metrics
 import uvicorn
 from fastapi import BackgroundTasks, FastAPI, HTTPException, Query, Request, status
 from fastapi.encoders import jsonable_encoder
@@ -37,7 +36,6 @@ async def lifespan(api: FastAPI):
 
 
 def on_start_up():
-    metrics.start()
     loop = asyncio.get_event_loop()
     loop.create_task(start_job_runner())
     loop.create_task(start_hoppy())
@@ -53,7 +51,6 @@ async def start_hoppy():
 
 async def on_shut_down():
     await HOPPY.stop_hoppy_clients()
-    metrics.stop()
 
 
 app = FastAPI(

--- a/domain-ee/ee-ep-merge-app/src/requirements.txt
+++ b/domain-ee/ee-ep-merge-app/src/requirements.txt
@@ -1,4 +1,4 @@
-datadog>=0.48
+datadog-api-client==2.22.*
 fastapi==0.109.*
 hoppy @ git+https://github.com/department-of-veterans-affairs/abd-vro.git@shared/lib-hoppy-0.6#subdirectory=shared/lib-hoppy
 httpx==0.24.*

--- a/domain-ee/ee-ep-merge-app/tests/service/conftest.py
+++ b/domain-ee/ee-ep-merge-app/tests/service/conftest.py
@@ -142,10 +142,10 @@ def assert_metrics_called(
 ):
 
     increment_calls = []
-    histogram_calls = [call(JOB_DURATION_METRIC, ANY)]
+    distribution_calls = [call(JOB_DURATION_METRIC, ANY)]
     if expected_completed_state == JobState.COMPLETED_SUCCESS:
         increment_calls.append(call(JOB_SUCCESS_METRIC))
-        histogram_calls.append(call(JOB_NEW_CONTENTIONS_METRIC, expected_new_contentions))
+        distribution_calls.append(call(JOB_NEW_CONTENTIONS_METRIC, expected_new_contentions))
         if expected_merge_skip:
             increment_calls.append(call(JOB_SKIPPED_MERGE_METRIC))
 
@@ -153,9 +153,9 @@ def assert_metrics_called(
         increment_calls.append(call(JOB_FAILURE_METRIC))
         increment_calls.append(call(f'{JOB_ERROR_METRIC_PREFIX}.{expected_error_state}'))
         if expected_error_state in ERROR_STATES_TO_LOG_METRICS:
-            histogram_calls.append(call(JOB_NEW_CONTENTIONS_METRIC, expected_new_contentions))
+            distribution_calls.append(call(JOB_NEW_CONTENTIONS_METRIC, expected_new_contentions))
             if expected_merge_skip:
                 increment_calls.append(call(JOB_SKIPPED_MERGE_METRIC))
 
     metric_logger_increment.assert_has_calls(increment_calls)
-    metric_logger_distribution.assert_has_calls(histogram_calls)
+    metric_logger_distribution.assert_has_calls(distribution_calls)


### PR DESCRIPTION
<!-- Ensure the PR title reflects the feature or bug name -->

## What was the problem?
<!-- brief description of how things worked before this PR -->
DogStatsD is not supported by LHDI infrastructure due to security concerns.

Associated tickets or Slack threads:
- [slack](https://dsva.slack.com/archives/C03UA9MV1EH/p1707342096814809)

## How does this fix it?[^1]
<!-- description of how things will work after this PR -->
This switches out the implementation for metric logging to use Datadog REST API instead of the python DogStatsD.

## How to test this PR
- pull code
- Unit Test:
  - from /domain-ee/ee-ep-merge-app run pytest
- Integration Tests:
  - run [base platform](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Docker-Compose#platform-base)
  - from /domain-ee/ee-ep-merge-app run pytest ./integration
- End to End tests:
  - run this [CI](https://github.com/department-of-veterans-affairs/abd-vro/actions/workflows/ee-ep-merge-end-to-end.yml) action to verify successful integration test
  - run end to end tests locally:
    - `export BIP_CLAIM_URL=mock-bip-claims-api:20300`
    - run bgs and bip services and mocks:
      - `COMPOSE_PROFILES="bip,bgs" ./gradlew :app:dockerComposeUp`
      - `COMPOSE_PROFILES="bip,bgs" ./gradlew -p mocks :dockerComposeUp`
    - `./gradlew :domain-ee:ee-ep-merge-app:endToEndTest`




[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
