### PR TITLE
mock-bip-claims-api: Updated mocks for new EE EP Merge End2End tests.

### DIFF
--- a/mocks/mock-bip-claims-api/src/main/java/gov/va/vro/mockbipclaims/config/ClaimIdConstants.java
+++ b/mocks/mock-bip-claims-api/src/main/java/gov/va/vro/mockbipclaims/config/ClaimIdConstants.java
@@ -12,7 +12,8 @@ public class ClaimIdConstants {
   public static final int CLAIM_ID_SET_TSOJ_YIELDS_500 = 5003;
 
   // GET /claims/{claimId}/contentions
-  public static final int CLAIM_ID_GET_CONTENTIONS_YIELDS_500 = 5004;
+  public static final int CLAIM_ID_GET_PENDING_EP_CONTENTIONS_YIELDS_500 = 5004;
+  public static final int CLAIM_ID_GET_SUPP_EP_CONTENTIONS_YIELDS_500 = 50041;
   // PUT /claims/{claimId}/contentions
   public static final int CLAIM_ID_UPDATE_CONTENTIONS_YIELDS_500 = 5005;
   // POST /claims/{claimId}/contentions

--- a/mocks/mock-bip-claims-api/src/main/java/gov/va/vro/mockbipclaims/controller/ContentionsController.java
+++ b/mocks/mock-bip-claims-api/src/main/java/gov/va/vro/mockbipclaims/controller/ContentionsController.java
@@ -2,7 +2,8 @@ package gov.va.vro.mockbipclaims.controller;
 
 import static gov.va.vro.mockbipclaims.config.ClaimIdConstants.CLAIM_ID_ALL_ENDPOINTS_YIELDS_500;
 import static gov.va.vro.mockbipclaims.config.ClaimIdConstants.CLAIM_ID_CREATE_CONTENTIONS_YIELDS_500;
-import static gov.va.vro.mockbipclaims.config.ClaimIdConstants.CLAIM_ID_GET_CONTENTIONS_YIELDS_500;
+import static gov.va.vro.mockbipclaims.config.ClaimIdConstants.CLAIM_ID_GET_PENDING_EP_CONTENTIONS_YIELDS_500;
+import static gov.va.vro.mockbipclaims.config.ClaimIdConstants.CLAIM_ID_GET_SUPP_EP_CONTENTIONS_YIELDS_500;
 import static gov.va.vro.mockbipclaims.config.ClaimIdConstants.CLAIM_ID_UPDATE_CONTENTIONS_YIELDS_500;
 
 import gov.va.vro.mockbipclaims.api.ContentionsApi;
@@ -79,7 +80,8 @@ public class ContentionsController extends BaseController implements Contentions
       return createClaim404(response, claimId);
     }
     if (claimId == CLAIM_ID_ALL_ENDPOINTS_YIELDS_500
-        || claimId == CLAIM_ID_GET_CONTENTIONS_YIELDS_500) {
+        || claimId == CLAIM_ID_GET_PENDING_EP_CONTENTIONS_YIELDS_500
+        || claimId == CLAIM_ID_GET_SUPP_EP_CONTENTIONS_YIELDS_500) {
       return create500(response);
     }
 

--- a/mocks/mock-bip-claims-api/src/main/resources/mock-claims.json
+++ b/mocks/mock-bip-claims-api/src/main/resources/mock-claims.json
@@ -814,7 +814,11 @@
       "claimId": 10001,
       "phase": "Claim Received",
       "endProductCode": "400",
