### PR TITLE
Remove whitespace from csv lookup table values

### DIFF
--- a/domain-cc/cc-app/src/python_src/util/lookup_table.py
+++ b/domain-cc/cc-app/src/python_src/util/lookup_table.py
@@ -134,7 +134,7 @@ def get_v1_lookup_table(filepath: str, input_key: str, output_key: str) -> dict:
                 try:
                     text_to_convert = int(csv_line[input_key])
                 except ValueError:
-                    text_to_convert = csv_line[input_key].lower()
+                    text_to_convert = csv_line[input_key].strip().lower()
                 classification_code = int(csv_line[output_key])
                 classification_code_mappings[text_to_convert] = classification_code
             except KeyError:
@@ -193,7 +193,7 @@ def get_lookup_table(
                 for row in csv_reader:
                     for k in v2_input_key:
                         if row[k] and row[v2_output_key]:
-                            classification_code_mappings[row[k].lower()] = int(
+                            classification_code_mappings[row[k].strip().lower()] = int(
                                 row[v2_output_key]
                             )
         # raises exception if dropdown_v2_filepath is None (only create DC LUT)

--- a/domain-cc/cc-app/tests/test_condition_dropdown_lookup.py
+++ b/domain-cc/cc-app/tests/test_condition_dropdown_lookup.py
@@ -119,3 +119,17 @@ def test_new_dropdown_list(client: TestClient):
     assert response.status_code == 200
     assert response.json()["classification_code"] == 9007
     assert response.json()["classification_name"] == "Neurological other System"
+
+
+def test_whitespace_removal(client: TestClient):
+    json_post_dict = {
+        "diagnostic_code": 7,
+        "claim_id": 700,
+        "form526_submission_id": 777,
+        "claim_type": "new",
+        "contention_text": "pharyngeal cancer (throat cancer) ",
+    }
+    response = client.post("/classifier", json=json_post_dict)
+    assert response.status_code == 200
+    assert response.json()["classification_code"] == 1230
+    assert response.json()["classification_name"] == "Cancer - Respiratory"


### PR DESCRIPTION
<!-- Ensure the PR title reflects the feature or bug name -->

## What was the problem?
<!-- brief description of how things worked before this PR -->
There was a value in the csv file that contained a whitespace at the end of the word preventing the dropdown option from being classified.  

Associated tickets or Slack threads:
- [#428](https://app.zenhub.com/workspaces/contention-classification-640a24db5dcd08457cebbc79/issues/gh/department-of-veterans-affairs/vagov-claim-classification/428)

## How does this fix it?[^1]
<!-- description of how things will work after this PR -->
This removes leading and trailing spaces from each term as the lookup tables are built. 

## How to test this PR
- Step 1 - from cc-app run `pytest` 
- Step 1a - run cc-app locally and send a request containing 'pharyngeal cancer (throat cancer) ' and it should return a classification code of 1230
- Step 2[^secrel]


[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
