### PR TITLE
Add templates and entities for installing DestinationRules in Helm

### DIFF
--- a/helm/_shared/named_templates/_destinationrule.tpl
+++ b/helm/_shared/named_templates/_destinationrule.tpl
@@ -1,0 +1,16 @@
+# See the wiki page at https://github.com/department-of-veterans-affairs/abd-vro/wiki/DestinationRule-for-Preventing-Forced-HTTP2-Upgrade
+# for context on why this is needed
+
+{{- define "vro.destinationrule" -}}
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: http-{{ .Values.serviceNameSuffix }}
+  namespace: va-abd-rrd-{{.Values.global.environment}}
+spec:
+  host: {{ .Values.global.hostnamePrefix }}-{{ .Values.serviceNameSuffix }}.va-abd-rrd-{{.Values.global.environment}}.svc.cluster.local
+  trafficPolicy:
+    connectionPool:
+      http:
+        h2UpgradePolicy: "DO_NOT_UPGRADE"
+{{- end }}

--- a/helm/api-gateway/templates/destination-rule.yaml
+++ b/helm/api-gateway/templates/destination-rule.yaml
@@ -1,1 +1,1 @@
-{{- include "vro.destinationrule"}}
+{{- include "vro.destinationrule" .}}

--- a/helm/api-gateway/templates/destination-rule.yaml
+++ b/helm/api-gateway/templates/destination-rule.yaml
@@ -1,0 +1,1 @@
+{{- include "vro.destinationrule"}}

--- a/helm/api-gateway/templates/destination-rule.yaml
+++ b/helm/api-gateway/templates/destination-rule.yaml
@@ -1,1 +1,1 @@
-{{- include "vro.destinationrule" .}}
+{{ include "vro.destinationrule" .}}

--- a/helm/api-gateway/templates/destination-rule.yaml
+++ b/helm/api-gateway/templates/destination-rule.yaml
@@ -1,1 +1,1 @@
-{{ include "vro.destinationrule" .}}
+{{ include "vro.destinationrule" . }}

--- a/helm/api-gateway/templates/service.yaml
+++ b/helm/api-gateway/templates/service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   # name is used as the hostname of the service
-  name: {{ .Values.global.hostnamePrefix }}-api-gateway
+  name: {{ .Values.global.hostnamePrefix }}-{{ .Values.serviceNameSuffix }}
   labels: {{- toYaml .Values.labels | nindent 4 }}
 spec:
   type: ClusterIP

--- a/helm/api-gateway/values.yaml
+++ b/helm/api-gateway/values.yaml
@@ -9,6 +9,8 @@ replicaCount: 1
 
 serviceUriPrefix: abd-vro
 
+serviceNameSuffix: api-gateway
+
 ports:
   - name: liveness
     containerPort: 8061

--- a/helm/domain-cc/templates/destination-rule.yaml
+++ b/helm/domain-cc/templates/destination-rule.yaml
@@ -1,1 +1,1 @@
-{{- include "vro.destinationrule"}}
+{{- include "vro.destinationrule" .}}

--- a/helm/domain-cc/templates/destination-rule.yaml
+++ b/helm/domain-cc/templates/destination-rule.yaml
@@ -1,0 +1,1 @@
+{{- include "vro.destinationrule"}}

--- a/helm/domain-cc/templates/service.yaml
+++ b/helm/domain-cc/templates/service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   # name is used as the hostname of the service
-  name: {{ .Values.global.hostnamePrefix }}-cc-app
+  name: {{ .Values.global.hostnamePrefix }}-{{ .Values.serviceNameSuffix }}
   labels: {{- toYaml .Values.labels | nindent 4 }}
 spec:
   type: ClusterIP

--- a/helm/domain-cc/values.yaml
+++ b/helm/domain-cc/values.yaml
@@ -3,6 +3,8 @@ labels:
 
 serviceUriPrefix: contention-classification
 
+serviceNameSuffix: cc-app
+
 replicaCount: 1
 
 # autoscaling:

--- a/helm/domain-ee-ep-merge-app/templates/destination-rule.yaml
+++ b/helm/domain-ee-ep-merge-app/templates/destination-rule.yaml
@@ -1,1 +1,1 @@
-{{- include "vro.destinationrule"}}
+{{- include "vro.destinationrule" .}}

--- a/helm/domain-ee-ep-merge-app/templates/destination-rule.yaml
+++ b/helm/domain-ee-ep-merge-app/templates/destination-rule.yaml
@@ -1,0 +1,1 @@
+{{- include "vro.destinationrule"}}

--- a/helm/domain-ee-ep-merge-app/templates/service.yaml
+++ b/helm/domain-ee-ep-merge-app/templates/service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   # name is used as the hostname of the service
-  name: {{ .Values.global.hostnamePrefix }}-ee-ep-merge-app
+  name: {{ .Values.global.hostnamePrefix }}-{{ .Values.serviceNameSuffix }}
   labels: {{- toYaml .Values.labels | nindent 4 }}
 spec:
   type: ClusterIP

--- a/helm/domain-ee-ep-merge-app/values.yaml
+++ b/helm/domain-ee-ep-merge-app/values.yaml
@@ -3,6 +3,8 @@ labels:
 
 serviceUriPrefix: employee-experience-ep-merge-app
 
+serviceNameSuffix: ee-ep-merge-app
+
 replicaCount: 1
 
 # autoscaling:

--- a/helm/domain-ee-max-cfi-app/templates/destination-rule.yaml
+++ b/helm/domain-ee-max-cfi-app/templates/destination-rule.yaml
@@ -1,0 +1,1 @@
+{{- include "vro.destinationrule"}}