-      "claimLifecycleStatus": "Open"
+      "claimLifecycleStatus": "Open",
+      "benefitClaimType": {
+        "name": "eBenefits 526EZ-Supplemental (400)",
+        "code": "400SUPP"
+      }
     },
     "contentions": [
       {
@@ -840,7 +844,11 @@
       "claimId": 10002,
       "phase": "Claim Received",
       "endProductCode": "400",
-      "claimLifecycleStatus": "Open"
+      "claimLifecycleStatus": "Open",
+      "benefitClaimType": {
+        "name": "eBenefits 526EZ-Supplemental (400)",
+        "code": "400SUPP"
+      }
     },
     "contentions": [
       {
@@ -866,7 +874,11 @@
       "claimId": 10003,
       "phase": "Claim Received",
       "endProductCode": "400",
-      "claimLifecycleStatus": "Open"
+      "claimLifecycleStatus": "Open",
+      "benefitClaimType": {
+        "name": "eBenefits 526EZ-Supplemental (400)",
+        "code": "400SUPP"
+      }
     },
     "contentions": [
       {
@@ -892,7 +904,11 @@
       "claimId": 10004,
       "phase": "Claim Received",
       "endProductCode": "400",
-      "claimLifecycleStatus": "Open"
+      "claimLifecycleStatus": "Open",
+      "benefitClaimType": {
+        "name": "eBenefits 526EZ-Supplemental (400)",
+        "code": "400SUPP"
+      }
     },
     "contentions": [
       {
@@ -931,7 +947,11 @@
       "claimId": 10005,
       "phase": "Claim Received",
       "endProductCode": "400",
-      "claimLifecycleStatus": "Open"
+      "claimLifecycleStatus": "Open",
+      "benefitClaimType": {
+        "name": "eBenefits 526EZ-Supplemental (400)",
+        "code": "400SUPP"
+      }
     },
     "contentions": [
       {
@@ -970,7 +990,11 @@
       "claimId": 10006,
       "phase": "Claim Received",
       "endProductCode": "400",
-      "claimLifecycleStatus": "Open"
+      "claimLifecycleStatus": "Open",
+      "benefitClaimType": {
+        "name": "eBenefits 526EZ-Supplemental (400)",
+        "code": "400SUPP"
+      }
     },
     "contentions": []
   },
@@ -1005,7 +1029,12 @@
       "claimId": 5002,
       "phase": "Claim Received",
       "tempStationOfJurisdiction": "398",
-      "endProductCode": "400"
+      "endProductCode": "400",
+      "claimLifecycleStatus": "Open",
+      "benefitClaimType": {
+        "name": "eBenefits 526EZ-Supplemental (400)",
+        "code": "400SUPP"
+      }
     },
     "contentions": [
       {
@@ -1028,7 +1057,12 @@
       "claimId": 5003,
       "phase": "Claim Received",
       "tempStationOfJurisdiction": "398",
-      "endProductCode": "400"
+      "endProductCode": "400",
+      "claimLifecycleStatus": "Open",
+      "benefitClaimType": {
+        "name": "eBenefits 526EZ-Supplemental (400)",
+        "code": "400SUPP"
+      }
     },
     "contentions": [
       {
@@ -1045,7 +1079,7 @@
   },
   {
     "description": [
-      "Employee Experience EP Merge End 2 End Testing - Fails at get claim contentions"
+      "Employee Experience EP Merge End 2 End Testing - Fails at get pending claim contentions"
     ],
     "claimDetail": {
       "claimId": 5004,
@@ -1068,13 +1102,45 @@
   },
   {
     "description": [
+      "Employee Experience EP Merge End 2 End Testing - Fails at get ep400 claim contentions"
+    ],
+    "claimDetail": {
+      "claimId": 50041,
+      "phase": "Claim Received",
+      "endProductCode": "400",
+      "claimLifecycleStatus": "Open",
+      "benefitClaimType": {
+        "name": "eBenefits 526EZ-Supplemental (400)",
+        "code": "400SUPP"
+      }
+    },
+    "contentions": [
+      {
+        "medicalInd": true,
+        "beginDate": "2023-01-01T00:00:00Z",
+        "contentionTypeCode": "NEW",
+        "classificationType": 1250,
+        "diagnosticTypeCode": "6100",
+        "claimantText": "tendinitis/bilateral",
+        "contentionId": "1",
+        "lastModified": "2023-01-01T00:00:01Z"
+      }
+    ]
+  },
+  {
+    "description": [
       "Employee Experience EP Merge End 2 End Testing - Fails at update claim contentions"
     ],
     "claimDetail": {
       "claimId": 5005,
       "phase": "Claim Received",
       "tempStationOfJurisdiction": "398",
-      "endProductCode": "400"
+      "endProductCode": "400",
+      "claimLifecycleStatus": "Open",
+      "benefitClaimType": {
+        "name": "eBenefits 526EZ-Supplemental (400)",
+        "code": "400SUPP"
+      }
     },
     "contentions": [
       {


### PR DESCRIPTION
<!-- Ensure the PR title reflects the feature or bug name -->

## What was the problem?
<!-- brief description of how things worked before this PR -->
Certain `mock-bip-claims-api` mocks need to be updated to include information for new EE EP Merge App end to end tests.

Associated tickets or Slack threads:
- #2734 

## How does this fix it?[^1]
<!-- description of how things will work after this PR -->

## How to test this PR
- run mock services unit tests 
- run integration tests for `svc-bip-api` and `ee-ep-merge-app`


[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
