### PR TITLE
EPMerge: Fix serialization issue resulting in bad request response from BIP API

### DIFF
--- a/svc-bip-api/src/main/java/gov/va/vro/bip/config/BipApiConfig.java
+++ b/svc-bip-api/src/main/java/gov/va/vro/bip/config/BipApiConfig.java
@@ -11,11 +11,11 @@ import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManagerBuil
 import org.apache.hc.client5.http.io.HttpClientConnectionManager;
 import org.apache.hc.client5.http.ssl.SSLConnectionSocketFactory;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.client.ClientHttpRequestFactory;
 import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.web.client.RestTemplate;
 
 import java.io.ByteArrayInputStream;
@@ -28,6 +28,7 @@ import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
 import java.security.cert.CertificateException;
 import java.util.Base64;
+import java.util.List;
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManagerFactory;
@@ -65,7 +66,7 @@ public class BipApiConfig {
       throws KeyStoreException, IOException, NoSuchAlgorithmException, CertificateException {
     KeyStore keyStore = KeyStore.getInstance("PKCS12");
     String noSpaceBase64 = base64.replaceAll("\\s+", "");
-    byte[] decodedBytes = new byte[] {};
+    byte[] decodedBytes;
     try {
       decodedBytes = Base64.getDecoder().decode(noSpaceBase64);
     } catch (IllegalArgumentException e) {
@@ -77,15 +78,9 @@ public class BipApiConfig {
     return keyStore;
   }
 
-  /**
-   * Get Rest template for BIP API connection.
-   *
-   * @param builder RestTemplateBuilder
-   * @return Rest template, request factory
-   * @throws BipException failure to create connection
-   */
   @Bean(name = "bipCERestTemplate")
-  public RestTemplate getHttpsRestTemplate(RestTemplateBuilder builder) throws BipException {
+  public RestTemplate getHttpsRestTemplate(List<HttpMessageConverter<?>> messageConverters)
+      throws BipException {
     try {
       if (trustStore.isEmpty() && password.isEmpty()) {
         log.info("No valid BIP mTLS setup. Skip related setup.");
@@ -122,7 +117,9 @@ public class BipApiConfig {
           HttpClients.custom().setConnectionManager(connectionManager).build();
       ClientHttpRequestFactory requestFactory =
           new HttpComponentsClientHttpRequestFactory(httpClient);
-      return new RestTemplate(requestFactory);
+      RestTemplate restTemplate = new RestTemplate(requestFactory);
+      restTemplate.setMessageConverters(messageConverters);
+      return restTemplate;
     } catch (NoSuchAlgorithmException | KeyStoreException | KeyManagementException e) {
       log.error("Failed to create SSL context for VA certificate. {}", e.getMessage(), e);
       throw new BipException("Failed to create SSL context.", e);

--- a/svc-bip-api/src/main/java/gov/va/vro/bip/config/JacksonConfig.java
+++ b/svc-bip-api/src/main/java/gov/va/vro/bip/config/JacksonConfig.java
@@ -1,5 +1,6 @@
 package gov.va.vro.bip.config;
 
+import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
@@ -9,6 +10,7 @@ import org.springframework.amqp.support.converter.MessageConverter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 
 @Configuration
 public class JacksonConfig {
@@ -19,12 +21,22 @@ public class JacksonConfig {
     objectMapper.registerModule(new JavaTimeModule());
     objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
     objectMapper.enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+    objectMapper.enable(JsonParser.Feature.INCLUDE_SOURCE_IN_LOCATION);
     return objectMapper;
   }
 
+  //  Used for AMQP message conversion
   @Bean
   @Primary
   public MessageConverter jackson2MessageConverter(ObjectMapper objectMapper) {
     return new Jackson2JsonMessageConverter(objectMapper);
+  }
+
+  //  Used for RestTemplate message conversion
+  @Bean
+  @Primary
+  public MappingJackson2HttpMessageConverter mappingJackson2HttpMessageConverter(
+      ObjectMapper objectMapper) {
+    return new MappingJackson2HttpMessageConverter(objectMapper);
   }
 }

--- a/svc-bip-api/src/test/java/gov/va/vro/bip/config/BipApiConfigTest.java
+++ b/svc-bip-api/src/test/java/gov/va/vro/bip/config/BipApiConfigTest.java
@@ -4,14 +4,15 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import gov.va.vro.bip.service.BipException;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.web.client.RestTemplate;
 
 import java.io.InputStream;
+import java.util.List;
 
 /**
  * BIP API configuration tests.
@@ -21,16 +22,19 @@ import java.io.InputStream;
 class BipApiConfigTest {
 
   private BipApiConfig config;
+  private JacksonConfig jacksonConfig;
 
   @BeforeEach
   public void setUp() {
     config = new BipApiConfig();
+    jacksonConfig = new JacksonConfig();
   }
 
   @Test
   public void testGetHttpsRestTemplate_WithoutConfiguringCerts() {
     try {
-      config.getHttpsRestTemplate(new RestTemplateBuilder());
+      config.getHttpsRestTemplate(
+          List.of(jacksonConfig.mappingJackson2HttpMessageConverter(new ObjectMapper())));
       fail();
     } catch (Exception e) {
       assertTrue(e.getCause() instanceof NullPointerException);
@@ -45,7 +49,8 @@ class BipApiConfigTest {
           config.setTrustStore("biptruststore.jks");
           config.setKeystore("biptruststore.jks");
           config.setPassword("bad");
-          config.getHttpsRestTemplate(new RestTemplateBuilder());
+          config.getHttpsRestTemplate(
+              List.of(jacksonConfig.mappingJackson2HttpMessageConverter(new ObjectMapper())));
         });
   }
 
@@ -53,7 +58,9 @@ class BipApiConfigTest {
   public void testGetHttpsRestTemplate_WithoutTrustStore() {
     config.setTrustStore("");
     config.setPassword("");
-    RestTemplate temp = config.getHttpsRestTemplate(new RestTemplateBuilder());
+    RestTemplate temp =
+        config.getHttpsRestTemplate(
+            List.of(jacksonConfig.mappingJackson2HttpMessageConverter(new ObjectMapper())));
     assertNotNull(temp);
   }
 
@@ -66,7 +73,10 @@ class BipApiConfigTest {
       config.setTrustStore(store);
       config.setKeystore(store);
       config.setPassword("vropassword");
-      RestTemplate template = config.getHttpsRestTemplate(new RestTemplateBuilder());
+      RestTemplate template =
+          config.getHttpsRestTemplate(
+              List.of(jacksonConfig.mappingJackson2HttpMessageConverter(new ObjectMapper())));
+
       assertNotNull(template);
     } catch (Exception e) {
       fail();

--- a/svc-bip-api/src/test/java/gov/va/vro/bip/service/BipApiServiceTest.java
+++ b/svc-bip-api/src/test/java/gov/va/vro/bip/service/BipApiServiceTest.java
@@ -31,10 +31,13 @@ import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
 import org.mockito.Mockito;
@@ -61,12 +64,13 @@ import java.util.Objects;
 public class BipApiServiceTest {
   private static final ObjectMapper MAPPER = new ObjectMapper();
   private static final long GOOD_CLAIM_ID = 9666959L;
-  private static final long BAD_CLAIM_ID = 9666958L;
   private static final long NOT_FOUND_CLAIM_ID = 9234567L;
   private static final long INTERNAL_SERVER_ERROR_CLAIM_ID = 9345678L;
   private static final String RESPONSE_500 = "bip-test-data/response_500.json";
   private static final String CONTENTION_RESPONSE_200 =
       "bip-test-data/contention_response_200.json";
+  private static final String CONTENTION_RESPONSE_201 =
+      "bip-test-data/contention_response_201.json";
   private static final String CLAIM_RESPONSE_404 = "bip-test-data/claim_response_404.json";
   private static final String CLAIM_RESPONSE_200 = "bip-test-data/claim_response_200.json";
   private static final String CLAIM_DETAILS = "/claims/%s";
@@ -88,6 +92,8 @@ public class BipApiServiceTest {
 
   private BipApiService service;
 
+  private final ObjectMapper mapper = new JacksonConfig().objectMapper();
+
   @Mock private RestTemplate restTemplate;
 
   @BeforeEach
@@ -100,7 +106,7 @@ public class BipApiServiceTest {
     bipApiProps.setStationId(STATION_ID);
     bipApiProps.setClaimClientId(CLAIM_USERID);
 
-    service = new BipApiService(restTemplate, bipApiProps, new JacksonConfig().objectMapper());
+    service = new BipApiService(restTemplate, bipApiProps, mapper);
   }
 
   private String formatClaimUrl(String format, Long claimId) {
@@ -116,6 +122,20 @@ public class BipApiServiceTest {
     return Files.readString(filePath);
   }
 
+  private void mockResponseForUrl(
+      Stubber response,
+      String claimUrl,
+      HttpMethod httpMethod,
+      Class<? extends BipPayloadResponse> clazz) {
+    response
+        .when(restTemplate)
+        .exchange(
+            ArgumentMatchers.eq(claimUrl),
+            ArgumentMatchers.eq(httpMethod),
+            ArgumentMatchers.any(HttpEntity.class),
+            ArgumentMatchers.eq(clazz));
+  }
+
   private void mockResponseForUrl(Stubber response, String claimUrl, HttpMethod httpMethod) {
     response
         .when(restTemplate)
@@ -126,472 +146,330 @@ public class BipApiServiceTest {
             ArgumentMatchers.eq(String.class));
   }
 
-  @Test
-  public void testGetClaimDetails_200() throws Exception {
-    String resp200Body = getTestData(CLAIM_RESPONSE_200);
-
-    ResponseEntity<String> resp200 = ResponseEntity.ok(resp200Body);
+  private <T extends BipPayloadResponse> void mock2xxResponse(
+      HttpMethod httpMethod,
+      String urlFormat,
+      HttpStatus httpStatus,
+      Class<T> responseType,
+      String responseFile)
+      throws Exception {
+    ResponseEntity<T> responseEntity;
+    if (Objects.isNull(responseFile)) {
+      responseEntity = new ResponseEntity<>(httpStatus);
+    } else {
+      T body = mapper.readValue(getTestData(responseFile), responseType);
+      responseEntity = new ResponseEntity<>(body, httpStatus);
+    }
     mockResponseForUrl(
-        Mockito.doReturn(resp200), formatClaimUrl(CLAIM_DETAILS, GOOD_CLAIM_ID), HttpMethod.GET);
-
-    GetClaimResponse result = service.getClaimDetails(GOOD_CLAIM_ID);
-    assertResponseIsSuccess(result, HttpStatus.OK);
+        Mockito.doReturn(responseEntity),
+        formatClaimUrl(urlFormat, BipApiServiceTest.GOOD_CLAIM_ID),
+        httpMethod,
+        responseType);
   }
 
-  @Test
-  public void testGetClaimDetails_404() throws Exception {
-    String resp404Body = getTestData(CLAIM_RESPONSE_404);
-    mockResponseForUrl(
-        Mockito.doThrow(
-            new HttpClientErrorException(
-                HttpStatus.NOT_FOUND,
-                HttpStatus.NOT_FOUND.name(),
-                resp404Body.getBytes(),
-                Charset.defaultCharset())),
-        formatClaimUrl(CLAIM_DETAILS, NOT_FOUND_CLAIM_ID),
-        HttpMethod.GET);
-
-    HttpStatusCodeException ex =
-        Assertions.assertThrows(
-            HttpStatusCodeException.class, () -> service.getClaimDetails(NOT_FOUND_CLAIM_ID));
-    assertResponseHasMessageWithStatus(ex.getResponseBodyAsString(), HttpStatus.NOT_FOUND);
+  private <T extends BipPayloadResponse> void mockExceptionResponse(
+      Exception exception, String url, HttpMethod httpMethod, Class<T> responseType) {
+    mockResponseForUrl(Mockito.doThrow(exception), url, httpMethod, responseType);
   }
 
-  @Test
-  public void testGetClaimDetailsDownstreamServerError_500() throws Exception {
-    String resp500Body = getTestData(RESPONSE_500);
-    mockResponseForUrl(
-        Mockito.doThrow(
-            new HttpServerErrorException(
-                HttpStatus.INTERNAL_SERVER_ERROR,
-                HttpStatus.INTERNAL_SERVER_ERROR.name(),
-                resp500Body.getBytes(),
-                Charset.defaultCharset())),
-        formatClaimUrl(CLAIM_DETAILS, INTERNAL_SERVER_ERROR_CLAIM_ID),
-        HttpMethod.GET);
+  @Nested
+  public class GetClaimDetails {
+    @Test
+    public void testGetClaimDetails_200() throws Exception {
+      mock2xxResponse(
+          HttpMethod.GET, CLAIM_DETAILS, HttpStatus.OK, GetClaimResponse.class, CLAIM_RESPONSE_200);
 
-    HttpStatusCodeException ex =
-        Assertions.assertThrows(
-            HttpStatusCodeException.class,
-            () -> service.getClaimDetails(INTERNAL_SERVER_ERROR_CLAIM_ID));
-    assertResponseHasMessageWithStatus(
-        ex.getResponseBodyAsString(), HttpStatus.INTERNAL_SERVER_ERROR);
+      GetClaimResponse result = service.getClaimDetails(GOOD_CLAIM_ID);
+      assertResponseIsSuccess(result, HttpStatus.OK);
+    }
+
+    @ParameterizedTest(name = "testGetClaimDetails_{0}")
+    @EnumSource(TestCase.class)
+    public void testGetClaimDetails_non2xx(TestCase test) throws Exception {
+      mockExceptionResponse(
+          test.ex,
+          formatClaimUrl(CLAIM_DETAILS, test.claimId),
+          HttpMethod.GET,
+          GetClaimResponse.class);
+
+      Exception ex =
+          Assertions.assertThrows(test.ex.getClass(), () -> service.getClaimDetails(test.claimId));
+      assertResponseExceptionWithStatus(ex, test.status);
+    }
   }
 
-  @Test
-  public void testGetClaimDetailsInternalServerError_500() {
-    mockResponseForUrl(
-        Mockito.doThrow(new RuntimeException("nope")),
-        formatClaimUrl(CLAIM_DETAILS, INTERNAL_SERVER_ERROR_CLAIM_ID),
-        HttpMethod.GET);
+  @Nested
+  public class GetClaimContentions {
+    @Test
+    public void testGetClaimContention_200() throws Exception {
+      mock2xxResponse(
+          HttpMethod.GET,
+          CONTENTION,
+          HttpStatus.OK,
+          GetClaimContentionsResponse.class,
+          CONTENTION_RESPONSE_200);
 
-    BipException ex =
-        Assertions.assertThrows(
-            BipException.class, () -> service.getClaimDetails(INTERNAL_SERVER_ERROR_CLAIM_ID));
-    assertSame(HttpStatus.INTERNAL_SERVER_ERROR, ex.getStatus());
+      GetClaimContentionsResponse result = service.getClaimContentions(GOOD_CLAIM_ID);
+      assertResponseIsSuccess(result, HttpStatus.OK);
+      assertEquals(1, result.getContentions().size());
+    }
+
+    @Test
+    public void testGetClaimContention_204() throws Exception {
+      mock2xxResponse(
+          HttpMethod.GET,
+          CONTENTION,
+          HttpStatus.NO_CONTENT,
+          GetClaimContentionsResponse.class,
+          null);
+
+      GetClaimContentionsResponse result = service.getClaimContentions(GOOD_CLAIM_ID);
+      assertResponseIsSuccess(result, HttpStatus.NO_CONTENT);
+      assertNull(result.getContentions());
+    }
+
+    @ParameterizedTest(name = "testGetClaimContentions_{0}")
+    @EnumSource(TestCase.class)
+    public void testGetClaimContentions_Non2xx(TestCase test) throws Exception {
+      mockExceptionResponse(
+          test.ex,
+          formatClaimUrl(CONTENTION, test.claimId),
+          HttpMethod.GET,
+          GetClaimContentionsResponse.class);
+
+      Exception ex =
+          Assertions.assertThrows(
+              test.ex.getClass(), () -> service.getClaimContentions(test.claimId));
+      assertResponseExceptionWithStatus(ex, test.status);
+    }
   }
 
-  @Test
-  public void testGetClaimContention_200() throws Exception {
-    String resp200Body = getTestData(CONTENTION_RESPONSE_200);
-    ResponseEntity<String> resp200 = ResponseEntity.ok(resp200Body);
+  @Nested
+  public class CreateClaimContentions {
+    @Test
+    public void testCreateClaimContentions_201() throws Exception {
+      mock2xxResponse(
+          HttpMethod.POST,
+          CONTENTION,
+          HttpStatus.CREATED,
+          CreateClaimContentionsResponse.class,
+          CONTENTION_RESPONSE_201);
+      CreateClaimContentionsRequest request =
+          CreateClaimContentionsRequest.builder()
+              .claimId(GOOD_CLAIM_ID)
+              .createContentions(
+                  List.of(
+                      Contention.builder()
+                          .medicalInd(true)
+                          .beginDate(OffsetDateTime.parse("2023-09-27T00:00:00-06:00"))
+                          .contentionTypeCode("NEW")
+                          .claimantText("tendinitis/bilateral")
+                          .build()))
+              .build();
+      CreateClaimContentionsResponse response = service.createClaimContentions(request);
+      assertResponseIsSuccess(response, HttpStatus.CREATED);
+      assertNotNull(response.getContentionIds());
+      assertEquals(1, response.getContentionIds().size());
+      assertEquals(1, response.getContentionIds().get(0));
+    }
 
-    mockResponseForUrl(
-        Mockito.doReturn(resp200), formatClaimUrl(CONTENTION, GOOD_CLAIM_ID), HttpMethod.GET);
-
-    GetClaimContentionsResponse result = service.getClaimContentions(GOOD_CLAIM_ID);
-    assertResponseIsSuccess(result, HttpStatus.OK);
-    assertEquals(1, result.getContentions().size());
+    @ParameterizedTest(name = "testCreateClaimContentions_{0}")
+    @EnumSource(TestCase.class)
+    public void testCreateClaimContentions_Non2xx(TestCase test) throws Exception {
+      mockExceptionResponse(
+          test.ex,
+          formatClaimUrl(CONTENTION, test.claimId),
+          HttpMethod.POST,
+          CreateClaimContentionsResponse.class);
+      CreateClaimContentionsRequest request =
+          CreateClaimContentionsRequest.builder()
+              .claimId(test.claimId)
+              .createContentions(
+                  List.of(
+                      Contention.builder()
+                          .medicalInd(true)
+                          .beginDate(OffsetDateTime.parse("2023-09-27T00:00:00-06:00"))
+                          .contentionTypeCode("NEW")
+                          .claimantText("tendinitis/bilateral")
+                          .build()))
+              .build();
+      Exception ex =
+          Assertions.assertThrows(
+              test.ex.getClass(), () -> service.createClaimContentions(request));
+      assertResponseExceptionWithStatus(ex, test.status);
+    }
   }
 
-  @Test
-  public void testGetClaimContention_204() throws Exception {
-    ResponseEntity<?> resp204 = ResponseEntity.noContent().build();
+  @Nested
+  public class UpdateClaimContentions {
+    @Test
+    public void testUpdateClaimContentions_200() throws Exception {
+      mock2xxResponse(
+          HttpMethod.PUT,
+          CONTENTION,
+          HttpStatus.OK,
+          UpdateClaimContentionsResponse.class,
+          CONTENTION_RESPONSE_200);
+      UpdateClaimContentionsRequest request =
+          UpdateClaimContentionsRequest.builder()
+              .claimId(GOOD_CLAIM_ID)
+              .updateContentions(
+                  List.of(
+                      ExistingContention.builder()
+                          .medicalInd(true)
+                          .beginDate(OffsetDateTime.parse("2023-09-27T00:00:00-06:00"))
+                          .contentionTypeCode("NEW")
+                          .claimantText("tendinitis/bilateral")
+                          .build()))
+              .build();
 
-    mockResponseForUrl(
-        Mockito.doReturn(resp204), formatClaimUrl(CONTENTION, GOOD_CLAIM_ID), HttpMethod.GET);
+      UpdateClaimContentionsResponse response = service.updateClaimContentions(request);
+      assertResponseIsSuccess(response, HttpStatus.OK);
+    }
 
-    GetClaimContentionsResponse result = service.getClaimContentions(GOOD_CLAIM_ID);
-    assertResponseIsSuccess(result, HttpStatus.NO_CONTENT);
-    assertNull(result.getContentions());
+    @ParameterizedTest(name = "testUpdateClaimContentions_{0}")
+    @EnumSource(TestCase.class)
+    public void testUpdateClaimContentions_Non2xx(TestCase test) throws Exception {
+      mockExceptionResponse(
+          test.ex,
+          formatClaimUrl(CONTENTION, test.claimId),
+          HttpMethod.PUT,
+          UpdateClaimContentionsResponse.class);
+      UpdateClaimContentionsRequest request =
+          UpdateClaimContentionsRequest.builder()
+              .claimId(test.claimId)
+              .updateContentions(
+                  List.of(
+                      ExistingContention.builder()
+                          .medicalInd(true)
+                          .beginDate(OffsetDateTime.parse("2023-09-27T00:00:00-06:00"))
+                          .contentionTypeCode("NEW")
+                          .claimantText("tendinitis/bilateral")
+                          .build()))
+              .build();
+      Exception ex =
+          Assertions.assertThrows(
+              test.ex.getClass(), () -> service.updateClaimContentions(request));
+      assertResponseExceptionWithStatus(ex, test.status);
+    }
   }
 
-  @Test
-  public void testGetClaimContentions_404() throws Exception {
-    String resp404Body = getTestData(CLAIM_RESPONSE_404);
+  @Nested
+  public class CancelClaim {
+    @Test
+    public void testCancelClaim_200() throws Exception {
+      mock2xxResponse(HttpMethod.PUT, CANCEL_CLAIM, HttpStatus.OK, CancelClaimResponse.class, null);
+      CancelClaimRequest request =
+          CancelClaimRequest.builder()
+              .claimId(GOOD_CLAIM_ID)
+              .closeReasonText("because we are testing")
+              .lifecycleStatusReasonCode("60")
+              .build();
+      CancelClaimResponse response = service.cancelClaim(request);
+      assertResponseIsSuccess(response, HttpStatus.OK);
+    }
 
-    mockResponseForUrl(
-        Mockito.doThrow(
-            new HttpClientErrorException(
-                HttpStatus.NOT_FOUND,
-                HttpStatus.NOT_FOUND.name(),
-                resp404Body.getBytes(),
-                Charset.defaultCharset())),
-        formatClaimUrl(CONTENTION, BAD_CLAIM_ID),
-        HttpMethod.GET);
-
-    HttpStatusCodeException ex =
-        Assertions.assertThrows(
-            HttpStatusCodeException.class, () -> service.getClaimContentions(BAD_CLAIM_ID));
-    assertResponseHasMessageWithStatus(ex.getResponseBodyAsString(), HttpStatus.NOT_FOUND);
+    @ParameterizedTest(name = "testCancelClaim_{0}")
+    @EnumSource(TestCase.class)
+    public void testCancelClaim_Non2xx(TestCase test) throws Exception {
+      mockExceptionResponse(
+          test.ex,
+          formatClaimUrl(CANCEL_CLAIM, test.claimId),
+          HttpMethod.PUT,
+          CancelClaimResponse.class);
+      CancelClaimRequest request =
+          CancelClaimRequest.builder()
+              .claimId(test.claimId)
+              .closeReasonText("because we are testing")
+              .lifecycleStatusReasonCode("60")
+              .build();
+      Exception ex =
+          Assertions.assertThrows(test.ex.getClass(), () -> service.cancelClaim(request));
+      assertResponseExceptionWithStatus(ex, test.status);
+    }
   }
 
-  @Test
-  public void testGetClaimContentionsDownstreamServerError_500() throws Exception {
-    String resp500Body = getTestData(RESPONSE_500);
-    mockResponseForUrl(
-        Mockito.doThrow(
-            new HttpServerErrorException(
-                HttpStatus.INTERNAL_SERVER_ERROR,
-                HttpStatus.INTERNAL_SERVER_ERROR.name(),
-                resp500Body.getBytes(),
-                Charset.defaultCharset())),
-        formatClaimUrl(CONTENTION, INTERNAL_SERVER_ERROR_CLAIM_ID),
-        HttpMethod.GET);
+  @Nested
+  public class PutLifecycleStatus {
+    @Test
+    public void testPutLifecycleStatus_200() throws Exception {
+      mock2xxResponse(
+          HttpMethod.PUT,
+          CLAIM_LIFECYCLE_STATUS,
+          HttpStatus.OK,
+          PutClaimLifecycleResponse.class,
+          null);
 
-    HttpStatusCodeException ex =
-        Assertions.assertThrows(
-            HttpStatusCodeException.class,
-            () -> service.getClaimContentions(INTERNAL_SERVER_ERROR_CLAIM_ID));
-    assertResponseHasMessageWithStatus(
-        ex.getResponseBodyAsString(), HttpStatus.INTERNAL_SERVER_ERROR);
+      PutClaimLifecycleRequest request =
+          PutClaimLifecycleRequest.builder()
+              .claimId(GOOD_CLAIM_ID)
+              .claimLifecycleStatus("Just a test")
+              .build();
+      PutClaimLifecycleResponse response = service.putClaimLifecycleStatus(request);
+      assertResponseIsSuccess(response, HttpStatus.OK);
+    }
+
+    @ParameterizedTest(name = "testPutLifecycleStatus_{0}")
+    @EnumSource(TestCase.class)
+    public void testPutLifecycleStatus_Non2xx(TestCase test) throws Exception {
+      mockExceptionResponse(
+          test.ex,
+          formatClaimUrl(CLAIM_LIFECYCLE_STATUS, test.claimId),
+          HttpMethod.PUT,
+          PutClaimLifecycleResponse.class);
+      PutClaimLifecycleRequest request =
+          PutClaimLifecycleRequest.builder()
+              .claimId(test.claimId)
+              .claimLifecycleStatus("Just a test")
+              .build();
+      Exception ex =
+          Assertions.assertThrows(
+              test.ex.getClass(), () -> service.putClaimLifecycleStatus(request));
+      assertResponseExceptionWithStatus(ex, test.status);
+    }
   }
 
-  @Test
-  public void testGetClaimContentionsInternalServerError_500() {
-    mockResponseForUrl(
-        Mockito.doThrow(new RuntimeException("nope")),
-        formatClaimUrl(CONTENTION, INTERNAL_SERVER_ERROR_CLAIM_ID),
-        HttpMethod.GET);
+  @Nested
+  public class PutTemporaryStationOfJursidiction {
+    @ParameterizedTest
+    @NullAndEmptySource
+    @CsvSource(value = {"398"})
+    public void testPutTemporaryStationOfJurisdiction_200(String tsoj) throws Exception {
+      mock2xxResponse(
+          HttpMethod.PUT,
+          TEMP_STATION_OF_JURISDICTION,
+          HttpStatus.OK,
+          PutTempStationOfJurisdictionResponse.class,
+          null);
 
-    BipException ex =
-        Assertions.assertThrows(
-            BipException.class, () -> service.getClaimContentions(INTERNAL_SERVER_ERROR_CLAIM_ID));
-    assertSame(HttpStatus.INTERNAL_SERVER_ERROR, ex.getStatus());
-  }
+      PutTempStationOfJurisdictionRequest request =
+          PutTempStationOfJurisdictionRequest.builder()
+              .claimId(GOOD_CLAIM_ID)
+              .tempStationOfJurisdiction(tsoj)
+              .build();
+      PutTempStationOfJurisdictionResponse result = service.putTempStationOfJurisdiction(request);
+      assertResponseIsSuccess(result, HttpStatus.OK);
+    }
 
-  @Test
-  public void testCreateClaimContentions_201() {
-    String resp200Body = "{\"contentionIds\":[1]}";
-    ResponseEntity<String> resp200 = new ResponseEntity<>(resp200Body, HttpStatus.CREATED);
-    mockResponseForUrl(
-        Mockito.doReturn(resp200), formatClaimUrl(CONTENTION, GOOD_CLAIM_ID), HttpMethod.POST);
-    CreateClaimContentionsRequest request =
-        CreateClaimContentionsRequest.builder()
-            .claimId(GOOD_CLAIM_ID)
-            .createContentions(
-                List.of(
-                    Contention.builder()
-                        .medicalInd(true)
-                        .beginDate(OffsetDateTime.parse("2023-09-27T00:00:00-06:00"))
-                        .contentionTypeCode("NEW")
-                        .claimantText("tendinitis/bilateral")
-                        .build()))
-            .build();
-    CreateClaimContentionsResponse response = service.createClaimContentions(request);
-    assertResponseIsSuccess(response, HttpStatus.CREATED);
-    assertNotNull(response.getContentionIds());
-    assertEquals(1, response.getContentionIds().size());
-    assertEquals(1, response.getContentionIds().get(0));
-  }
+    @ParameterizedTest(name = "testPutTemporaryStationOfJurisdiction_{0}")
+    @EnumSource(TestCase.class)
+    public void testPutTemporaryStationOfJurisdiction_Non2xx(TestCase test) throws Exception {
+      mockExceptionResponse(
+          test.ex,
+          formatClaimUrl(TEMP_STATION_OF_JURISDICTION, test.claimId),
+          HttpMethod.PUT,
+          PutTempStationOfJurisdictionResponse.class);
 
-  @ParameterizedTest(name = "testCreateClaimContentions_{0}")
-  @EnumSource(TestCase.class)
-  public void testCreateClaimContentions_Non2xx(TestCase test) throws JsonProcessingException {
-    mockResponseForUrl(
-        Mockito.doThrow(test.ex), formatClaimUrl(CONTENTION, test.claimId), HttpMethod.POST);
-    CreateClaimContentionsRequest request =
-        CreateClaimContentionsRequest.builder()
-            .claimId(test.claimId)
-            .createContentions(
-                List.of(
-                    Contention.builder()
-                        .medicalInd(true)
-                        .beginDate(OffsetDateTime.parse("2023-09-27T00:00:00-06:00"))
-                        .contentionTypeCode("NEW")
-                        .claimantText("tendinitis/bilateral")
-                        .build()))
-            .build();
-    HttpStatusCodeException ex =
-        Assertions.assertThrows(test.ex.getClass(), () -> service.createClaimContentions(request));
-    assertResponseHasMessageWithStatus(ex.getResponseBodyAsString(), test.status);
-  }
-
-  @Test
-  public void testCreateClaimContentionsInternalServerError_500() {
-    mockResponseForUrl(
-        Mockito.doThrow(new RuntimeException("nope")),
-        formatClaimUrl(CONTENTION, INTERNAL_SERVER_ERROR_CLAIM_ID),
-        HttpMethod.POST);
-    CreateClaimContentionsRequest request =
-        CreateClaimContentionsRequest.builder()
-            .claimId(INTERNAL_SERVER_ERROR_CLAIM_ID)
-            .createContentions(
-                List.of(
-                    Contention.builder()
-                        .medicalInd(true)
-                        .beginDate(OffsetDateTime.parse("2023-09-27T00:00:00-06:00"))
-                        .contentionTypeCode("NEW")
-                        .claimantText("tendinitis/bilateral")
-                        .build()))
-            .build();
-    BipException ex =
-        Assertions.assertThrows(BipException.class, () -> service.createClaimContentions(request));
-    assertSame(HttpStatus.INTERNAL_SERVER_ERROR, ex.getStatus());
-  }
-
-  @Test
-  public void testUpdateClaimContentions_200() throws Exception {
-    String resp200Body = getTestData(CONTENTION_RESPONSE_200);
-    ResponseEntity<String> resp200 = ResponseEntity.ok(resp200Body);
-    mockResponseForUrl(
-        Mockito.doReturn(resp200), formatClaimUrl(CONTENTION, GOOD_CLAIM_ID), HttpMethod.PUT);
-
-    UpdateClaimContentionsRequest request =
-        UpdateClaimContentionsRequest.builder()
-            .claimId(GOOD_CLAIM_ID)
-            .updateContentions(
-                List.of(
-                    ExistingContention.builder()
-                        .medicalInd(true)
-                        .beginDate(OffsetDateTime.parse("2023-09-27T00:00:00-06:00"))
-                        .contentionTypeCode("NEW")
-                        .claimantText("tendinitis/bilateral")
-                        .build()))
-            .build();
-
-    UpdateClaimContentionsResponse response = service.updateClaimContentions(request);
-    assertResponseIsSuccess(response, HttpStatus.OK);
-  }
-
-  @ParameterizedTest(name = "testUpdateClaimContentions_{0}")
-  @EnumSource(TestCase.class)
-  public void testUpdateClaimContentions_Non2xx(TestCase test) throws JsonProcessingException {
-    mockResponseForUrl(
-        Mockito.doThrow(test.ex), formatClaimUrl(CONTENTION, test.claimId), HttpMethod.PUT);
-    UpdateClaimContentionsRequest request =
-        UpdateClaimContentionsRequest.builder()
-            .claimId(test.claimId)
-            .updateContentions(
-                List.of(
-                    ExistingContention.builder()
-                        .medicalInd(true)
-                        .beginDate(OffsetDateTime.parse("2023-09-27T00:00:00-06:00"))
-                        .contentionTypeCode("NEW")
-                        .claimantText("tendinitis/bilateral")
-                        .build()))
-            .build();
-    HttpStatusCodeException ex =
-        Assertions.assertThrows(test.ex.getClass(), () -> service.updateClaimContentions(request));
-    assertResponseHasMessageWithStatus(ex.getResponseBodyAsString(), test.status);
-  }
-
-  @Test
-  public void testUpdateClaimContentionsInternalServerError_500() {
-    mockResponseForUrl(
-        Mockito.doThrow(new RuntimeException("nope")),
-        formatClaimUrl(CONTENTION, INTERNAL_SERVER_ERROR_CLAIM_ID),
-        HttpMethod.PUT);
-    UpdateClaimContentionsRequest request =
-        UpdateClaimContentionsRequest.builder()
-            .claimId(INTERNAL_SERVER_ERROR_CLAIM_ID)
-            .updateContentions(
-                List.of(
-                    ExistingContention.builder()
-                        .medicalInd(true)
-                        .beginDate(OffsetDateTime.parse("2023-09-27T00:00:00-06:00"))
-                        .contentionTypeCode("NEW")
-                        .claimantText("tendinitis/bilateral")
-                        .build()))
-            .build();
-    BipException ex =
-        Assertions.assertThrows(BipException.class, () -> service.updateClaimContentions(request));
-    assertSame(HttpStatus.INTERNAL_SERVER_ERROR, ex.getStatus());
-  }
-
-  @Test
-  public void testCancelClaim_200() {
-    ResponseEntity<String> resp200 = ResponseEntity.ok("{}");
-    mockResponseForUrl(
-        Mockito.doReturn(resp200), formatClaimUrl(CANCEL_CLAIM, GOOD_CLAIM_ID), HttpMethod.PUT);
-    CancelClaimRequest request =
-        CancelClaimRequest.builder()
-            .claimId(GOOD_CLAIM_ID)
-            .closeReasonText("because we are testing")
-            .lifecycleStatusReasonCode("60")
-            .build();
-    CancelClaimResponse response = service.cancelClaim(request);
-    assertResponseIsSuccess(response, HttpStatus.OK);
-  }
-
-  @ParameterizedTest(name = "testCancelClaim_{0}")
-  @EnumSource(TestCase.class)
-  public void testCancelClaim_Non2xx(TestCase test) throws JsonProcessingException {
-    mockResponseForUrl(
-        Mockito.doThrow(test.ex), formatClaimUrl(CANCEL_CLAIM, test.claimId), HttpMethod.PUT);
-    CancelClaimRequest request =
-        CancelClaimRequest.builder()
-            .claimId(test.claimId)
-            .closeReasonText("because we are testing")
-            .lifecycleStatusReasonCode("60")
-            .build();
-    HttpStatusCodeException ex =
-        Assertions.assertThrows(test.ex.getClass(), () -> service.cancelClaim(request));
-    assertResponseHasMessageWithStatus(ex.getResponseBodyAsString(), test.status);
-  }
-
-  @Test
-  public void testCancelClaimInternalServerError_500() {
-    mockResponseForUrl(
-        Mockito.doThrow(new RuntimeException("nope")),
-        formatClaimUrl(CANCEL_CLAIM, INTERNAL_SERVER_ERROR_CLAIM_ID),
-        HttpMethod.PUT);
-
-    CancelClaimRequest request =
-        CancelClaimRequest.builder()
-            .claimId(INTERNAL_SERVER_ERROR_CLAIM_ID)
-            .closeReasonText("because we are testing")
-            .lifecycleStatusReasonCode("60")
-            .build();
-    BipException ex =
-        Assertions.assertThrows(BipException.class, () -> service.cancelClaim(request));
-    assertSame(HttpStatus.INTERNAL_SERVER_ERROR, ex.getStatus());
-  }
-
-  @Test
-  public void testPutLifecycleStatus_200() {
-    ResponseEntity<String> resp200 = ResponseEntity.ok("{}");
-    mockResponseForUrl(
-        Mockito.doReturn(resp200),
-        formatClaimUrl(CLAIM_LIFECYCLE_STATUS, GOOD_CLAIM_ID),
-        HttpMethod.PUT);
-    PutClaimLifecycleRequest request =
-        PutClaimLifecycleRequest.builder()
-            .claimId(GOOD_CLAIM_ID)
-            .claimLifecycleStatus("Just a test")
-            .build();
-    PutClaimLifecycleResponse response = service.putClaimLifecycleStatus(request);
-    assertResponseIsSuccess(response, HttpStatus.OK);
-  }
-
-  @ParameterizedTest(name = "testPutLifecycleStatus_{0}")
-  @EnumSource(TestCase.class)
-  public void testPutLifecycleStatus_Non2xx(TestCase test) throws JsonProcessingException {
-    mockResponseForUrl(
-        Mockito.doThrow(test.ex),
-        formatClaimUrl(CLAIM_LIFECYCLE_STATUS, test.claimId),
-        HttpMethod.PUT);
-    PutClaimLifecycleRequest request =
-        PutClaimLifecycleRequest.builder()
-            .claimId(test.claimId)
-            .claimLifecycleStatus("Just a test")
-            .build();
-    HttpStatusCodeException ex =
-        Assertions.assertThrows(test.ex.getClass(), () -> service.putClaimLifecycleStatus(request));
-    assertResponseHasMessageWithStatus(ex.getResponseBodyAsString(), test.status);
-  }
-
-  @Test
-  public void testPutLifecycleStatusInternalServerError_500() {
-    mockResponseForUrl(
-        Mockito.doThrow(new RuntimeException("nope")),
-        formatClaimUrl(CLAIM_LIFECYCLE_STATUS, INTERNAL_SERVER_ERROR_CLAIM_ID),
-        HttpMethod.PUT);
-
-    PutClaimLifecycleRequest request =
-        PutClaimLifecycleRequest.builder()
-            .claimId(INTERNAL_SERVER_ERROR_CLAIM_ID)
-            .claimLifecycleStatus("Just a test")
-            .build();
-    BipException ex =
-        Assertions.assertThrows(BipException.class, () -> service.putClaimLifecycleStatus(request));
-    assertSame(HttpStatus.INTERNAL_SERVER_ERROR, ex.getStatus());
-  }
-
-  @Test
-  public void testPutTemporaryStationOfJurisdiction_200() {
-    ResponseEntity<String> resp200 = ResponseEntity.ok("{}");
-
-    mockResponseForUrl(
-        Mockito.doReturn(resp200),
-        formatClaimUrl(TEMP_STATION_OF_JURISDICTION, GOOD_CLAIM_ID),
-        HttpMethod.PUT);
-
-    PutTempStationOfJurisdictionRequest request =
-        PutTempStationOfJurisdictionRequest.builder()
-            .claimId(GOOD_CLAIM_ID)
-            .tempStationOfJurisdiction("398")
-            .build();
-    PutTempStationOfJurisdictionResponse result = service.putTempStationOfJurisdiction(request);
-    assertResponseIsSuccess(result, HttpStatus.OK);
-  }
-
-  @Test
-  public void testPutTemporaryStationOfJurisdiction_404() throws Exception {
-    String resp404Body = getTestData(CLAIM_RESPONSE_404);
-
-    mockResponseForUrl(
-        Mockito.doThrow(
-            new HttpClientErrorException(
-                HttpStatus.NOT_FOUND,
-                HttpStatus.NOT_FOUND.name(),
-                resp404Body.getBytes(),
-                Charset.defaultCharset())),
-        formatClaimUrl(TEMP_STATION_OF_JURISDICTION, BAD_CLAIM_ID),
-        HttpMethod.PUT);
-
-    PutTempStationOfJurisdictionRequest request =
-        PutTempStationOfJurisdictionRequest.builder()
-            .claimId(BAD_CLAIM_ID)
-            .tempStationOfJurisdiction("398")
-            .build();
-    HttpStatusCodeException ex =
-        Assertions.assertThrows(
-            HttpStatusCodeException.class, () -> service.putTempStationOfJurisdiction(request));
-    assertResponseHasMessageWithStatus(ex.getResponseBodyAsString(), HttpStatus.NOT_FOUND);
-  }
-
-  @Test
-  public void testPutTemporaryStationOfJurisdictionDownstreamServerError_500() throws Exception {
-    String resp500Body = getTestData(RESPONSE_500);
-    mockResponseForUrl(
-        Mockito.doThrow(
-            new HttpServerErrorException(
-                HttpStatus.INTERNAL_SERVER_ERROR,
-                HttpStatus.INTERNAL_SERVER_ERROR.name(),
-                resp500Body.getBytes(),
-                Charset.defaultCharset())),
-        formatClaimUrl(TEMP_STATION_OF_JURISDICTION, INTERNAL_SERVER_ERROR_CLAIM_ID),
-        HttpMethod.PUT);
-
-    PutTempStationOfJurisdictionRequest request =
-        PutTempStationOfJurisdictionRequest.builder()
-            .claimId(INTERNAL_SERVER_ERROR_CLAIM_ID)
-            .tempStationOfJurisdiction("398")
-            .build();
-    HttpStatusCodeException ex =
-        Assertions.assertThrows(
-            HttpStatusCodeException.class, () -> service.putTempStationOfJurisdiction(request));
-    assertResponseHasMessageWithStatus(
-        ex.getResponseBodyAsString(), HttpStatus.INTERNAL_SERVER_ERROR);
-  }
-
-  @Test
-  public void testPutTemporaryStationOfJurisdictionInternalServerError_500() {
-    mockResponseForUrl(
-        Mockito.doThrow(new RuntimeException("nope")),
-        formatClaimUrl(TEMP_STATION_OF_JURISDICTION, INTERNAL_SERVER_ERROR_CLAIM_ID),
-        HttpMethod.PUT);
-
-    PutTempStationOfJurisdictionRequest request =
-        PutTempStationOfJurisdictionRequest.builder()
-            .claimId(INTERNAL_SERVER_ERROR_CLAIM_ID)
-            .tempStationOfJurisdiction("398")
-            .build();
-    BipException ex =
-        Assertions.assertThrows(
-            BipException.class, () -> service.putTempStationOfJurisdiction(request));
-    assertSame(HttpStatus.INTERNAL_SERVER_ERROR, ex.getStatus());
+      PutTempStationOfJurisdictionRequest request =
+          PutTempStationOfJurisdictionRequest.builder()
+              .claimId(test.claimId)
+              .tempStationOfJurisdiction("398")
+              .build();
+      Exception ex =
+          Assertions.assertThrows(
+              test.ex.getClass(), () -> service.putTempStationOfJurisdiction(request));
+      assertResponseExceptionWithStatus(ex, test.status);
+    }
   }
 
   @Test
@@ -635,6 +513,18 @@ public class BipApiServiceTest {
     assertNull(response.getMessages());
   }
 
+  private void assertResponseExceptionWithStatus(Exception ex, HttpStatus expected)
+      throws JsonProcessingException {
+    if (ex instanceof HttpStatusCodeException httpStatusCodeException) {
+      assertResponseHasMessageWithStatus(
+          httpStatusCodeException.getResponseBodyAsString(), expected);
+    } else if (ex instanceof BipException bipException) {
+      assertSame(expected, bipException.getStatus());
+    } else {
+      fail("Unsupported Error Type");
+    }
+  }
+
   private void assertResponseHasMessageWithStatus(String response, HttpStatus expected)
       throws JsonProcessingException {
     BipPayloadResponse bipResponse = MAPPER.readValue(response, BipPayloadResponse.class);
@@ -646,28 +536,41 @@ public class BipApiServiceTest {
     assertEquals(expected.name(), message.getHttpStatus());
   }
 
+  private enum ErrType {
+    CLIENT,
+    SERVER,
+    INTERNAL
+  }
+
   public enum TestCase {
-    NOT_FOUND(NOT_FOUND_CLAIM_ID, HttpStatus.NOT_FOUND, CLAIM_RESPONSE_404),
+    NOT_FOUND(ErrType.CLIENT, NOT_FOUND_CLAIM_ID, HttpStatus.NOT_FOUND, CLAIM_RESPONSE_404),
     DOWNSTREAM_ERROR(
-        INTERNAL_SERVER_ERROR_CLAIM_ID, HttpStatus.INTERNAL_SERVER_ERROR, RESPONSE_500);
+        ErrType.SERVER,
+        INTERNAL_SERVER_ERROR_CLAIM_ID,
+        HttpStatus.INTERNAL_SERVER_ERROR,
+        RESPONSE_500),
+    BIP_INTERNAL(
+        ErrType.INTERNAL,
+        INTERNAL_SERVER_ERROR_CLAIM_ID,
+        HttpStatus.INTERNAL_SERVER_ERROR,
+        RESPONSE_500);
 
     final long claimId;
     final HttpStatus status;
-    final HttpStatusCodeException ex;
+    final Exception ex;
 
     @SneakyThrows
-    TestCase(long claimId, HttpStatus status, String dataFile) {
+    TestCase(ErrType type, long claimId, HttpStatus status, String dataFile) {
       this.claimId = claimId;
       this.status = status;
       this.ex =
-          status == HttpStatus.INTERNAL_SERVER_ERROR
-              ? new HttpServerErrorException(
-                  status, status.name(), getTestData(dataFile).getBytes(), Charset.defaultCharset())
-              : new HttpClientErrorException(
-                  status,
-                  status.name(),
-                  getTestData(dataFile).getBytes(),
-                  Charset.defaultCharset());
+          switch (type) {
+            case CLIENT -> new HttpClientErrorException(
+                status, status.name(), getTestData(dataFile).getBytes(), Charset.defaultCharset());
+            case SERVER -> new HttpServerErrorException(
+                status, status.name(), getTestData(dataFile).getBytes(), Charset.defaultCharset());
+            case INTERNAL -> new RuntimeException("nope");
+          };
     }
   }
 }

--- a/svc-bip-api/src/test/resources/bip-test-data/claim_response_404.json
+++ b/svc-bip-api/src/test/resources/bip-test-data/claim_response_404.json
@@ -1,7 +1,7 @@
 {
   "messages": [
     {
-      "timestamp": "2023-02-06T18:10:59.288",
+      "timestamp": "2023-02-06T18:10:59.288Z",
       "key": "bip.vetservices.claims.contentions.claimidnotfound",
       "severity": "FATAL",
       "status": "404",

--- a/svc-bip-api/src/test/resources/bip-test-data/contention_response_201.json
+++ b/svc-bip-api/src/test/resources/bip-test-data/contention_response_201.json
@@ -1,0 +1,5 @@
+{
+  "contentionIds": [
+    1
+  ]
+}

--- a/svc-bip-api/src/test/resources/bip-test-data/contention_response_412.json
+++ b/svc-bip-api/src/test/resources/bip-test-data/contention_response_412.json
@@ -1,7 +1,7 @@
 {
   "messages": [
     {
-      "timestamp": "2023-02-06T18:27:32.316",
+      "timestamp": "2023-02-06T18:27:32.316Z",
       "key": "bip.vetservices.lastmodified.not.matched",
       "severity": "ERROR",
       "status": "412",

--- a/svc-bip-api/src/test/resources/bip-test-data/response_500.json
+++ b/svc-bip-api/src/test/resources/bip-test-data/response_500.json
@@ -1,7 +1,7 @@
 {
   "messages": [
     {
-      "timestamp": "2023-02-06T18:10:59.288",
+      "timestamp": "2023-02-06T18:10:59.288Z",
       "key": "bip.vetservices.internalServerError",
       "severity": "FATAL",
       "status": "500",


### PR DESCRIPTION
<!-- Ensure the PR title reflects the feature or bug name -->
## What was the problem?
<!-- brief description of how things worked before this PR -->
`svc-bip-api` was not correctly serializing bodies containing date/timestamp fields for requests made to BIP API. Turns out that the message converter for BIP api was not using the JavaTimeModule.

Associated tickets or Slack threads:
- #2714
- Thought it was fixed in #2715 but issue still persisted (see slack [thread](https://dsva.slack.com/archives/C01BVF2A3V0/p1709842883373739))

## How does this fix it?[^1]
<!-- description of how things will work after this PR -->
Uses the configured object mapper to serialize the requests with bodies for RestTemplate
 
## How to test this PR
- run unit and integration tests for `svc-bip-api` 

Run EP Merge tests as well: 
- End to End tests:
  - run this [CI](https://github.com/department-of-veterans-affairs/abd-vro/actions/workflows/ee-ep-merge-end-to-end.yml) action to verify successful integration test
  - run end to end tests locally:
    - `export BIP_CLAIM_URL=mock-bip-claims-api:20300`
    - run bgs and bip services and mocks:
      - `COMPOSE_PROFILES="bip,bgs" ./gradlew :app:dockerComposeUp`
      - `COMPOSE_PROFILES="bip,bgs" ./gradlew -p mocks :dockerComposeUp`
    - `./gradlew :domain-ee:ee-ep-merge-app:endToEndTest`

Note that the tests above use the `mock-bip-claims-api` which is VRO's best-guess based on swagger documentation of how actual BIP API works. So I also tested by deploying this commit to dev and finding a claim (id: 600145754) and making a manual request to `svc-bip-api` to create claim contentions endpoint using curl commands and putting a request into rabbitmq `bipApiExchange`. The steps outlined in #2715 can be followed to repeat the process assuming that the deployment has not been overwritten. 

[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
