### PR TITLE
Upgrade github action versions

### DIFF
--- a/.github/actions/install-java-tools/action.yml
+++ b/.github/actions/install-java-tools/action.yml
@@ -11,7 +11,7 @@ runs:
       shell: bash
 
     - name: Restore hadolint
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: cache-hadolint
       with:
         path: /usr/local/bin/hadolint

--- a/.github/actions/publish-images/action.yml
+++ b/.github/actions/publish-images/action.yml
@@ -44,7 +44,7 @@ runs:
       run: ./gradlew check
 
     - name: "Login to GitHub Container Registry"
-      uses: docker/login-action@v2.1.0
+      uses: docker/login-action@v3.0.0
       with:
         registry: ghcr.io
         username: ${{ inputs.ghcr_username }}

--- a/.github/actions/setup-vro/action.yml
+++ b/.github/actions/setup-vro/action.yml
@@ -29,7 +29,7 @@ runs:
     - uses: ./.github/actions/install-java-tools
 
     - name: "Install Python"
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: "3.10"
         cache: "pip"

--- a/.github/workflows/api-gateway-integration-test.yml
+++ b/.github/workflows/api-gateway-integration-test.yml
@@ -151,7 +151,7 @@ jobs:
           dest: './api-gw-itest-container-logs'
       - name: "Upload artifact"
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: api-gw-itest-container-logs
           path: ./api-gw-itest-container-logs/**

--- a/.github/workflows/bie-kafka-end2end-test.yml
+++ b/.github/workflows/bie-kafka-end2end-test.yml
@@ -154,7 +154,7 @@ jobs:
 
       - name: "Upload artifact"
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: bie-kafka-end2end-test-with-mock-container-logs
           path: ./bie-kafka-end2end-test-with-mock-container-logs/**

--- a/.github/workflows/container-healthchecks.yml
+++ b/.github/workflows/container-healthchecks.yml
@@ -116,7 +116,7 @@ jobs:
           dest: './healthchecks-container-logs'
       - name: "Upload artifact"
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: healthchecks-container-logs
           path: ./healthchecks-container-logs/**

--- a/.github/workflows/delete-old-releases.yml
+++ b/.github/workflows/delete-old-releases.yml
@@ -65,7 +65,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: "Delete old releases in GHCR"
-      uses: yoomlam/delete-older-releases@v0.3.0
+      uses: yoomlam/delete-older-releases@v0.3.2
       with:
         dry_run: ${{ inputs.dry_run || false }}
         delete_tags: true

--- a/.github/workflows/delete-published-dev-images.yml
+++ b/.github/workflows/delete-published-dev-images.yml
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: "Delete old images in GHCR"
-      uses: vlaurin/action-ghcr-prune@v0.5.0
+      uses: vlaurin/action-ghcr-prune@v0.6.0
       with:
         token: ${{ secrets.ACCESS_TOKEN_DELETE_PACKAGE }}
         organization: department-of-veterans-affairs

--- a/.github/workflows/delete-published-images.yml
+++ b/.github/workflows/delete-published-images.yml
@@ -80,7 +80,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: "Delete old images in GHCR"
-      uses: vlaurin/action-ghcr-prune@v0.5.0
+      uses: vlaurin/action-ghcr-prune@v0.6.0
       with:
         token: ${{ secrets.ACCESS_TOKEN_DELETE_PACKAGE }}
         organization: department-of-veterans-affairs

--- a/.github/workflows/deploy-secrets.yml
+++ b/.github/workflows/deploy-secrets.yml
@@ -61,7 +61,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Login to GitHub Container Registry"
-        uses: docker/login-action@v2.1.0
+        uses: docker/login-action@v3.0.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/machine-user-active.yml
+++ b/.github/workflows/machine-user-active.yml
@@ -17,7 +17,7 @@ jobs:
       issues: write
     steps:
       - name: "Add comment"
-        uses: peter-evans/create-or-update-comment@v2
+        uses: peter-evans/create-or-update-comment@v4
         with:
           token: ${{ secrets.MACHINE_USER_TOKEN_TO_ADD_COMMENT }}
           issue-number: 28

--- a/.github/workflows/notify-push-to-branch.yml
+++ b/.github/workflows/notify-push-to-branch.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: "Notify Slack"
         id: notify-slack
-        uses: archive/github-actions-slack@v2.6.0
+        uses: archive/github-actions-slack@v2.9.0
         with:
           slack-bot-user-oauth-access-token: ${{ secrets.SLACK_BOT_USER_OAUTH_ACCESS_TOKEN }}
           slack-channel: ${{ env.SLACK_CHANNEL }}
@@ -43,7 +43,7 @@ jobs:
       - name: "Slack thread: Post git commit message"
         if: steps.get-pr-title.outputs.multiline == 'true'
         # Post in thread to reduce clutter in Slack
-        uses: archive/github-actions-slack@v2.6.0
+        uses: archive/github-actions-slack@v2.9.0
         with:
           slack-bot-user-oauth-access-token: ${{ secrets.SLACK_BOT_USER_OAUTH_ACCESS_TOKEN }}
           slack-channel: ${{ env.SLACK_CHANNEL }}

--- a/.github/workflows/publish-3rd-party-image.yml
+++ b/.github/workflows/publish-3rd-party-image.yml
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: "Login to GitHub Container Registry"
-      uses: docker/login-action@v2.1.0
+      uses: docker/login-action@v3.0.0
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
@@ -76,7 +76,7 @@ jobs:
     steps:
       - name: "Notify Slack"
         id: notify-slack
-        uses: archive/github-actions-slack@v2.6.0
+        uses: archive/github-actions-slack@v2.9.0
         with:
           slack-bot-user-oauth-access-token: ${{ secrets.SLACK_BOT_USER_OAUTH_ACCESS_TOKEN }}
           slack-channel: ${{ env.SLACK_CHANNEL }}
@@ -86,7 +86,7 @@ jobs:
 
       - name: "Slack thread: Post follow-on TODO actions"
         # Post in thread to reduce clutter in Slack
-        uses: archive/github-actions-slack@v2.6.0
+        uses: archive/github-actions-slack@v2.9.0
         with:
           slack-bot-user-oauth-access-token: ${{ secrets.SLACK_BOT_USER_OAUTH_ACCESS_TOKEN }}
           slack-channel: ${{ env.SLACK_CHANNEL }}

--- a/.github/workflows/secrel.yml
+++ b/.github/workflows/secrel.yml
@@ -158,7 +158,7 @@ jobs:
 
       - name: "Slack: workflow triggered"
         id: notify-slack
-        uses: archive/github-actions-slack@v2.6.0
+        uses: archive/github-actions-slack@v2.9.0
         with:
           slack-bot-user-oauth-access-token: ${{ secrets.SLACK_BOT_USER_OAUTH_ACCESS_TOKEN }}
           slack-channel: ${{ env.SLACK_CHANNEL }}
@@ -183,7 +183,7 @@ jobs:
           publish_mode: ${{ steps.image-props.outputs.publish_mode }}
 
       - name: "Slack thread: Images published"
-        uses: archive/github-actions-slack@v2.6.0
+        uses: archive/github-actions-slack@v2.9.0
         with:
           slack-bot-user-oauth-access-token: ${{ secrets.SLACK_BOT_USER_OAUTH_ACCESS_TOKEN }}
           slack-channel: ${{ env.SLACK_CHANNEL }}
@@ -216,7 +216,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Slack: SecRel Failure"
-        uses: archive/github-actions-slack@v2.6.0
+        uses: archive/github-actions-slack@v2.9.0
         # only run for the internal repo
         if: ${{ github.repository == 'department-of-veterans-affairs/abd-vro-internal' }}
         with:
@@ -262,7 +262,7 @@ jobs:
 
       - name: "Slack thread: Post final status"
         if: always() && needs.gate-check.outputs.continue == 'true'
-        uses: archive/github-actions-slack@v2.6.0
+        uses: archive/github-actions-slack@v2.9.0
         with:
           slack-bot-user-oauth-access-token: ${{ secrets.SLACK_BOT_USER_OAUTH_ACCESS_TOKEN }}
           slack-channel: ${{ env.SLACK_CHANNEL }}
@@ -270,7 +270,7 @@ jobs:
           slack-text: ${{ env.WORKFLOW_STATE_TEXT }}
       - name: "Slack emoji: React success on top-level Slack notification"
         if: always() && needs.gate-check.outputs.continue == 'true'
-        uses: archive/github-actions-slack@v2.6.0
+        uses: archive/github-actions-slack@v2.9.0
         with:
           slack-function: send-reaction
           slack-bot-user-oauth-access-token: ${{ secrets.SLACK_BOT_USER_OAUTH_ACCESS_TOKEN }}

--- a/.github/workflows/svc-bip-api-integration-test.yml
+++ b/.github/workflows/svc-bip-api-integration-test.yml
@@ -86,7 +86,7 @@ jobs:
 
       - name: "Upload artifact"
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: svc-bip-api-container-logs
           path: ./svc-bip-api-container-logs/**

--- a/.github/workflows/test-code.yml
+++ b/.github/workflows/test-code.yml
@@ -153,7 +153,7 @@ jobs:
 
       - name: "Install Python"
         if: inputs.run_all_tests || steps.changed-files-specific.outputs.any_changed == 'true' || steps.ee-changed-files-specific.outputs.any_changed == 'true'
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.10"
           cache: "pip"

--- a/.github/workflows/update-deployment.yml
+++ b/.github/workflows/update-deployment.yml
@@ -118,7 +118,7 @@ jobs:
     steps:
       - name: "Slack: workflow triggered"
         id: notify-slack
-        uses: archive/github-actions-slack@v2.8.0
+        uses: archive/github-actions-slack@v2.9.0
         with:
           slack-bot-user-oauth-access-token: ${{ secrets.SLACK_BOT_USER_OAUTH_ACCESS_TOKEN }}
           slack-channel: ${{ env.SLACK_CHANNEL }}
@@ -161,7 +161,7 @@ jobs:
 
       - name: "Slack thread: Post deploying message"
         # Post in thread to reduce clutter in Slack
-        uses: archive/github-actions-slack@v2.8.0
+        uses: archive/github-actions-slack@v2.9.0
         with:
           slack-bot-user-oauth-access-token: ${{ secrets.SLACK_BOT_USER_OAUTH_ACCESS_TOKEN }}
           slack-channel: ${{ env.SLACK_CHANNEL }}
@@ -219,7 +219,7 @@ jobs:
 
       - name: "Slack thread: Post failed status message"
         if: failure()
-        uses: archive/github-actions-slack@v2.8.0
+        uses: archive/github-actions-slack@v2.9.0
         with:
           slack-bot-user-oauth-access-token: ${{ secrets.SLACK_BOT_USER_OAUTH_ACCESS_TOKEN }}
           slack-channel: ${{ env.SLACK_CHANNEL }}
@@ -227,7 +227,7 @@ jobs:
           slack-text: ":panda_cry: Failed *${{ inputs.helm_chart }}* deployment to *${{ inputs.target_env }}*"
       - name: "Slack emoji: React failure on top-level Slack notification"
         if: failure()
-        uses: archive/github-actions-slack@v2.8.0
+        uses: archive/github-actions-slack@v2.9.0
         with:
           slack-function: send-reaction
           slack-bot-user-oauth-access-token: ${{ secrets.SLACK_BOT_USER_OAUTH_ACCESS_TOKEN }}
@@ -236,14 +236,14 @@ jobs:
           slack-emoji-name: 'x'
 
       - name: "Slack thread: Post success status message"
-        uses: archive/github-actions-slack@v2.8.0
+        uses: archive/github-actions-slack@v2.9.0
         with:
           slack-bot-user-oauth-access-token: ${{ secrets.SLACK_BOT_USER_OAUTH_ACCESS_TOKEN }}
           slack-channel: ${{ env.SLACK_CHANNEL }}
           slack-optional-thread_ts: ${{ fromJson(steps.notify-slack.outputs.slack-result).response.message.ts }}
           slack-text: ":panda_duck_yay: Completed *${{ inputs.helm_chart }}* deployment to *${{ inputs.target_env }}*"
       - name: "Slack emoji: React success on top-level Slack notification"
-        uses: archive/github-actions-slack@v2.8.0
+        uses: archive/github-actions-slack@v2.9.0
         with:
           slack-function: send-reaction
           slack-bot-user-oauth-access-token: ${{ secrets.SLACK_BOT_USER_OAUTH_ACCESS_TOKEN }}

--- a/.github/workflows/xample-integration-test.yml
+++ b/.github/workflows/xample-integration-test.yml
@@ -90,7 +90,7 @@ jobs:
 
       - name: "Upload artifact"
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: xample-itest-container-logs
           path: ./xample-itest-container-logs/**

--- a/domain-rrd/github/rrd-end2end-test.yml
+++ b/domain-rrd/github/rrd-end2end-test.yml
@@ -79,7 +79,7 @@ jobs:
 
       - name: "Upload artifact"
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: vro-logs
           path: ./vro-logs/**


### PR DESCRIPTION
## What was the problem?
We currently have multiple warnings after running most of our pipelines. Most of the warnings were flagged regarding the use of deprecated Node.js actions, an upcoming deprecation of CodeQL Action v2, as well as other deprecated versions. 

Associated tickets or Slack threads:
- #2643 
- #2652 

## How to test this PR
- Warnings not present in Secrel workflow and others
- Check recent workflow runs after this PR has been merged
