### PR TITLE
Upgrade Libxml2 package to version 2.11.7-r0 or above

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,11 +1,8 @@
 FROM eclipse-temurin:17-jre-alpine
 
 # hadolint ignore=DL3018
-RUN apk update && \
-    apk --no-cache add curl redis sudo gcompat && \
-    apk upgrade --available && \
-    apk add libxml2=2.11.7-r0 && \
-    rm -rf /var/cache/apk/*
+RUN apk add --no-cache curl redis sudo gcompat libxml2=2.11.7-r0 && \
+    apk upgrade --available 
 
 WORKDIR /app
 COPY set-env-secrets.src entrypoint-wrapper.sh docker-entry*.sh ./

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,7 +1,7 @@
 FROM eclipse-temurin:17-jre-alpine
 
 # hadolint ignore=DL3018
-RUN apk add --no-cache curl redis sudo gcompat libxml2=2.11.7-r0 && \
+RUN apk add --no-cache curl redis sudo gcompat libxml2 && \
     apk upgrade --available 
 
 WORKDIR /app

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -4,6 +4,7 @@ FROM eclipse-temurin:17-jre-alpine
 RUN apk update && \
     apk --no-cache add curl redis sudo gcompat && \
     apk upgrade --available && \
+    apk add libxml2=2.11.7-r0 && \
     rm -rf /var/cache/apk/*
 
 WORKDIR /app

--- a/gradle-plugins/src/main/resources/docker/Dockerfile-java
+++ b/gradle-plugins/src/main/resources/docker/Dockerfile-java
@@ -6,7 +6,7 @@ FROM eclipse-temurin:17-jre-alpine
 
 # curl is needed for HEALTHCHECK
 # hadolint ignore=DL3018
-RUN apk add --no-cache curl redis sudo gcompat libxml2=2.11.7-r0 && \
+RUN apk add --no-cache curl redis sudo gcompat libxml2 && \
     apk upgrade --available
 
 WORKDIR /app

--- a/gradle-plugins/src/main/resources/docker/Dockerfile-java
+++ b/gradle-plugins/src/main/resources/docker/Dockerfile-java
@@ -9,6 +9,7 @@ FROM eclipse-temurin:17-jre-alpine
 RUN apk update && \
     apk --no-cache add curl redis sudo gcompat && \
     apk upgrade --available && \
+    apk add libxml2=2.11.7-r0 && \
     rm -rf /var/cache/apk/*
 
 WORKDIR /app

--- a/gradle-plugins/src/main/resources/docker/Dockerfile-java
+++ b/gradle-plugins/src/main/resources/docker/Dockerfile-java
@@ -6,11 +6,8 @@ FROM eclipse-temurin:17-jre-alpine
 
 # curl is needed for HEALTHCHECK
 # hadolint ignore=DL3018
-RUN apk update && \
-    apk --no-cache add curl redis sudo gcompat && \
+RUN apk add --no-cache curl redis sudo gcompat libxml2=2.11.7-r0 && \
     apk upgrade --available && \
-    apk add libxml2=2.11.7-r0 && \
-    rm -rf /var/cache/apk/*
 
 WORKDIR /app
 

--- a/gradle-plugins/src/main/resources/docker/Dockerfile-java
+++ b/gradle-plugins/src/main/resources/docker/Dockerfile-java
@@ -7,7 +7,7 @@ FROM eclipse-temurin:17-jre-alpine
 # curl is needed for HEALTHCHECK
 # hadolint ignore=DL3018
 RUN apk add --no-cache curl redis sudo gcompat libxml2=2.11.7-r0 && \
-    apk upgrade --available && \
+    apk upgrade --available
 
 WORKDIR /app
 


### PR DESCRIPTION
##What was the problem?
During a recent Secrel run, a vulnerability with high severity came up and the remediation was to upgrade Libxml2 package to version 2.11.7-r0 or above. 

##How to test this PR
- Validate the results of a Secrel run