### PR TITLE
Reverts the camel upgrade to unblock more of the build pipeline

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ taskinfo.disableSafeguard=true
 # 3.11.0 uses spring_boot 2.5.3
 # 3.12.0 uses spring_boot 2.5.5
 # 3.13 through 3.15 are not compatible with va.starter's spring_boot version
-camel_version=4.4.0
+camel_version=4.1.0
 
 h2_version=2.2.224
 hibernate_types_version=3.5.2


### PR DESCRIPTION
SecRel pipeline flagged another vulnerability in the camel libraries. Seeing that it was a minor version change, I thought it could be worth it to attempt the upgrade as the remediation recommended. After pruning images and rebuilding, everything looked good.  Little did i realize that the way i rebuilt everything still pulled the previous camel version into the rebuild of my environment.  This invalidated all my testing, and I didn't realize that I had broken things until later in the day yesterday. The rollback of the version number is aimed at getting the build running again.  Though we should expect that Snyk reintroduces the camel vulnerability, which means we are still going to be blocked by SecRel, but hopefully image publishing starts working again. 


[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
