### PR TITLE
Minor camel upgrade is referenced as resolution on snyk failures

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ taskinfo.disableSafeguard=true
 # 3.11.0 uses spring_boot 2.5.3
 # 3.12.0 uses spring_boot 2.5.5
 # 3.13 through 3.15 are not compatible with va.starter's spring_boot version
-camel_version=4.1.0
+camel_version=4.4.0
 
 h2_version=2.2.224
 hibernate_types_version=3.5.2


### PR DESCRIPTION

## What was the problem?
SecRel failures in Snyk gate check: https://github.com/department-of-veterans-affairs/abd-vro-internal/security/code-scanning/1732

Associated tickets or Slack threads:
- [code-scanning](https://github.com/department-of-veterans-affairs/abd-vro-internal/security/code-scanning/1732)

## How does this fix it?[^1]
Upgrades camel to the patched version referenced in the recommended remediation.

## How to test this PR
* When validating the update, we want to ensure that we ./gradlew clean and dockerPrune* to ensure that you are indeed picking up the modified version number.  I ran through some bip functionality that is still fresh on my mind. Ultimately if the projects all build, the processes all start, and you can still successfully invoke bip operations, a minor version upgrade is nothing to fear. 


[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
