### PR TITLE
Applies a BGS gem swap on the Rack library

### DIFF
--- a/svc-bgs-api/src/Gemfile.lock
+++ b/svc-bgs-api/src/Gemfile.lock
@@ -22,6 +22,7 @@ GEM
       gyoku (>= 0.4.0)
       nokogiri
     amq-protocol (2.3.2)
+    base64 (0.2.0)
     builder (3.2.4)
     bunny (2.22.0)
       amq-protocol (~> 2.3, >= 2.3.1)
@@ -34,8 +35,11 @@ GEM
       builder (>= 2.1.2)
       rexml (~> 3.0)
     httpclient (2.8.3)
-    httpi (3.0.1)
-      rack
+    httpi (3.0.2)
+      base64
+      mutex_m
+      nkf
+      rack (< 3)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
     mail (2.8.1)
@@ -46,6 +50,7 @@ GEM
     mini_mime (1.1.5)
     mini_portile2 (2.8.5)
     minitest (5.20.0)
+    mutex_m (0.2.0)
     net-imap (0.4.9.1)
       date
       net-protocol
@@ -55,6 +60,7 @@ GEM
       timeout
     net-smtp (0.4.0.1)
       net-protocol
+    nkf (0.2.0)
     nokogiri (1.16.2)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
@@ -65,7 +71,7 @@ GEM
     nori (2.6.0)
     public_suffix (5.0.4)
     racc (1.7.3)
-    rack (3.0.8)
+    rack (2.2.8.1)
     rbtree (0.4.6)
     rexml (3.2.6)
     rspec (3.12.0)
@@ -119,4 +125,4 @@ RUBY VERSION
    ruby 3.3.0p0
 
 BUNDLED WITH
-   2.5.4
+   2.5.3


### PR DESCRIPTION
A high severity secrel failure highlighted in [code-scanning-1731](https://github.com/department-of-veterans-affairs/abd-vro-internal/security/code-scanning/1731) identifies the rack dependency of the BGS service as vulnerable. After some bundling commands, I landed on this version of the Gemfile.lock, which seems to avoid the vulnerability, offering a low impact change that still resolves snyk failure

## How to test this PR
- Monitor secrel runs that include this gemfile change.


[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
