### PR TITLE
Update BGS-api readiness probe

### DIFF
--- a/helm/svc-bgs-api/values.yaml
+++ b/helm/svc-bgs-api/values.yaml
@@ -20,7 +20,7 @@ startupProbe:
   initialDelaySeconds: 120  
   periodSeconds: 10
   timeoutSeconds: 10
-  failureThreshold: 30  
+  failureThreshold: 25 
 
 livenessProbe:
   exec:

--- a/svc-bgs-api/src/healthcheck/readiness_script.rb
+++ b/svc-bgs-api/src/healthcheck/readiness_script.rb
@@ -34,7 +34,7 @@ def check_vro_participant_id
   bgs_client = BgsClient.new
   participant_id = bgs_client.vro_participant_id
   if participant_id
-    log "Successfully fetched VRO participant ID: #{participant_id}"
+    log "Successfully fetched VRO participant ID"
     true
   else
     log "Failed to fetch VRO participant ID"

--- a/svc-bgs-api/src/healthcheck/readiness_script.rb
+++ b/svc-bgs-api/src/healthcheck/readiness_script.rb
@@ -4,6 +4,7 @@
 
 require 'logger'
 require_relative '../lib/rabbit_subscriber'
+require_relative '../lib/bgs_client'
 require_relative '../config/constants'
 require_relative '../config/setup'
 
@@ -28,27 +29,23 @@ def rabbitmq_connection_active?
   end
 end
 
-# Function to check if BGS settings are correctly loaded and configured
-def check_bgs_configuration
-  bgs_settings = SETTINGS['bgs']
-  
-  # Check if all required BGS settings in the settings.yml file are present
-  required_keys = %w[application client_station_id client_username log base_url]
-  missing_keys = required_keys.select { |key| bgs_settings[key].nil? || bgs_settings[key].to_s.empty? }
-  
-  if missing_keys.empty?
-    log "BGS configuration loaded successfully."
+# Function to fetch the VRO participant ID from BGS
+def check_vro_participant_id
+  bgs_client = BgsClient.new
+  participant_id = bgs_client.vro_participant_id
+  if participant_id
+    log "Successfully fetched VRO participant ID: #{participant_id}"
     true
   else
-    log "Missing BGS configuration keys: #{missing_keys.join(', ')}"
+    log "Failed to fetch VRO participant ID"
     false
   end
 end
 
 def perform_readiness_checks
-  bgs_config_ok = check_bgs_configuration
   rabbitmq_ok = rabbitmq_connection_active?
-  if bgs_config_ok && rabbitmq_ok
+  vro_participant_id_ok = check_vro_participant_id
+  if rabbitmq_ok && vro_participant_id_ok
     log "Readiness checks passed!"
     true
   else
@@ -56,7 +53,6 @@ def perform_readiness_checks
     false
   end
 end
-
 
 unless perform_readiness_checks
   exit(1)

--- a/svc-bgs-api/src/main_consumer.rb
+++ b/svc-bgs-api/src/main_consumer.rb
@@ -11,6 +11,7 @@ require 'bgs_client'
 $stdout.sync = true
 
 def initialize_subscriber(bgs_client)
+  $logger.info bgs_client.vro_participant_id
   subscriber = RabbitSubscriber.new(BUNNY_ARGS)
 
   # Setup queue/subscription for healthcheck

--- a/svc-bgs-api/src/main_consumer.rb
+++ b/svc-bgs-api/src/main_consumer.rb
@@ -11,7 +11,6 @@ require 'bgs_client'
 $stdout.sync = true
 
 def initialize_subscriber(bgs_client)
-  $logger.info bgs_client.vro_participant_id
   subscriber = RabbitSubscriber.new(BUNNY_ARGS)
 
   # Setup queue/subscription for healthcheck


### PR DESCRIPTION
## What was the problem?
Improving our K8s readiness probe for **svc-bgs-api** pod. Before it checked RabbitMQ connectivity and our configuration in our **settings.yml** file, which caused our readiness probe to always pass regardless of the current status of svc-bgs-api microservice. 

Associated tickets or Slack threads:
- #2566 

## How does this fix it?[^1]
Adds a method that fetches for specific data (**vro_participant_id**) from bgs-api microservice. This ensures that our application has all necessary external connections established and can access critical data before it starts processing messages. In turn, ensures highest level of visibility and reliability into the health and readiness of svc-bgs-api. 

## How to test this PR
On Lens:
- Get into svc-bgs-api pod and run the following command to check readiness:
                   `bundle exec ruby healthcheck/readiness_script.rb`
- Restart **RabbitMQ** pod and run this command in the **svc-bgs-api** pod again (readiness probes will fail)
