### PR TITLE
Reduce RabbitMQ free disk space limit to 1G

### DIFF
--- a/rabbitmq/src/main/resources/rabbitmq.conf
+++ b/rabbitmq/src/main/resources/rabbitmq.conf
@@ -22,4 +22,4 @@ loopback_users.user = false
 
 ## Resource limits
 # Set a free disk space limit relative to total available RAM
-disk_free_limit.absolute = 5GB
+disk_free_limit.absolute = 1GB


### PR DESCRIPTION
Lower the RabbitMQ free disk space limit to 1G to minimize the risk of integration failures and client connection issues caused by RabbitMQ running out of storage.