### PR TITLE
#320 upgrading libexpat and libgcrypt based on the SecRel failures linked in

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -3,7 +3,7 @@ FROM eclipse-temurin:17-jre-alpine
 # hadolint ignore=DL3018
 RUN apk update && \
     apk --no-cache add curl redis sudo && \
-    apk upgrade openssl libssl3 libcrypto3 && \
+    apk upgrade openssl libssl3 libcrypto3 libexpat && \
     rm -rf /var/cache/apk/*
 
 WORKDIR /app

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -2,8 +2,9 @@ FROM eclipse-temurin:17-jre-alpine
 
 # hadolint ignore=DL3018
 RUN apk update && \
-    apk --no-cache add curl redis sudo && \
-    apk upgrade openssl libssl3 libcrypto3 libexpat && \
+    apk --no-cache add curl redis sudo gcompat && \
+    apk search libgcrypt && \
+    apk upgrade openssl libssl3 libcrypto3 libexpat libgcrypt && \
     rm -rf /var/cache/apk/*
 
 WORKDIR /app

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -3,7 +3,6 @@ FROM eclipse-temurin:17-jre-alpine
 # hadolint ignore=DL3018
 RUN apk update && \
     apk --no-cache add curl redis sudo gcompat && \
-    apk search libgcrypt && \
     apk upgrade openssl libssl3 libcrypto3 libexpat libgcrypt && \
     rm -rf /var/cache/apk/*
 


### PR DESCRIPTION
## What was the problem?
SecRel pipeline failures reference required updates to libexpat and libgnutls30.

Associated tickets or Slack threads:
- #320

## How does this fix it?[^1]
libexpat was updatable directly, so that update was applied in the first commit.  libgnutls30 on the other hand I can't find a more direct package name to update.  The addition of gcompat and inclusion of libgcrypt in the update line are aimed at updating libgnutls30 indirectly.

## How to test this PR
- Attempt to build another release version and monitor secrel pipeline for failures


[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
