### PR TITLE
Fixing domain-cc helm chart reference

### DIFF
--- a/helm/domain-cc/Chart.yaml
+++ b/helm/domain-cc/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 
 # numbers, lowercase, and dashes only
 # https://helm.sh/docs/chart_best_practices/conventions/#chart-names
-name: domain-cc-chart
+name: domain-cc
 description: Workflows and microservices for the Contention Classification domain
 
 # This is the chart version. This version number should be incremented each time you make changes


### PR DESCRIPTION
## What was the problem?
A change in the helm chart name, broke conventions established for finding the chart's related helm templates.

Associated tickets or Slack threads:
- #2862

## How does this fix it?[^1]
Removes the incorrect chart path


[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
