### PR TITLE
rollback github action version

### DIFF
--- a/.github/workflows/delete-old-releases.yml
+++ b/.github/workflows/delete-old-releases.yml
@@ -37,7 +37,7 @@ jobs:
     - id: checkUserMember
       # Only check for manual runs, not scheduled runs
       if: github.event_name == 'workflow_dispatch'
-      uses: tspascoal/get-user-teams-membership@v3
+      uses: tspascoal/get-user-teams-membership@v3.0.0
       with:
         username: ${{ github.actor }}
         team: 'vro-restricted'

--- a/.github/workflows/delete-published-images.yml
+++ b/.github/workflows/delete-published-images.yml
@@ -41,7 +41,7 @@ jobs:
     - id: checkUserMember
       # Only check for manual runs, not scheduled runs
       if: github.event_name == 'workflow_dispatch'
-      uses: tspascoal/get-user-teams-membership@v3
+      uses: tspascoal/get-user-teams-membership@v3.0.0
       with:
         username: ${{ github.actor }}
         team: 'vro-restricted'

--- a/.github/workflows/delete-workflow-runs.yml
+++ b/.github/workflows/delete-workflow-runs.yml
@@ -27,7 +27,7 @@ jobs:
     - id: checkUserMember
       # Only check for manual runs, not scheduled runs
       if: github.event_name == 'workflow_dispatch'
-      uses: tspascoal/get-user-teams-membership@v3
+      uses: tspascoal/get-user-teams-membership@v3.0.0
       with:
         username: ${{ github.actor }}
         team: 'vro-restricted'

--- a/.github/workflows/deploy-secrets.yml
+++ b/.github/workflows/deploy-secrets.yml
@@ -37,7 +37,7 @@ jobs:
     - id: checkUserMember
       # Only check for manual runs against prod
       if: github.event_name == 'workflow_dispatch' && inputs.target_env == 'prod'
-      uses: tspascoal/get-user-teams-membership@v3
+      uses: tspascoal/get-user-teams-membership@v3.0.0
       with:
         username: ${{ github.actor }}
         team: 'vro-restricted'

--- a/.github/workflows/update-deployment.yml
+++ b/.github/workflows/update-deployment.yml
@@ -95,7 +95,7 @@ jobs:
     - id: checkUserMember
       # Only check for manual runs against prod
       if: github.event_name == 'workflow_dispatch' && inputs.target_env == 'prod'
-      uses: tspascoal/get-user-teams-membership@v3
+      uses: tspascoal/get-user-teams-membership@v3.0.0
       with:
         username: ${{ github.actor }}
         team: 'vro-restricted'


### PR DESCRIPTION
Rolling back tspascoal/get-user-teams-membership@v3.3.0 to tspascoal/get-user-teams-membership@v3.0.0 due to this error:
`Unable to resolve action tspascoal/get-user-teams-membership@v3.3.0, unable to find version v3.3.0`
