### PR TITLE
#2749: PROD FIX, Increase rabbitmq container memory

### DIFF
--- a/helm/platform/charts/rabbitmq/values.yaml
+++ b/helm/platform/charts/rabbitmq/values.yaml
@@ -13,3 +13,11 @@ service:
   mq:
     sourcePort: 5672
     targetPort: 5672
+
+resources:
+  requests:
+    cpu: 150m
+    memory: 1024Mi
+  limits:
+    cpu: 2000m
+    memory: 4096Mi


### PR DESCRIPTION
## What was the problem?
The production rabbitmq instance is experiencing intense memory pressure.

Associated tickets or Slack threads:
- #2749

## How does this fix it?[^1]
Quick fix to increase the memory



[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
