### PR TITLE
Further reduce rabbitmq free disk space limit

### DIFF
--- a/rabbitmq/src/main/resources/rabbitmq.conf
+++ b/rabbitmq/src/main/resources/rabbitmq.conf
@@ -22,4 +22,4 @@ loopback_users.user = false
 
 ## Resource limits
 # Set a free disk space limit relative to total available RAM
-disk_free_limit.absolute = 10GB
+disk_free_limit.absolute = 5GB


### PR DESCRIPTION
After reviewing the failed integration test PRs, I discovered that RabbitMQ is still facing 'out of disk space' warnings in the GitHub Actions artifact logs. The Bitnami images are configured by default to use disk space equivalent to the host machine's total memory, which is 16G in this case. Despite having previously set the limit to 10G, assuming it would be adequate, it proved to be excessive. As a result, RabbitMQ in the integration tests continued to encounter disk space issues, blocking any incoming messages. This led to failures caused by prolonged waiting times and timeouts.
