### PR TITLE
Secrel Decoupling

### DIFF
--- a/.github/workflows/secrel.yml
+++ b/.github/workflows/secrel.yml
@@ -210,11 +210,11 @@ jobs:
           fi
 
           # Throw an error if the IMAGE_LIST variable is an empty array
-          if [ ${{ IMAGE_LIST }} == "[]"]; then
+          if [ "${{ IMAGE_LIST }}" == "[]" ]; then
             exit 1
           fi
 
-          echo "image_list=IMAGE_LIST" >> "$GITHUB_OUTPUT"
+          echo "image_list=${IMAGE_LIST}" >> "$GITHUB_OUTPUT"
 
   secrel:
     name: SecRel Pipeline

--- a/.github/workflows/secrel.yml
+++ b/.github/workflows/secrel.yml
@@ -221,7 +221,7 @@ jobs:
 
           echo "${{needs.gate-check.outputs.run-secrel}}"
 
-          RUN_SECREL="${{needs.gate-check.outputs.run-secrel}}"
+          RUN_SECREL="true"
           {
             echo "image_list=${IMAGE_LIST}"
             echo "run_secrel=${RUN_SECREL}"

--- a/.github/workflows/secrel.yml
+++ b/.github/workflows/secrel.yml
@@ -6,6 +6,7 @@ on:
   push:
     branches: [ main, qa, develop, domain-* ]
 
+  # Run SecRel on Dependabot PRs, automatically
   pull_request:
     branches: [ develop ]
 
@@ -22,6 +23,37 @@ on:
         required: true
         type: boolean
         default: true
+      publish_images:
+        description: "Publish images from the head of the selected branch?"
+        required: true
+        type: boolean
+        default: false
+      image_name:
+        description: "Which images do you want to run SecRel on?"
+        required: true
+        type: choice
+        default: all
+        options:
+          - all
+          - domain-cc
+          - domain-xample
+          - svc-bgs-api
+          - svc-bie-kafka
+          - svc-bip-api
+          - svc-lighthouse-api
+          - api-gateway
+          - domain-ee-max-cfi-app
+          - domain-ee-ep-merge-app
+          - dev-tools
+          - db-init
+          - vro-app
+          - vro-redis
+          - vro-rabbitmq
+      image_tag:
+        description: "Image tag to run SecRel on. If 'all' is selected, then 'latest' will always be used"
+        required: true
+        type: string
+        default: latest
 
 env:
   # Id for the #benefits-vro-devops Slack channel
@@ -33,33 +65,43 @@ jobs:
     # only run for the internal repo, where the images are published
     if: github.repository == 'department-of-veterans-affairs/abd-vro-internal'
     outputs:
-      continue: ${{ steps.check-state.outputs.continue }}
+      run-secrel: ${{ steps.check-run-conds.outputs.run_secrel }}
+      publish-images: ${{ steps.check-run-conds.outputs.publish_images }}
     runs-on: ubuntu-latest
     steps:
-      - name: "Check trigger event"
-        id: check-state
+      - name: "Decide downstream actions"
+        id: check-run-conds
         run: |
           # Gate Check
           if [ "${{ github.event_name }}" == "pull_request" ]; then
             if echo "$GITHUB_HEAD_REF" | grep '^dependabot/'; then
-              CONTINUE=true
+              RUN_SECREL=true
+              PUBLISH_IMAGES=true
               echo "Running SecRel against a Dependabot PR" | tee -a "$GITHUB_STEP_SUMMARY"
             else
-              CONTINUE=false
+              RUN_SECREL=false
               echo "For PRs, SecRel runs against only Dependabot PR" | tee -a "$GITHUB_STEP_SUMMARY"
             fi
+          elif [ "${{ github.event_name }}" == "push" ]; then
+              PUBLISH_IMAGES=true
+          elif [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+            RUN_SECREL=${{ inputs.run_secrel }}
+            PUBLISH_IMAGES=${{ inputs.publish_images }}
           fi
 
-          echo "continue=${CONTINUE:-true}" >> "$GITHUB_OUTPUT"
+          {
+            echo "run_secrel=${RUN_SECREL:-true}"
+            echo "publish_images=${PUBLISH_IMAGES:-false}"
+          } >> "$GITHUB_OUTPUT"
 
+  # This step is always expected to output a non-empty list of images published
   publish-to-ghcr:
     name: Publish to GHCR
     needs: gate-check
-    if: needs.gate-check.outputs.continue == 'true'
+    if: needs.gate-check.outputs.publish-images == 'true'
     outputs:
       vro-images: ${{ steps.publish-images.outputs.images_list }}
       slack-response-ts: ${{ fromJson(steps.notify-slack.outputs.slack-result).response.message.ts }}
-      run-secrel: ${{ steps.image-props.outputs.run_secrel }}
     runs-on: ubuntu-latest
     steps:
       - name: "Determine image tag"
@@ -68,7 +110,6 @@ jobs:
           # Set defaults
           IMG_TAG=${GITHUB_SHA:0:7}
           RUN_GRADLE_TESTS="true"
-          RUN_SECREL="true"
 
           # Override some defaults depending on the branch/ref_name
           echo "ref_name: ${{ github.ref_name }}"
@@ -76,13 +117,11 @@ jobs:
           # If workflow was manually dispatched, override settings
           if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
             RUN_GRADLE_TESTS=${{ inputs.run_tests }}
-            RUN_SECREL=${{ inputs.run_secrel }}
           fi
 
           {
             echo "image_tag=${IMG_TAG}"
             echo "run_tests=${RUN_GRADLE_TESTS}"
-            echo "run_secrel=${RUN_SECREL}"
           } >> "$GITHUB_OUTPUT"
 
       - name: "DEBUG"
@@ -127,24 +166,64 @@ jobs:
           slack-optional-thread_ts: ${{ fromJson(steps.notify-slack.outputs.slack-result).response.message.ts }}
           slack-text: ":panda_builder: Images published!"
 
-  debug-job:
-    needs: publish-to-ghcr
+  secrel-inputs:
+    if: ${{ !failure() }} && ${{ needs.gate-check.outputs.run-secrel }}
+    needs: [publish-to-ghcr, gate-check]
+    outputs:
+      vro-images: ${{ steps.vro-images.outputs.image_list }}
     runs-on: ubuntu-latest
     steps:
-      - name: show vars
+      - name: "Determine VRO image inputs"
+        id: vro-images
         run: |
-          echo "ref_name: ${{github.ref_name}}"
-          echo "vro-images: ${{ needs.publish-to-ghcr.outputs.vro-images }}"
+
+          source scripts/image_vars.src
+          IMAGE_LIST="[]"
+
+          # This case captures manual dispatches where publishing is disabled
+          if [ "${{needs.publish-to-ghcr.result}}" == 'skipped' ]; then
+
+            IMAGE_LIST="["
+
+            if [ "${{ inputs.image_name }}" == 'all' ]; then
+              for PREFIX in "${VAR_PREFIXES_ARR[@]}"; do
+                IMG_NAME="$(getVarValue "${PREFIX}" _IMG)"
+                GHCR_PATH="ghcr.io/${{ github.repository }}/${IMG_NAME}"
+                IMAGE_LIST+=("\"${GHCR_PATH}:latest\",")
+              done
+
+              # Remove the trailing comma
+              IMAGE_LIST=${IMAGE_LIST%?}
+            else
+              IMG_TAG="${{ inputs.image_tag }}"
+              IMG_NAME="$(getVarValue "$(bashVarPrefix "${inputs.image_name}")" _IMG)"
+              GHCR_PATH="ghcr.io/${{ github.repository }}/${IMG_NAME}"
+              IMAGE_LIST+=("\"${GHCR_PATH}:${IMG_TAG}\"")
+            fi
+
+            IMAGE_LIST+="]"
+
+          # This case captures when the workflow is run automatically on PR merge along
+          # with manual dispatches where publishing is disabled
+          elif [ "${{needs.publish-to-ghcr.result}}" == 'success' ]; then
+            IMAGE_LIST=${{ needs.publish-to-ghcr.outputs.vro-images }}
+          fi
+
+          # Throw an error if the IMAGE_LIST variable is an empty array
+          if [ ${{ IMAGE_LIST }} == "[]"]; then
+            exit 1
+          fi
+
+          echo "image_list=IMAGE_LIST" >> "$GITHUB_OUTPUT"
 
   secrel:
     name: SecRel Pipeline
-    needs: publish-to-ghcr
-    if: needs.publish-to-ghcr.outputs.run-secrel == 'true'
+    needs: secrel-inputs
+    secrets: inherit
     uses: department-of-veterans-affairs/lighthouse-tornado-secrel-pipeline/.github/workflows/pipeline.yml@v5
     with:
       config-file: .github/secrel/config.yml
-      images: ${{ needs.publish-to-ghcr.outputs.vro-images }}
-    secrets: inherit
+      images: ${{ needs.secrel-inputs.outputs.vro-images }}
 
   notify-secrel-error:
     needs: secrel
@@ -162,54 +241,3 @@ jobs:
               SecRel scan (#${{ github.run_number }}) failed>! \n\
               ${{github.ref_type}} `${{github.ref_name}}` (`${{github.sha}}`), \n\
               caused by `${{github.event_name}}` triggered by `${{github.triggering_actor}}` ..."
-
-  slack-final:
-    needs: [ gate-check, publish-to-ghcr, secrel]
-    runs-on: ubuntu-latest
-    if: always()
-    steps:
-      - name: "Set status message"
-        run: |
-          URL=${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}
-          {
-            if [ "${{needs.publish-to-ghcr.result}}" == 'failure' ]; then
-              echo "WORKFLOW_STATE_TEXT=:panda_blank: <$URL|Publishing> failed!"
-              echo 'WORKFLOW_STATE_EMOJI=x'
-            elif [ "${{needs.secrel.result}}" == 'failure' ]; then
-              echo "WORKFLOW_STATE_TEXT=:panda_cop: <$URL|SecRel> failed!"
-              echo 'WORKFLOW_STATE_EMOJI=x'
-            elif [ "${{needs.secrel.result}}" == 'success' ]; then
-              echo "WORKFLOW_STATE_TEXT=:panda-yay: SecRel passed and images signed!"
-              echo 'WORKFLOW_STATE_EMOJI=panda-yay'
-            elif [ "${{needs.publish-to-ghcr.result}}" == 'skipped' ]; then
-              echo "WORKFLOW_STATE_TEXT=:black_square_for_stop: <$URL|Publishing> skipped"
-              echo 'WORKFLOW_STATE_EMOJI=black_square_for_stop'
-            elif [ "${{needs.publish-to-ghcr.outputs.run-secrel}}" == "true" ] && [ "${{needs.secrel.result}}" != 'success' ]; then
-              echo "WORKFLOW_STATE_TEXT=:black_square_for_stop: <$URL|SecRel> ${{needs.secrel.result}}"
-              echo 'WORKFLOW_STATE_EMOJI=black_square_for_stop'
-            elif [ "${{needs.publish-to-ghcr.outputs.run-secrel}}" == "false" ] && [ "${{needs.publish-to-ghcr.result}}" == 'success' ]; then
-              echo "WORKFLOW_STATE_TEXT=:heavy_check_mark: Run completed (without SecRel scans or signing images)"
-              echo 'WORKFLOW_STATE_EMOJI=heavy_check_mark'
-            else
-              echo "WORKFLOW_STATE_TEXT=publish: ${{needs.publish-to-ghcr.result}}; secrel: ${{needs.secrel.result}}"
-              echo 'WORKFLOW_STATE_EMOJI=shrug'
-            fi
-          } >> "$GITHUB_ENV"
-
-      - name: "Slack thread: Post final status"
-        if: always() && needs.gate-check.outputs.continue == 'true'
-        uses: archive/github-actions-slack@v2.9.0
-        with:
-          slack-bot-user-oauth-access-token: ${{ secrets.SLACK_BOT_USER_OAUTH_ACCESS_TOKEN }}
-          slack-channel: ${{ env.SLACK_CHANNEL }}
-          slack-optional-thread_ts: ${{ needs.publish-to-ghcr.outputs.slack-response-ts }}
-          slack-text: ${{ env.WORKFLOW_STATE_TEXT }}
-      - name: "Slack emoji: React success on top-level Slack notification"
-        if: always() && needs.gate-check.outputs.continue == 'true'
-        uses: archive/github-actions-slack@v2.9.0
-        with:
-          slack-function: send-reaction
-          slack-bot-user-oauth-access-token: ${{ secrets.SLACK_BOT_USER_OAUTH_ACCESS_TOKEN }}
-          slack-channel: ${{ env.SLACK_CHANNEL }}
-          slack-message-timestamp: ${{ needs.publish-to-ghcr.outputs.slack-response-ts }}
-          slack-emoji-name: ${{ env.WORKFLOW_STATE_EMOJI }}

--- a/.github/workflows/secrel.yml
+++ b/.github/workflows/secrel.yml
@@ -167,7 +167,7 @@ jobs:
           slack-text: ":panda_builder: Images published!"
 
   secrel-inputs:
-    if: ${{ !failure() }} && ${{ needs.gate-check.outputs.run-secrel }}
+    if: ${{ !failure() && needs.gate-check.outputs.run-secrel }}
     needs: [publish-to-ghcr, gate-check]
     outputs:
       vro-images: ${{ steps.vro-images.outputs.image_list }}
@@ -175,7 +175,46 @@ jobs:
     steps:
       - name: "Determine VRO image inputs"
         id: vro-images
-        run: ./scripts/secrel-secrel-inputs.sh
+        run: |
+
+          source scripts/image_vars.src
+          IMAGE_LIST="[]"
+
+          # This case captures manual dispatches where publishing is disabled
+          if [ "${needs.publish-to-ghcr.result}" == 'skipped' ]; then
+
+          IMAGE_LIST="["
+
+          if [ "${inputs.image_name}" == 'all' ]; then
+          for PREFIX in "${VAR_PREFIXES_ARR[@]}"; do
+          IMG_NAME="$(getVarValue "${PREFIX}" _IMG)"
+          GHCR_PATH="ghcr.io/${github.repository}/${IMG_NAME}"
+          IMAGE_LIST+="\"${GHCR_PATH}:latest\","
+          done
+
+          # Remove the trailing comma
+          IMAGE_LIST=${IMAGE_LIST%?}
+          else
+          IMG_TAG="${inputs.image_tag}"
+          IMG_NAME="$(getVarValue "$(bashVarPrefix "${inputs.image_name}")" _IMG)"
+          GHCR_PATH="ghcr.io/${github.repository}/${IMG_NAME}"
+          IMAGE_LIST+="\"${GHCR_PATH}:${IMG_TAG}\""
+          fi
+
+          IMAGE_LIST+="]"
+
+          # This case captures when the workflow is run automatically on PR merge along
+          # with manual dispatches where publishing is disabled
+          elif [ "${needs.publish-to-ghcr.result}" == 'success' ]; then
+          IMAGE_LIST=${needs.publish-to-ghcr.outputs.vro-images}
+          fi
+
+          # Throw an error if the IMAGE_LIST variable is an empty array
+          if [ "${IMAGE_LIST}" == "[]" ]; then
+          exit 1
+          fi
+
+          echo "image_list=${IMAGE_LIST}" >> "$GITHUB_OUTPUT"
 
   secrel:
     name: SecRel Pipeline

--- a/.github/workflows/secrel.yml
+++ b/.github/workflows/secrel.yml
@@ -224,7 +224,7 @@ jobs:
 
   secrel:
     name: SecRel Pipeline
-    if: needs.gate-check.outputs.run-secrel == 'true'
+    if: needs.gate-check.outputs.run-secrel == true
     needs: [secrel-inputs, gate-check]
     secrets: inherit
     uses: department-of-veterans-affairs/lighthouse-tornado-secrel-pipeline/.github/workflows/pipeline.yml@v5

--- a/.github/workflows/secrel.yml
+++ b/.github/workflows/secrel.yml
@@ -180,7 +180,45 @@ jobs:
           token: ${{ secrets.ACCESS_TOKEN_PUSH_TO_DEVELOP }}
       - name: "Determine VRO image inputs"
         id: vro-images
-        run: ./scripts/secrel-secrel-inputs.sh
+        run: |
+          source scripts/image_vars.src
+          IMAGE_LIST="[]"
+
+          # This case captures manual dispatches where publishing is disabled
+          if [ "${{ needs.publish-to-ghcr.result }}" == 'skipped' ]; then
+
+          IMAGE_LIST="["
+
+          if [ "${{inputs.image_name}}" == 'all' ]; then
+          for PREFIX in "${VAR_PREFIXES_ARR[@]}"; do
+          IMG_NAME="$(getVarValue "${PREFIX}" _IMG)"
+          GHCR_PATH="ghcr.io/${{github.repository}}/${IMG_NAME}"
+          IMAGE_LIST+="\"${GHCR_PATH}:latest\","
+          done
+
+          # Remove the trailing comma
+          IMAGE_LIST=${IMAGE_LIST%?}
+          else
+          IMG_TAG="${{inputs.image_tag}}"
+          IMG_NAME="$(getVarValue "$(bashVarPrefix "${{inputs.image_name}}")" _IMG)"
+          GHCR_PATH="ghcr.io/${{github.repository}}/${IMG_NAME}"
+          IMAGE_LIST+="\"${GHCR_PATH}:${IMG_TAG}\""
+          fi
+
+          IMAGE_LIST+="]"
+
+          # This case captures when the workflow is run automatically on PR merge along
+          # with manual dispatches where publishing is disabled
+          elif [ "${{needs.publish-to-ghcr.result}}" == 'success' ]; then
+          IMAGE_LIST=${{needs.publish-to-ghcr.outputs.vro-images}}
+          fi
+
+          # Throw an error if the IMAGE_LIST variable is an empty array
+          if [ "${IMAGE_LIST}" == "[]" ]; then
+          exit 1
+          fi
+
+          echo "image_list=${IMAGE_LIST}" >> "$GITHUB_OUTPUT"
 
   secrel:
     name: SecRel Pipeline

--- a/.github/workflows/secrel.yml
+++ b/.github/workflows/secrel.yml
@@ -224,7 +224,7 @@ jobs:
 
   secrel:
     name: SecRel Pipeline
-    if: ${{ needs.gate-check.outputs.run-secrel }}
+    if: needs.gate-check.outputs.run-secrel == 'true'
     needs: [secrel-inputs, gate-check]
     secrets: inherit
     uses: department-of-veterans-affairs/lighthouse-tornado-secrel-pipeline/.github/workflows/pipeline.yml@v5

--- a/.github/workflows/secrel.yml
+++ b/.github/workflows/secrel.yml
@@ -173,48 +173,14 @@ jobs:
       vro-images: ${{ steps.vro-images.outputs.image_list }}
     runs-on: ubuntu-latest
     steps:
+      - name: "Checkout source code"
+        uses: actions/checkout@v4
+        with:
+          # Checkout using a PAT so that we can do `git push` later in publish-images
+          token: ${{ secrets.ACCESS_TOKEN_PUSH_TO_DEVELOP }}
       - name: "Determine VRO image inputs"
         id: vro-images
-        run: |
-
-          source scripts/image_vars.src
-          IMAGE_LIST="[]"
-
-          # This case captures manual dispatches where publishing is disabled
-          if [ "${needs.publish-to-ghcr.result}" == 'skipped' ]; then
-
-          IMAGE_LIST="["
-
-          if [ "${inputs.image_name}" == 'all' ]; then
-          for PREFIX in "${VAR_PREFIXES_ARR[@]}"; do
-          IMG_NAME="$(getVarValue "${PREFIX}" _IMG)"
-          GHCR_PATH="ghcr.io/${github.repository}/${IMG_NAME}"
-          IMAGE_LIST+="\"${GHCR_PATH}:latest\","
-          done
-
-          # Remove the trailing comma
-          IMAGE_LIST=${IMAGE_LIST%?}
-          else
-          IMG_TAG="${inputs.image_tag}"
-          IMG_NAME="$(getVarValue "$(bashVarPrefix "${inputs.image_name}")" _IMG)"
-          GHCR_PATH="ghcr.io/${github.repository}/${IMG_NAME}"
-          IMAGE_LIST+="\"${GHCR_PATH}:${IMG_TAG}\""
-          fi
-
-          IMAGE_LIST+="]"
-
-          # This case captures when the workflow is run automatically on PR merge along
-          # with manual dispatches where publishing is disabled
-          elif [ "${needs.publish-to-ghcr.result}" == 'success' ]; then
-          IMAGE_LIST=${needs.publish-to-ghcr.outputs.vro-images}
-          fi
-
-          # Throw an error if the IMAGE_LIST variable is an empty array
-          if [ "${IMAGE_LIST}" == "[]" ]; then
-          exit 1
-          fi
-
-          echo "image_list=${IMAGE_LIST}" >> "$GITHUB_OUTPUT"
+        run: ./scripts/secrel-secrel-inputs.sh
 
   secrel:
     name: SecRel Pipeline

--- a/.github/workflows/secrel.yml
+++ b/.github/workflows/secrel.yml
@@ -234,7 +234,7 @@ jobs:
     steps:
       - name: "debug"
         run: |
-          echo "${{ needs.secrel-inputs.outputs.run-secrel }}
+          echo "${{ needs.secrel-inputs.outputs.run-secrel }}"
 
   secrel:
     name: SecRel Pipeline

--- a/.github/workflows/secrel.yml
+++ b/.github/workflows/secrel.yml
@@ -221,25 +221,12 @@ jobs:
 
           echo "${{needs.gate-check.outputs.run-secrel}}"
 
-          RUN_SECREL="true"
-          {
-            echo "image_list=${IMAGE_LIST}"
-            echo "run_secrel=true"
-          } >> "$GITHUB_OUTPUT"
-
-  secrel-test:
-    name: SecRel Pipeline
-    needs: secrel-inputs
-    runs-on: ubuntu-latest
-    steps:
-      - name: "debug"
-        run: |
-          echo "${{ needs.secrel-inputs.outputs.run-secrel }}"
+          echo "image_list=${IMAGE_LIST}" >> "$GITHUB_OUTPUT"
 
   secrel:
     name: SecRel Pipeline
-    needs: secrel-inputs
-    if: needs.secrel-inputs.outputs.run-secrel == 'true'
+    needs: [secrel-inputs, gate-check]
+    if: ${{always() && needs.secrel-inputs.outputs.run-secrel == 'true'}}
     secrets: inherit
     uses: department-of-veterans-affairs/lighthouse-tornado-secrel-pipeline/.github/workflows/pipeline.yml@v5
     with:

--- a/.github/workflows/secrel.yml
+++ b/.github/workflows/secrel.yml
@@ -229,7 +229,7 @@ jobs:
   secrel:
     name: SecRel Pipeline
     if: needs.secrel-inputs.outputs.run-secrel == 'true'
-    needs: [secrel-inputs]
+    needs: secrel-inputs
     secrets: inherit
     uses: department-of-veterans-affairs/lighthouse-tornado-secrel-pipeline/.github/workflows/pipeline.yml@v5
     with:

--- a/.github/workflows/secrel.yml
+++ b/.github/workflows/secrel.yml
@@ -232,20 +232,3 @@ jobs:
     with:
       config-file: .github/secrel/config.yml
       images: ${{ needs.secrel-inputs.outputs.vro-images }}
-
-  notify-secrel-error:
-    needs: secrel
-    if: always() && needs.secrel.result == 'failure'
-    runs-on: ubuntu-latest
-    steps:
-      - name: "Slack: SecRel Failure"
-        uses: archive/github-actions-slack@v2.9.0
-        # only run for the internal repo
-        if: ${{ github.repository == 'department-of-veterans-affairs/abd-vro-internal' }}
-        with:
-          slack-bot-user-oauth-access-token: ${{ secrets.SLACK_BOT_USER_OAUTH_ACCESS_TOKEN }}
-          slack-channel: ${{ env.SLACK_CHANNEL }}
-          slack-text: ":redlight: <${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}|\
-              SecRel scan (#${{ github.run_number }}) failed>! \n\
-              ${{github.ref_type}} `${{github.ref_name}}` (`${{github.sha}}`), \n\
-              caused by `${{github.event_name}}` triggered by `${{github.triggering_actor}}` ..."

--- a/.github/workflows/secrel.yml
+++ b/.github/workflows/secrel.yml
@@ -224,7 +224,7 @@ jobs:
 
   secrel:
     name: SecRel Pipeline
-    if: ${{needs.gate-check.outputs.run-secrel}} == 'true'
+    if: ${{ needs.gate-check.outputs.run-secrel == 'true' }}
     needs: [secrel-inputs, gate-check]
     secrets: inherit
     uses: department-of-veterans-affairs/lighthouse-tornado-secrel-pipeline/.github/workflows/pipeline.yml@v5

--- a/.github/workflows/secrel.yml
+++ b/.github/workflows/secrel.yml
@@ -166,9 +166,14 @@ jobs:
           slack-optional-thread_ts: ${{ fromJson(steps.notify-slack.outputs.slack-result).response.message.ts }}
           slack-text: ":panda_builder: Images published!"
 
+  secrel-gate:
+    if: ${{ !failure() }}
+    needs: publish-to-ghcr
+    runs-on: ubuntu-latest
+
   secrel-inputs:
-    if: ${{ !failure() && needs.gate-check.outputs.run-secrel }}
-    needs: [publish-to-ghcr, gate-check]
+    if: ${{ needs.gate-check.outputs.run-secrel }}
+    needs: [secrel-gate, gate-check]
     outputs:
       vro-images: ${{ steps.vro-images.outputs.image_list }}
     runs-on: ubuntu-latest

--- a/.github/workflows/secrel.yml
+++ b/.github/workflows/secrel.yml
@@ -224,7 +224,7 @@ jobs:
 
   secrel:
     name: SecRel Pipeline
-    if: needs.gate-check.outputs.run-secrel == 'true'
+    if: ${{needs.gate-check.outputs.run-secrel}} == 'true'
     needs: [secrel-inputs, gate-check]
     secrets: inherit
     uses: department-of-veterans-affairs/lighthouse-tornado-secrel-pipeline/.github/workflows/pipeline.yml@v5

--- a/.github/workflows/secrel.yml
+++ b/.github/workflows/secrel.yml
@@ -227,6 +227,15 @@ jobs:
             echo "run_secrel=true"
           } >> "$GITHUB_OUTPUT"
 
+  secrel-test:
+    name: SecRel Pipeline
+    needs: secrel-inputs
+    runs-on: ubuntu-latest
+    steps:
+      - name: "debug"
+        run: |
+          echo "${{ needs.secrel-inputs.outputs.run-secrel }}
+
   secrel:
     name: SecRel Pipeline
     needs: secrel-inputs

--- a/.github/workflows/secrel.yml
+++ b/.github/workflows/secrel.yml
@@ -171,6 +171,7 @@ jobs:
     needs: [publish-to-ghcr, gate-check]
     outputs:
       vro-images: ${{ steps.vro-images.outputs.image_list }}
+      run-secrel: ${{ steps.vro-images.outputs.run_secrel }}
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout source code"
@@ -220,12 +221,15 @@ jobs:
 
           echo "${{needs.gate-check.outputs.run-secrel}}"
 
-          echo "image_list=${IMAGE_LIST}" >> "$GITHUB_OUTPUT"
+          {
+            echo "image_list=${IMAGE_LIST}"
+            echo "run_secrel=${{needs.gate-check.outputs.run-secrel}}"
+          } >> "$GITHUB_OUTPUT"
 
   secrel:
     name: SecRel Pipeline
-    if: ${{ needs.gate-check.outputs.run-secrel == 'true' }}
-    needs: [secrel-inputs, gate-check]
+    if: needs.secrel-inputs.outputs.run-secrel == 'true'
+    needs: [secrel-inputs]
     secrets: inherit
     uses: department-of-veterans-affairs/lighthouse-tornado-secrel-pipeline/.github/workflows/pipeline.yml@v5
     with:

--- a/.github/workflows/secrel.yml
+++ b/.github/workflows/secrel.yml
@@ -175,46 +175,7 @@ jobs:
     steps:
       - name: "Determine VRO image inputs"
         id: vro-images
-        run: |
-
-          source scripts/image_vars.src
-          IMAGE_LIST="[]"
-
-          # This case captures manual dispatches where publishing is disabled
-          if [ "${{needs.publish-to-ghcr.result}}" == 'skipped' ]; then
-
-            IMAGE_LIST="["
-
-            if [ "${{ inputs.image_name }}" == 'all' ]; then
-              for PREFIX in "${VAR_PREFIXES_ARR[@]}"; do
-                IMG_NAME="$(getVarValue "${PREFIX}" _IMG)"
-                GHCR_PATH="ghcr.io/${{ github.repository }}/${IMG_NAME}"
-                IMAGE_LIST+=("\"${GHCR_PATH}:latest\",")
-              done
-
-              # Remove the trailing comma
-              IMAGE_LIST=${IMAGE_LIST%?}
-            else
-              IMG_TAG="${{ inputs.image_tag }}"
-              IMG_NAME="$(getVarValue "$(bashVarPrefix "${inputs.image_name}")" _IMG)"
-              GHCR_PATH="ghcr.io/${{ github.repository }}/${IMG_NAME}"
-              IMAGE_LIST+=("\"${GHCR_PATH}:${IMG_TAG}\"")
-            fi
-
-            IMAGE_LIST+="]"
-
-          # This case captures when the workflow is run automatically on PR merge along
-          # with manual dispatches where publishing is disabled
-          elif [ "${{needs.publish-to-ghcr.result}}" == 'success' ]; then
-            IMAGE_LIST=${{ needs.publish-to-ghcr.outputs.vro-images }}
-          fi
-
-          # Throw an error if the IMAGE_LIST variable is an empty array
-          if [ "${{ IMAGE_LIST }}" == "[]" ]; then
-            exit 1
-          fi
-
-          echo "image_list=${IMAGE_LIST}" >> "$GITHUB_OUTPUT"
+        run: ./scripts/secrel-secrel-inputs.sh
 
   secrel:
     name: SecRel Pipeline

--- a/.github/workflows/secrel.yml
+++ b/.github/workflows/secrel.yml
@@ -171,7 +171,6 @@ jobs:
     needs: [publish-to-ghcr, gate-check]
     outputs:
       vro-images: ${{ steps.vro-images.outputs.image_list }}
-      run-secrel: ${{ steps.vro-images.outputs.run_secrel }}
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout source code"
@@ -226,7 +225,7 @@ jobs:
   secrel:
     name: SecRel Pipeline
     needs: [secrel-inputs, gate-check]
-    if: ${{always() && needs.secrel-inputs.outputs.run-secrel == 'true'}}
+    if: ${{always() && needs.gate-check.outputs.run-secrel == 'true'}}
     secrets: inherit
     uses: department-of-veterans-affairs/lighthouse-tornado-secrel-pipeline/.github/workflows/pipeline.yml@v5
     with:

--- a/.github/workflows/secrel.yml
+++ b/.github/workflows/secrel.yml
@@ -224,7 +224,7 @@ jobs:
 
   secrel:
     name: SecRel Pipeline
-    if: needs.gate-check.outputs.run-secrel == "true"
+    if: needs.gate-check.outputs.run-secrel == 'true'
     needs: [secrel-inputs, gate-check]
     secrets: inherit
     uses: department-of-veterans-affairs/lighthouse-tornado-secrel-pipeline/.github/workflows/pipeline.yml@v5

--- a/.github/workflows/secrel.yml
+++ b/.github/workflows/secrel.yml
@@ -224,7 +224,7 @@ jobs:
 
   secrel:
     name: SecRel Pipeline
-    if: needs.gate-check.outputs.run-secrel == true
+    if: needs.gate-check.outputs.run-secrel == "true"
     needs: [secrel-inputs, gate-check]
     secrets: inherit
     uses: department-of-veterans-affairs/lighthouse-tornado-secrel-pipeline/.github/workflows/pipeline.yml@v5

--- a/.github/workflows/secrel.yml
+++ b/.github/workflows/secrel.yml
@@ -221,9 +221,10 @@ jobs:
 
           echo "${{needs.gate-check.outputs.run-secrel}}"
 
+          RUN_SECREL="${{needs.gate-check.outputs.run-secrel}}"
           {
             echo "image_list=${IMAGE_LIST}"
-            echo "run_secrel="${{needs.gate-check.outputs.run-secrel}}""
+            echo "run_secrel=${RUN_SECREL}"
           } >> "$GITHUB_OUTPUT"
 
   secrel:

--- a/.github/workflows/secrel.yml
+++ b/.github/workflows/secrel.yml
@@ -166,14 +166,9 @@ jobs:
           slack-optional-thread_ts: ${{ fromJson(steps.notify-slack.outputs.slack-result).response.message.ts }}
           slack-text: ":panda_builder: Images published!"
 
-  secrel-gate:
-    if: ${{ !failure() }}
-    needs: publish-to-ghcr
-    runs-on: ubuntu-latest
-
   secrel-inputs:
-    if: ${{ needs.gate-check.outputs.run-secrel }}
-    needs: [secrel-gate, gate-check]
+    if: ${{ !failure() }}
+    needs: [publish-to-ghcr, gate-check]
     outputs:
       vro-images: ${{ steps.vro-images.outputs.image_list }}
     runs-on: ubuntu-latest
@@ -213,7 +208,7 @@ jobs:
           IMAGE_LIST+="]"
 
           # This case captures when the workflow is run automatically on PR merge along
-          # with manual dispatches where publishing is disabled
+          # with manual dispatches where publishing is enabled
           elif [ "${{needs.publish-to-ghcr.result}}" == 'success' ]; then
           IMAGE_LIST=${{needs.publish-to-ghcr.outputs.vro-images}}
           fi
@@ -227,7 +222,8 @@ jobs:
 
   secrel:
     name: SecRel Pipeline
-    needs: secrel-inputs
+    if: ${{ needs.gate-check.outputs.run-secrel }}
+    needs: [secrel-inputs, gate-check]
     secrets: inherit
     uses: department-of-veterans-affairs/lighthouse-tornado-secrel-pipeline/.github/workflows/pipeline.yml@v5
     with:

--- a/.github/workflows/secrel.yml
+++ b/.github/workflows/secrel.yml
@@ -223,7 +223,7 @@ jobs:
 
           {
             echo "image_list=${IMAGE_LIST}"
-            echo "run_secrel=${{needs.gate-check.outputs.run-secrel}}"
+            echo "run_secrel="${{needs.gate-check.outputs.run-secrel}}""
           } >> "$GITHUB_OUTPUT"
 
   secrel:

--- a/.github/workflows/secrel.yml
+++ b/.github/workflows/secrel.yml
@@ -224,13 +224,13 @@ jobs:
           RUN_SECREL="true"
           {
             echo "image_list=${IMAGE_LIST}"
-            echo "run_secrel=${RUN_SECREL}"
+            echo "run_secrel=true"
           } >> "$GITHUB_OUTPUT"
 
   secrel:
     name: SecRel Pipeline
-    if: needs.secrel-inputs.outputs.run-secrel == 'true'
     needs: secrel-inputs
+    if: needs.secrel-inputs.outputs.run-secrel == 'true'
     secrets: inherit
     uses: department-of-veterans-affairs/lighthouse-tornado-secrel-pipeline/.github/workflows/pipeline.yml@v5
     with:

--- a/.github/workflows/secrel.yml
+++ b/.github/workflows/secrel.yml
@@ -35,20 +35,20 @@ on:
         default: all
         options:
           - all
-          - domain-cc
-          - domain-xample
+          - cc-app
+          - xample-workflows
           - svc-bgs-api
           - svc-bie-kafka
           - svc-bip-api
           - svc-lighthouse-api
           - api-gateway
-          - domain-ee-max-cfi-app
-          - domain-ee-ep-merge-app
+          - ee-max-cfi-app
+          - ee-ep-merge-app
           - dev-tools
           - db-init
-          - vro-app
-          - vro-redis
-          - vro-rabbitmq
+          - app
+          - redis
+          - rabbitmq
       image_tag:
         description: "Image tag to run SecRel on. If 'all' is selected, then 'latest' will always be used"
         required: true

--- a/.github/workflows/secrel.yml
+++ b/.github/workflows/secrel.yml
@@ -218,6 +218,8 @@ jobs:
           exit 1
           fi
 
+          echo "${{needs.gate-check.outputs.run-secrel}}"
+
           echo "image_list=${IMAGE_LIST}" >> "$GITHUB_OUTPUT"
 
   secrel:

--- a/scripts/secrel-secrel-inputs.sh
+++ b/scripts/secrel-secrel-inputs.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+# This script is only used as the secrel-inputs step in the Secrel GH workflow
+
+source scripts/image_vars.src
+IMAGE_LIST="[]"
+
+# This case captures manual dispatches where publishing is disabled
+if [ "${needs.publish-to-ghcr.result}" == 'skipped' ]; then
+
+  IMAGE_LIST="["
+
+  if [ "${inputs.image_name}" == 'all' ]; then
+    for PREFIX in "${VAR_PREFIXES_ARR[@]}"; do
+      IMG_NAME="$(getVarValue "${PREFIX}" _IMG)"
+      GHCR_PATH="ghcr.io/${github.repository}/${IMG_NAME}"
+      IMAGE_LIST+="\"${GHCR_PATH}:latest\","
+    done
+
+    # Remove the trailing comma
+    IMAGE_LIST=${IMAGE_LIST%?}
+  else
+    IMG_TAG="${inputs.image_tag}"
+    IMG_NAME="$(getVarValue "$(bashVarPrefix "${inputs.image_name}")" _IMG)"
+    GHCR_PATH="ghcr.io/${github.repository}/${IMG_NAME}"
+    IMAGE_LIST+="\"${GHCR_PATH}:${IMG_TAG}\""
+  fi
+
+  IMAGE_LIST+="]"
+
+# This case captures when the workflow is run automatically on PR merge along
+# with manual dispatches where publishing is disabled
+elif [ "${needs.publish-to-ghcr.result}" == 'success' ]; then
+  IMAGE_LIST=${needs.publish-to-ghcr.outputs.vro-images}
+fi
+
+# Throw an error if the IMAGE_LIST variable is an empty array
+if [ "${IMAGE_LIST}" == "[]" ]; then
+  exit 1
+fi
+
+echo "image_list=${IMAGE_LIST}" >> "$GITHUB_OUTPUT"

--- a/scripts/secrel-secrel-inputs.sh
+++ b/scripts/secrel-secrel-inputs.sh
@@ -6,23 +6,23 @@ source scripts/image_vars.src
 IMAGE_LIST="[]"
 
 # This case captures manual dispatches where publishing is disabled
-if [ "${needs.publish-to-ghcr.result}" == 'skipped' ]; then
+if [ "${{needs.publish-to-ghcr.result}}" == 'skipped' ]; then
 
   IMAGE_LIST="["
 
-  if [ "${inputs.image_name}" == 'all' ]; then
+  if [ "${{inputs.image_name}}" == 'all' ]; then
     for PREFIX in "${VAR_PREFIXES_ARR[@]}"; do
       IMG_NAME="$(getVarValue "${PREFIX}" _IMG)"
-      GHCR_PATH="ghcr.io/${github.repository}/${IMG_NAME}"
+      GHCR_PATH="ghcr.io/${{github.repository}}/${IMG_NAME}"
       IMAGE_LIST+="\"${GHCR_PATH}:latest\","
     done
 
     # Remove the trailing comma
     IMAGE_LIST=${IMAGE_LIST%?}
   else
-    IMG_TAG="${inputs.image_tag}"
-    IMG_NAME="$(getVarValue "$(bashVarPrefix "${inputs.image_name}")" _IMG)"
-    GHCR_PATH="ghcr.io/${github.repository}/${IMG_NAME}"
+    IMG_TAG="${{inputs.image_tag}}"
+    IMG_NAME="$(getVarValue "$(bashVarPrefix "${{inputs.image_name}}")" _IMG)"
+    GHCR_PATH="ghcr.io/${{github.repository}}/${IMG_NAME}"
     IMAGE_LIST+="\"${GHCR_PATH}:${IMG_TAG}\""
   fi
 
@@ -30,8 +30,8 @@ if [ "${needs.publish-to-ghcr.result}" == 'skipped' ]; then
 
 # This case captures when the workflow is run automatically on PR merge along
 # with manual dispatches where publishing is disabled
-elif [ "${needs.publish-to-ghcr.result}" == 'success' ]; then
-  IMAGE_LIST=${needs.publish-to-ghcr.outputs.vro-images}
+elif [ "${{needs.publish-to-ghcr.result}}" == 'success' ]; then
+  IMAGE_LIST=${{needs.publish-to-ghcr.outputs.vro-images}}
 fi
 
 # Throw an error if the IMAGE_LIST variable is an empty array

--- a/scripts/secrel-secrel-inputs.sh
+++ b/scripts/secrel-secrel-inputs.sh
@@ -6,7 +6,7 @@ source scripts/image_vars.src
 IMAGE_LIST="[]"
 
 # This case captures manual dispatches where publishing is disabled
-if [ "${{needs.publish-to-ghcr.result}}" == 'skipped' ]; then
+if [ "${{ needs.publish-to-ghcr.result }}" == 'skipped' ]; then
 
   IMAGE_LIST="["
 


### PR DESCRIPTION
<!-- Ensure the PR title reflects the feature or bug name -->

After the changes in my PR, users of the SecRel workflow can choose to run existing images through SecRel, unrelated of when those images were published. For instance, a common issue that we used to face with running SecRel was that if there were no changes made from the last time SecRel ran, then SecRel would not run as there would be no new images published to be fed into the next step of the workflow. However, now images can be published in one run of the workflow, and then future runs of the workflow can perform SecRel scanning as many times as the user desires.

Essentially, the changes allow for publishing to be skipped and only SecRel performed whereas historically we only allowed for skipping secrel but always required image publishing as the images published were fed directly into the SecRel pipeline. Now, any published image can be fed into the SecRel pipeline. 

On PR merge to `develop`, image publishing and SecRel will continue to run in the same way it has historically: publishing all images and running SecRel on all of them simultaneously. 

With these changes, partner team engineers could select only their images for a SecRel run, decoupling their SecRel Aqua image scanning from the rest of the platform. This means that even if there are vulnerabilities found on VRO images, if the EE team’s images passes SecRel, deployment of EE team’s applications could continue to all environments without interruption. The same goes for any VRO images that we seek to deploy. Any image can be deployed with a passing Aqua status, even if other images in the platform do not pass Aqua. 

Snyk and SDE alerts must continue to pass or block deployment across the whole platform; however, Aqua is the most frequent offender in terms of deployment blockers and SecRel failures. 

In the short-term, VRO team will need to continue to manage SecRel on behalf of our partner teams, as there will definitely be an education component. However, these changes get us closer to partner teams being able to manage their own images’ SecRel statuses and to partner teams being able to perform their own deployments to LHDI environments that require SecRel-signed images.

The changes will be available for use as soon as the PR containing the changes is merged. The changes can be easily reverted through a quick PR reversion. This work does not seem to be impacted at all by the recent work on removing versioning, beyond simplifying the mental model of the process. 

Associated tickets or Slack threads:
- #2472 

## How to test this PR
- Tested through manual workflow dispatching
- Will have to followup with some testing after merge as certain triggers can only be performed once the workflow is in the `develop` branch

[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
