### PR TITLE
update the script that generates kafka truststore file

### DIFF
--- a/scripts/svc-bie-kafka-certgen.sh
+++ b/scripts/svc-bie-kafka-certgen.sh
@@ -6,23 +6,12 @@
 # output.json contains 4 key-value pairs, which should be pasted into to Vault
 #
 #   Following keys/values are generated
-#       BIE_KAFKA_KEYSTORE_INBASE64
-#       BIE_KAFKA_KEYSTORE_PASSWORD
 #       BIE_KAFKA_TRUSTSTORE_INBASE64
 #       BIE_KAFKA_TRUSTSTORE_PASSWORD
 # Pre-requisite:
-#     - Download certificates locally from the links provided at wiki https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/VRO-Secrets
-#       VA-Internal-S2-ICA4.cer
-#       VA-Internal-S2-ICA19.cer
-#       VA-Internal-S2-ICA11.cer
-#       VA-Internal-S2-RCA2.cer
-# Input:
-# $1 Input environment name like dev, qa, prod
-# $2 Input BIE provided certificate file
-# $3 Input BIE provided key
-# $4 Input BIE Kafka environment prefix like dev, ivv, pr, pp
+#     - Download all public certificates from http://aia.pki.va.gov/PKI/AIA/VA/ (ignore AllVAInternalCAs.p7b and NewVAInternalCAs.p7b)
+#       locally before running this script
 #
-# - ----
 
 # Function:  generates a random password for keystore and truststore
 generate_password() {
@@ -39,29 +28,33 @@ generate_password() {
     openssl rand -base64 20 | tr -dc "$all_chars" | head -c 16
 }
 
-export KEYSTORE_PWD=$(generate_password)
-export TRUSTSTORE_PWD=$(generate_password)
+# Generate a password for the keystore
+STOREPASS=$(generate_password)
+echo "Generated keystore password: $STOREPASS"
 
-# Delete temporary files (if they exist) to avoid issues when re-running script.
-# Keeping them will result in password mismatch error. They are safe to delete as they are recreated.
-rm -f bip.truststore.jks keystore.p12 bip.truststore.p12 passwd output.json
+# Define the keystore file name
+TRUSTSTORE="vro-truststore.p12"
 
-openssl pkcs12 -export -in "$2" -inkey "$3" -out keystore.p12 -name kafka-keystore-$4-$1 -CAfile VACACerts.pem -caname root -passout env:KEYSTORE_PWD
+# Create or clear the existing keystore
+rm -f "$TRUSTSTORE"
 
-keytool -importkeystore -srckeystore keystore.p12 -srcstoretype pkcs12 -destkeystore bip.truststore.jks -deststoretype JKS -srcstorepass "$KEYSTORE_PWD" -deststorepass "$TRUSTSTORE_PWD"
+# Loop through the .cer files and import each into the keystore
+for certfile in *.cer; do
+    # Extract alias name by removing the 'VA-Internal-' prefix from the filename
+    alias=$(echo "$certfile" | sed 's/VA-Internal-//; s/.cer$//')
 
-echo "yes" | keytool -import -alias AllVA1 -file VA-Internal-S2-ICA4.cer -storetype JKS -keystore bip.truststore.jks -storepass "$TRUSTSTORE_PWD"
-# shellcheck disable=SC2086
-echo "yes" | keytool -import -alias AllVA2 -file VA-Internal-S2-ICA19.cer -storetype JKS -keystore bip.truststore.jks -storepass "$TRUSTSTORE_PWD"
-echo "yes" | keytool -import -alias AllVA3 -file VA-Internal-S2-ICA11.cer -storetype JKS -keystore bip.truststore.jks -storepass "$TRUSTSTORE_PWD"
-echo "yes" | keytool -import -alias AllVA4 -file VA-Internal-S2-RCA2.cer -storetype JKS -keystore bip.truststore.jks -storepass "$TRUSTSTORE_PWD"
+    # Import the certificate into the keystore
+    keytool -import -noprompt -alias "$alias" -file "$certfile" -keystore "$TRUSTSTORE" -storepass "$STOREPASS" -storetype PKCS12
+done
 
-echo "$KEYSTORE_PWD" | keytool -importkeystore -srckeystore bip.truststore.jks -srcstoretype jks -srcstorepass "$TRUSTSTORE_PWD" -destkeystore bip.truststore.p12 -deststoretype pkcs12 -deststorepass "$TRUSTSTORE_PWD"
+# Encode the keystore file to Base64 and print it
+echo "Base64 Encoded Truststore:"
+base64 -i "$TRUSTSTORE"
 
 
 # Encode the files
-keystore=$(cat keystore.p12 | base64 | tr -d '\n')
-bip_truststore=$(cat bip.truststore.p12 | base64 | tr -d '\n')
+keystore=$(cat "$TRUSTSTORE" | base64 | tr -d '\n')
+truststore=$(cat "$TRUSTSTORE" | base64 | tr -d '\n')
 
 # Create the JSON file
-echo -e "{\n\"BIE_KAFKA_KEYSTORE_INBASE64\": \"$keystore\", \n\"BIE_KAFKA_KEYSTORE_PASSWORD\": \"$KEYSTORE_PWD\", \n\"BIE_KAFKA_TRUSTSTORE_INBASE64\": \"$bip_truststore\", \n\"BIE_KAFKA_TRUSTSTORE_PASSWORD\": \"$TRUSTSTORE_PWD\"\n}" > output.json
+echo -e "{\n\"BIE_KAFKA_TRUSTSTORE_INBASE64\": \"$truststore\", \n\"BIE_KAFKA_TRUSTSTORE_PASSWORD\": \"$STOREPASS\"\n}" > output.json

--- a/scripts/svc-bie-kafka-certgen.sh
+++ b/scripts/svc-bie-kafka-certgen.sh
@@ -30,30 +30,29 @@ generate_password() {
 
 # Generate a password for the keystore
 STOREPASS=$(generate_password)
-echo "Generated keystore password: $STOREPASS"
+echo "Generated truststore password: $STOREPASS"
 
-# Define the keystore file name
+# Define the truststore file name
 TRUSTSTORE="vro-truststore.p12"
 
-# Create or clear the existing keystore
+# Create or clear the existing truststore
 rm -f "$TRUSTSTORE"
 
-# Loop through the .cer files and import each into the keystore
+# Loop through the .cer files and import each into the truststore
 for certfile in *.cer; do
     # Extract alias name by removing the 'VA-Internal-' prefix from the filename
     alias=$(echo "$certfile" | sed 's/VA-Internal-//; s/.cer$//')
 
-    # Import the certificate into the keystore
+    # Import the certificate into the truststore
     keytool -import -noprompt -alias "$alias" -file "$certfile" -keystore "$TRUSTSTORE" -storepass "$STOREPASS" -storetype PKCS12
 done
 
-# Encode the keystore file to Base64 and print it
+# Encode the truststore file to Base64 and print it
 echo "Base64 Encoded Truststore:"
 base64 -i "$TRUSTSTORE"
 
 
 # Encode the files
-keystore=$(cat "$TRUSTSTORE" | base64 | tr -d '\n')
 truststore=$(cat "$TRUSTSTORE" | base64 | tr -d '\n')
 
 # Create the JSON file


### PR DESCRIPTION
<!-- Ensure the PR title reflects the feature or bug name -->

## What was the problem?
1. With kafka RBAC changes, we no longer need to have a keystore file
2. The truststore file need to include all VA s1 and s2 certs

Associated tickets or Slack threads:
- NA

## How does this fix it?[^1]
updated the script to generate truststore base64 and password to be stored in VRO Vault



[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
