### PR TITLE
Github action version rollback

### DIFF
--- a/.github/workflows/delete-old-releases.yml
+++ b/.github/workflows/delete-old-releases.yml
@@ -65,7 +65,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: "Delete old releases in GHCR"
-      uses: yoomlam/delete-older-releases@v0.3.0
+      uses: yoomlam/delete-older-releases@v0.3.2
       with:
         dry_run: ${{ inputs.dry_run || false }}
         delete_tags: true

--- a/.github/workflows/delete-old-releases.yml
+++ b/.github/workflows/delete-old-releases.yml
@@ -65,7 +65,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: "Delete old releases in GHCR"
-      uses: yoomlam/delete-older-releases@v0.3.2
+      uses: yoomlam/delete-older-releases@v0.3.0
       with:
         dry_run: ${{ inputs.dry_run || false }}
         delete_tags: true


### PR DESCRIPTION
Update yoomlam/delete-older-releases version due to error in pipeline:
`Unable to resolve action `yoomlam/delete-older-releases@v0.3.2`, unable to find version 0.3.2`