### PR TITLE
Reference gradle github actions according to the action's repository

### DIFF
--- a/.github/actions/setup-vro/action.yml
+++ b/.github/actions/setup-vro/action.yml
@@ -16,14 +16,14 @@ runs:
         # cache: 'gradle'
 
     - name: "Setup Gradle"
-      uses: gradle/gradle-build-action@v2
+      uses: gradle/actions/setup-gradle@v3
       with:
         # Only write to the cache for builds on the 'main' and 'develop' branches. (Default is 'main' only.)
         # Builds on other branches will only read existing entries from the cache.
         cache-read-only: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/qa' && github.ref != 'refs/heads/develop' }}
         # To avoid a growing cache over time, attempt to delete any files in the Gradle User Home
         # that were not used by Gradle during the workflow, prior to saving the cache.
-        # https://github.com/gradle/gradle-build-action#removing-unused-files-from-gradle-user-home-before-saving-to-cache
+        # https://github.com/gradle/actions/setup-gradle@v3#removing-unused-files-from-gradle-user-home-before-saving-to-cache
         gradle-home-cache-cleanup: true
 
     - uses: ./.github/actions/install-java-tools

--- a/.github/workflows/create-release-tag.yml
+++ b/.github/workflows/create-release-tag.yml
@@ -27,14 +27,14 @@ jobs:
           # cache the Gradle User Home"
           # cache: 'gradle'
       - name: "Setup Gradle"
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/actions/setup-gradle@v3
         with:
           # Only write to the cache for builds on the 'main' and 'develop' branches. (Default is 'main' only.)
           # Builds on other branches will only read existing entries from the cache.
           cache-read-only: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/qa' && github.ref != 'refs/heads/develop' }}
           # To avoid a growing cache over time, attempt to delete any files in the Gradle User Home
           # that were not used by Gradle during the workflow, prior to saving the cache.
-          # https://github.com/gradle/gradle-build-action#removing-unused-files-from-gradle-user-home-before-saving-to-cache
+          # https://github.com/gradle/actions/setup-gradle@v3#removing-unused-files-from-gradle-user-home-before-saving-to-cache
           gradle-home-cache-cleanup: true
       - name: "Checkout source code"
         uses: actions/checkout@v3

--- a/.github/workflows/lint-gradle-files.yml
+++ b/.github/workflows/lint-gradle-files.yml
@@ -23,14 +23,14 @@ jobs:
           # cache the Gradle User Home"
           # cache: 'gradle'
       - name: "Setup Gradle"
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/actions/setup-gradle@v3
         with:
           # Only write to the cache for builds on the 'main' and 'develop' branches. (Default is 'main' only.)
           # Builds on other branches will only read existing entries from the cache.
           cache-read-only: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/qa' && github.ref != 'refs/heads/develop' }}
           # To avoid a growing cache over time, attempt to delete any files in the Gradle User Home
           # that were not used by Gradle during the workflow, prior to saving the cache.
-          # https://github.com/gradle/gradle-build-action#removing-unused-files-from-gradle-user-home-before-saving-to-cache
+          # https://github.com/gradle/actions/setup-gradle@v3#removing-unused-files-from-gradle-user-home-before-saving-to-cache
           gradle-home-cache-cleanup: true
       - name: "Lint Gradle files"
         run: ./gradlew lintGradle


### PR DESCRIPTION
## What was the problem?

Recent CodeQL Policy Changes have Caused our [github action: gradle-build-action ](https://github.com/department-of-veterans-affairs/abd-vro-internal/security/dependabot/11#Remediation) to start failing SecRel.  These alerts have been sitting in out code scanning results contributing to our overall remediation completion of 79%.  Since these have been our only outstanding remediations, it has not been a problem.  However the [Feb 15th 2024 Policy change](https://github.com/orgs/department-of-veterans-affairs/discussions/5) from VA management has caused the notice of this github action upgrade to become required. 

The github action repository to upgrade is here: 
https://github.com/gradle/gradle-build-action

The readme.md of the repository link above clarifies exactly what needs to change.

Associated tickets or Slack threads:
- #[2632](https://app.zenhub.com/workspaces/vro-team-6557e67173391c000e1409f3/issues/gh/department-of-veterans-affairs/abd-vro/2632)

## How does this fix it?[^1]
We reference the gradle github action in three places throughout our github action workflows. All three have been patched according to the upgrade clarification provided in the gradle github action.

## How to test this PR
- Ensure the CodeQL errors are resolved in the Secrel scans that trigger based on this PR


[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