--- a/helm/domain-ee-max-cfi-app/templates/destination-rule.yaml
+++ b/helm/domain-ee-max-cfi-app/templates/destination-rule.yaml
@@ -1,1 +1,1 @@
-{{- include "vro.destinationrule"}}
+{{- include "vro.destinationrule" . }}

--- a/helm/domain-ee-max-cfi-app/templates/service.yaml
+++ b/helm/domain-ee-max-cfi-app/templates/service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   # name is used as the hostname of the service
-  name: {{ .Values.global.hostnamePrefix }}-ee-max-cfi-app
+  name: {{ .Values.global.hostnamePrefix }}-{{ .Values.serviceNameSuffix }}
   labels: {{- toYaml .Values.labels | nindent 4 }}
 spec:
   type: ClusterIP

--- a/helm/domain-ee-max-cfi-app/values.yaml
+++ b/helm/domain-ee-max-cfi-app/values.yaml
@@ -3,6 +3,8 @@ labels:
 
 serviceUriPrefix: employee-experience
 
+serviceNameSuffix: ee-max-cfi-app
+
 replicaCount: 1
 
 # autoscaling:

--- a/helm/platform/charts/rabbitmq/templates/destination-rule.yaml
+++ b/helm/platform/charts/rabbitmq/templates/destination-rule.yaml
@@ -1,1 +1,1 @@
-{{- include "vro.destinationrule"}}
+{{- include "vro.destinationrule" .}}

--- a/helm/platform/charts/rabbitmq/templates/destination-rule.yaml
+++ b/helm/platform/charts/rabbitmq/templates/destination-rule.yaml
@@ -1,0 +1,1 @@
+{{- include "vro.destinationrule"}}

--- a/helm/platform/charts/rabbitmq/templates/service.yaml
+++ b/helm/platform/charts/rabbitmq/templates/service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   # name is used as the hostname of the service
-  name: {{ .Values.global.hostnamePrefix }}-rabbitmq
+  name: {{ .Values.global.hostnamePrefix }}-{{.Values.serviceNameSuffix}}
   labels: {{- toYaml .Values.labels | nindent 4 }}
 spec:
   type: ClusterIP

--- a/helm/platform/charts/rabbitmq/values.yaml
+++ b/helm/platform/charts/rabbitmq/values.yaml
@@ -5,6 +5,8 @@ labels:
 
 imageTag: "latest"
 
+serviceNameSuffix: rabbitmq
+
 replicaCount: 1
 
 service:

--- a/helm/platform/charts/redis/templates/destination-rule.yaml
+++ b/helm/platform/charts/redis/templates/destination-rule.yaml
@@ -1,1 +1,1 @@
-{{- include "vro.destinationrule"}}
+{{- include "vro.destinationrule" .}}

--- a/helm/platform/charts/redis/templates/destination-rule.yaml
+++ b/helm/platform/charts/redis/templates/destination-rule.yaml
@@ -1,0 +1,1 @@
+{{- include "vro.destinationrule"}}

--- a/helm/platform/charts/redis/templates/service.yaml
+++ b/helm/platform/charts/redis/templates/service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   # name is used as the hostname of the service
-  name: {{ .Values.global.hostnamePrefix }}-redis
+  name: {{ .Values.global.hostnamePrefix }}-{{ .Values.serviceNameSuffix }}
   labels: {{- toYaml .Values.labels | nindent 4 }}
 spec:
   type: ClusterIP

--- a/helm/platform/charts/redis/values.yaml
+++ b/helm/platform/charts/redis/values.yaml
@@ -5,6 +5,8 @@ labels:
 
 imageTag: "latest"
 
+serviceNameSuffix: redis
+
 replicaCount: 1
 
 service:

--- a/helm/vro-app/templates/destination-rule.yaml
+++ b/helm/vro-app/templates/destination-rule.yaml
@@ -1,1 +1,1 @@
-{{- include "vro.destinationrule"}}
+{{- include "vro.destinationrule" .}}

--- a/helm/vro-app/templates/destination-rule.yaml
+++ b/helm/vro-app/templates/destination-rule.yaml
@@ -1,0 +1,1 @@
+{{- include "vro.destinationrule"}}

--- a/helm/vro-app/templates/service.yaml
+++ b/helm/vro-app/templates/service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   # name is used as the hostname of the service
-  name: {{ .Values.global.hostnamePrefix }}-app
+  name: {{ .Values.global.hostnamePrefix }}-{{ .Values.serviceNameSuffix }}
   labels: {{- toYaml .Values.labels | nindent 4 }}
 spec:
   type: ClusterIP

--- a/helm/vro-app/values.yaml
+++ b/helm/vro-app/values.yaml
@@ -8,6 +8,8 @@ replicaCount: 1
 
 serviceUriPrefix: vro-app
 
+serviceNameSuffix: app
+
 service:
   app:
     sourcePort: 8110


### PR DESCRIPTION
<!-- Ensure the PR title reflects the feature or bug name -->

## What was the problem?
<!-- brief description of how things worked before this PR -->
LHDI has had instances where there were sporadic forced upgrades to HTTP2 protocol for traffic in the service mesh. There are currently no guarantees made by LHDI in place that this will not happen again, requiring installation of DestinationRules in order to avoid forced upgrades for our application that expose a service to the mesh. 

Associated tickets or Slack threads:
- #2557 

## How does this fix it?[^1]
<!-- description of how things will work after this PR -->
Creates new shared Helm template along with a few new variables and installs it alongside the affected application

## How to test this PR
- Run a deployment of the affected applications in a lower environment and confirm that the DestinationRule entities are successfully installed.


[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
