### PR TITLE
remove old log statements, same info is captured in log_claim_stats()

### DIFF
--- a/domain-cc/cc-app/src/python_src/api.py
+++ b/domain-cc/cc-app/src/python_src/api.py
@@ -112,23 +112,12 @@ def log_claim_stats(claim: Claim, classification: Optional[PredictedClassificati
 
 @app.post("/classifier")
 def get_classification(claim: Claim) -> Optional[PredictedClassification]:
-    log_as_json(
-        {
-            "claim_id": sanitize_log(claim.claim_id),
-            "form526_submission_id": sanitize_log(claim.form526_submission_id),
-        }
-    )
     classification_code = None
     if claim.claim_type == "claim_for_increase":
         classification_code = dc_lookup_table.get(claim.diagnostic_code, None)
 
     if claim.contention_text and not classification_code:
         classification_code = dropdown_lookup_table.get(claim.contention_text, None)
-
-    if claim.claim_type == "new":
-        log_lookup_table_match(classification_code, claim.contention_text)
-    else:
-        log_as_json({"diagnostic code": sanitize_log(claim.diagnostic_code)})
 
     if classification_code:
         classification_name = get_classification_name(classification_code)
@@ -139,7 +128,6 @@ def get_classification(claim: Claim) -> Optional[PredictedClassification]:
     else:
         classification = None
 
-    log_as_json({"classification": classification})
     log_claim_stats(
         claim, PredictedClassification(**classification) if classification else None
     )


### PR DESCRIPTION
<!-- Ensure the PR title reflects the feature or bug name -->

## What was the problem?
<!-- brief description of how things worked before this PR -->
Clean up old logging statements. Previously, individual log statements were used for dashboard, but have switched to logging all the info in single statement `log_claim_stats()`

Associated tickets or Slack threads:
- https://app.zenhub.com/workspaces/contention-classification-640a24db5dcd08457cebbc79/issues/gh/department-of-veterans-affairs/vagov-claim-classification/351

## How does this fix it?[^1]
<!-- description of how things will work after this PR -->

## How to test this PR
- run cc-app locally
- make POST to `http://localhost:8120/classifier`
- observe logs


[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
