### PR TITLE
#2582 Another round of datadog env vars

### DIFF
--- a/helm/_shared/named_templates/_datadog.tpl
+++ b/helm/_shared/named_templates/_datadog.tpl
@@ -3,14 +3,19 @@
 */}}
 
 {{- define "vro.datadog.envVars" -}}
-- name: DATADOG_API_KEY
+- name: DD_SITE
   valueFrom:
     secretKeyRef:
       name: vro-datadog
-      key: DATADOG_API_KEY
-- name: DATADOG_API_KEY_ID
+      key: DD_SITE
+- name: DD_API_KEY
   valueFrom:
     secretKeyRef:
       name: vro-datadog
-      key: DATADOG_API_KEY_ID
+      key: DD_API_KEY
+- name: DD_APP_KEY
+  valueFrom:
+    secretKeyRef:
+      name: vro-datadog
+      key: DD_APP_KEY
 {{- end }}

--- a/scripts/set-datadog-secret.sh
+++ b/scripts/set-datadog-secret.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# Adds details needed for datadog api.
+# Script expects to be executed from the repository's root directory
+# abd_vro> ./scripts/set-datadog-secret.sh TARGET_ENV DATADOG_API_KEY DATADOG_API_KEY_ID
+
+# https://github.com/DataDog/datadog-api-client-python/blob/4f81d425324d7719fc5ee7a56c7e4bae0f3f848f/src/datadog_api_client/configuration.py#L175
+# based on DataDog Python api client we need the following environment variables populated:
+# * DD_SITE (see datadog python api client - https://github.com/DataDog/datadog-api-client-python/blob/4f81d425324d7719fc5ee7a56c7e4bae0f3f848f/src/datadog_api_client/configuration.py#L175)
+# * DD_API_KEY (see DATADOG_API_KEY in vault)
+# * DD_APP_KEY (see DATADOG_API_KEY_ID in vault)
+
+if [[ -z "$1" || -z "$2" || -z "$3" ]]; then
+  echo "Usage: $0 \"<TARGET_ENV>\" \"<paste DATADOG_API_KEY>\" \"<paste DATADOG_API_KEY_ID>\""
+  exit 1
+fi
+
+: "${TARGET_ENV:=$1}"
+: "${DD_SITE:=https://api.ddog-gov.com}"
+: "${DD_API_KEY:=$2}"
+: "${DD_APP_KEY:=$3}"
+
+DD_SITE="$(echo -n "$DD_SITE" | base64)"
+DD_API_KEY="$(echo -n "$DD_API_KEY" | base64)"
+DD_APP_KEY="$(echo -n "$DD_APP_KEY" | base64)"
+
+case "${TARGET_ENV}" in
+  dev|qa|sandbox) choice="y"; echo "Executing $0 for env: $TARGET_ENV";;
+  prod-test|prod) read -rp "Executing $0 for env: $TARGET_ENV Please Confirm (y/n)?" choice;;
+  *)  echo "Unknown TARGET_ENV: $TARGET_ENV"
+      exit 3
+      ;;
+esac
+
+
+case "$choice" in
+    y|Y ) echo "$TARGET_ENV confirmed: yes";;
+    * ) echo "$TARGET_ENV was not confirmed"
+        exit 4
+        ;;
+esac
+
+SECRET_MAP="
+  DD_SITE: \"$DD_SITE\"
+  DD_API_KEY: \"$DD_API_KEY\"
+  DD_APP_KEY: \"$DD_APP_KEY\"
+"
+./scripts/echo-secret-yaml.sh "vro-datadog" "$SECRET_MAP" | \
+  kubectl -n "va-abd-rrd-$TARGET_ENV" replace --force -f -


### PR DESCRIPTION
Applying updated environment variables in support of datadog python api client naming expectations. [datadog_api_client/configuration.py](https://github.com/DataDog/datadog-api-client-python/blob/4f81d425324d7719fc5ee7a56c7e4bae0f3f848f/src/datadog_api_client/configuration.py#L175)

Includes a new script for populating the vro-datadog secret, with support for TARGET_ENV. The script expects to be executed from the repository's root directory
```sh 
abd_vro> ./scripts/set-datadog-secret.sh TARGET_ENV DATADOG_API_KEY DATADOG_API_KEY_ID
```

## What was the problem?
Environment variables did not match what the datadog python api client expects.

Associated tickets or Slack threads:
- #2582
- #2618 - just stumbled onto this ticket, a well documented change request for this PR

## How does this fix it?[^1]
We are now setting DD_SITE, DD_API_KEY and DD_APP_KEY as the python client expects.

## How to test this PR
- Run the deployment and validate that helm populates the datadog variables with the vro-datadog secret.


[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
