### PR TITLE
fix flaky integration tests in xample-domain 

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -18,11 +18,35 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+
   lint-and-test:
     uses: ./.github/workflows/test-code.yml
+    secrets: inherit
+
+  codeql:
+    uses: ./.github/workflows/codeql-analysis.yml
+    secrets: inherit
+
+  container-healthchecks:
+    uses: ./.github/workflows/container-healthchecks.yml
     secrets: inherit
 
   xample-domain:
     uses: ./.github/workflows/xample-integration-test.yml
     secrets: inherit
 
+  svc-bgs-api:
+    uses: ./.github/workflows/svc-bgs-api-integration-test.yml
+    secrets: inherit
+
+  svc-bip-api:
+    uses: ./.github/workflows/svc-bip-api-integration-test.yml
+    secrets: inherit
+
+  svc-bie-kafka-end-to-end:
+    uses: ./.github/workflows/bie-kafka-end2end-test.yml
+    secrets: inherit
+
+  ee-ep-merge-end-to-end:
+    uses: ./.github/workflows/ee-ep-merge-end-to-end.yml
+    secrets: inherit

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -18,6 +18,17 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  nondraft-pr:
+    # Adding an `if:` that evaluates to false for this nondraft-pr job prevents other dependent jobs from running.
+    # For github.event.pull_request fields, see
+    # https://docs.github.com/en/webhooks-and-events/webhooks/webhook-events-and-payloads#pull_request
+    if: github.event_name != 'pull_request' ||
+      (github.event_name == 'pull_request' && !github.event.pull_request.draft )
+    runs-on: ubuntu-latest
+    steps:
+    - name: "DEBUG"
+      run: |
+        echo "${{ github.event_name }} ${{ github.event.pull_request.draft }}"
 
   lint-and-test:
     uses: ./.github/workflows/test-code.yml
@@ -28,25 +39,31 @@ jobs:
     secrets: inherit
 
   container-healthchecks:
+    needs: nondraft-pr
     uses: ./.github/workflows/container-healthchecks.yml
     secrets: inherit
 
   xample-domain:
+    needs: nondraft-pr
     uses: ./.github/workflows/xample-integration-test.yml
     secrets: inherit
 
   svc-bgs-api:
+    needs: nondraft-pr
     uses: ./.github/workflows/svc-bgs-api-integration-test.yml
     secrets: inherit
 
   svc-bip-api:
+    needs: nondraft-pr
     uses: ./.github/workflows/svc-bip-api-integration-test.yml
     secrets: inherit
 
   svc-bie-kafka-end-to-end:
+    needs: nondraft-pr
     uses: ./.github/workflows/bie-kafka-end2end-test.yml
     secrets: inherit
 
   ee-ep-merge-end-to-end:
+    needs: nondraft-pr
     uses: ./.github/workflows/ee-ep-merge-end-to-end.yml
     secrets: inherit

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -18,18 +18,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  nondraft-pr:
-    # Adding an `if:` that evaluates to false for this nondraft-pr job prevents other dependent jobs from running.
-    # For github.event.pull_request fields, see
-    # https://docs.github.com/en/webhooks-and-events/webhooks/webhook-events-and-payloads#pull_request
-    if: github.event_name != 'pull_request' ||
-      (github.event_name == 'pull_request' && !github.event.pull_request.draft )
-    runs-on: ubuntu-latest
-    steps:
-    - name: "DEBUG"
-      run: |
-        echo "${{ github.event_name }} ${{ github.event.pull_request.draft }}"
-
   lint-and-test:
     uses: ./.github/workflows/test-code.yml
     secrets: inherit
@@ -39,7 +27,6 @@ jobs:
     secrets: inherit
 
   container-healthchecks:
-    needs: nondraft-pr
     uses: ./.github/workflows/container-healthchecks.yml
     secrets: inherit
 
@@ -48,21 +35,17 @@ jobs:
     secrets: inherit
 
   svc-bgs-api:
-    needs: nondraft-pr
     uses: ./.github/workflows/svc-bgs-api-integration-test.yml
     secrets: inherit
 
   svc-bip-api:
-    needs: nondraft-pr
     uses: ./.github/workflows/svc-bip-api-integration-test.yml
     secrets: inherit
 
   svc-bie-kafka-end-to-end:
-    needs: nondraft-pr
     uses: ./.github/workflows/bie-kafka-end2end-test.yml
     secrets: inherit
 
   ee-ep-merge-end-to-end:
-    needs: nondraft-pr
     uses: ./.github/workflows/ee-ep-merge-end-to-end.yml
     secrets: inherit

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -22,30 +22,7 @@ jobs:
     uses: ./.github/workflows/test-code.yml
     secrets: inherit
 
-  codeql:
-    uses: ./.github/workflows/codeql-analysis.yml
-    secrets: inherit
-
-  container-healthchecks:
-    uses: ./.github/workflows/container-healthchecks.yml
-    secrets: inherit
-
   xample-domain:
     uses: ./.github/workflows/xample-integration-test.yml
     secrets: inherit
 
-  svc-bgs-api:
-    uses: ./.github/workflows/svc-bgs-api-integration-test.yml
-    secrets: inherit
-
-  svc-bip-api:
-    uses: ./.github/workflows/svc-bip-api-integration-test.yml
-    secrets: inherit
-
-  svc-bie-kafka-end-to-end:
-    uses: ./.github/workflows/bie-kafka-end2end-test.yml
-    secrets: inherit
-
-  ee-ep-merge-end-to-end:
-    uses: ./.github/workflows/ee-ep-merge-end-to-end.yml
-    secrets: inherit

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -44,7 +44,6 @@ jobs:
     secrets: inherit
 
   xample-domain:
-    needs: nondraft-pr
     uses: ./.github/workflows/xample-integration-test.yml
     secrets: inherit
 

--- a/.github/workflows/xample-integration-test.yml
+++ b/.github/workflows/xample-integration-test.yml
@@ -94,6 +94,7 @@ jobs:
           fi
 
           ./gradlew -p domain-xample integrationTest
+
       - name: "Collect docker logs"
         if: always()
         uses: jwalton/gh-docker-logs@v2
@@ -120,6 +121,7 @@ jobs:
           fi
 
       - name: 'Check (again) status of RabbitMQ'
+        if: always()
         uses: department-of-veterans-affairs/curl-action@v1.0.0
         with:
           url: 'http://localhost:15672/api/vhosts'
@@ -133,6 +135,7 @@ jobs:
           log-response: true
 
       - name: 'Check (again) queues of RabbitMQ'
+        if: always()
         uses: department-of-veterans-affairs/curl-action@v1.0.0
         with:
           url: 'http://localhost:15672/api/queues'

--- a/.github/workflows/xample-integration-test.yml
+++ b/.github/workflows/xample-integration-test.yml
@@ -101,13 +101,9 @@ jobs:
             echo "Unexpected ERROR logs in xample-workflows container"
             exit 11
           fi
-          if docker logs vro_svc-xample-j_1 | grep -A 5 'Failed tests:'; then
-            echo "test failures in svc-xample-j"
-            exit 12
-          fi
           if docker logs vro_svc-xample-j_1 | grep 'ERROR\|WARN' | grep -v 'Simulated error' | grep -v SimpleMessageListenerContainer ; then
             echo "Unexpected ERROR logs in svc-xample-j container"
-            exit 13
+            exit 12
           fi
 
       - name: "Clean shutdown of all containers"

--- a/.github/workflows/xample-integration-test.yml
+++ b/.github/workflows/xample-integration-test.yml
@@ -116,6 +116,7 @@ jobs:
             exit 11
           fi
           if docker logs vro_svc-xample-j_1 | grep -B 25 -A 4 'ERROR\|WARN' | grep -v 'Simulated error'; then
+            echo $(docker logs vro_svc-xample-j_1 | grep -A 5 "Failed tests:")
             echo "Unexpected ERROR logs in svc-xample-j container"
             exit 12
           fi

--- a/.github/workflows/xample-integration-test.yml
+++ b/.github/workflows/xample-integration-test.yml
@@ -41,12 +41,23 @@ jobs:
         run: sleep 60s
         shell: bash
 
-
-
       - name: 'Check for RabbitMQ to be ready'
         uses: department-of-veterans-affairs/curl-action@v1.0.0
         with:
           url: 'http://localhost:15672/api/vhosts'
+          method: 'GET'
+          basic-auth-token: '${{env.RABBITMQ_BASIC_AUTH}}'
+          accept: 200
+          # Retry every 2 seconds
+          timeout: 2000
+          # Quit after 60 seconds
+          retries: 30
+          log-response: true
+
+      - name: 'Check queues of RabbitMQ'
+        uses: department-of-veterans-affairs/curl-action@v1.0.0
+        with:
+          url: 'http://localhost:15672/api/queues'
           method: 'GET'
           basic-auth-token: '${{env.RABBITMQ_BASIC_AUTH}}'
           accept: 200
@@ -82,7 +93,7 @@ jobs:
             exit 10
           fi
 
-          ./gradlew -p domain-xample integrationTest
+          ./gradlew -i -p domain-xample integrationTest
       - name: "Collect docker logs"
         if: always()
         uses: jwalton/gh-docker-logs@v2
@@ -107,6 +118,32 @@ jobs:
             echo "Unexpected ERROR logs in svc-xample-j container"
             exit 12
           fi
+
+      - name: 'Check (again) status of RabbitMQ'
+        uses: department-of-veterans-affairs/curl-action@v1.0.0
+        with:
+          url: 'http://localhost:15672/api/vhosts'
+          method: 'GET'
+          basic-auth-token: '${{env.RABBITMQ_BASIC_AUTH}}'
+          accept: 200
+          # Retry every 2 seconds
+          timeout: 2000
+          # Quit after 60 seconds
+          retries: 30
+          log-response: true
+
+      - name: 'Check (again) queues of RabbitMQ'
+        uses: department-of-veterans-affairs/curl-action@v1.0.0
+        with:
+          url: 'http://localhost:15672/api/queues'
+          method: 'GET'
+          basic-auth-token: '${{env.RABBITMQ_BASIC_AUTH}}'
+          accept: 200
+          # Retry every 2 seconds
+          timeout: 2000
+          # Quit after 60 seconds
+          retries: 30
+          log-response: true
 
       - name: "Clean shutdown of all containers"
         if: always()

--- a/.github/workflows/xample-integration-test.yml
+++ b/.github/workflows/xample-integration-test.yml
@@ -93,7 +93,7 @@ jobs:
             exit 10
           fi
 
-          ./gradlew -i -p domain-xample integrationTest
+          ./gradlew -p domain-xample integrationTest
       - name: "Collect docker logs"
         if: always()
         uses: jwalton/gh-docker-logs@v2
@@ -114,7 +114,7 @@ jobs:
             echo "Unexpected ERROR logs in xample-workflows container"
             exit 11
           fi
-          if docker logs vro_svc-xample-j_1 | grep 'ERROR\|WARN' | grep -v 'Simulated error'; then
+          if docker logs vro_svc-xample-j_1 | grep -B 25 'ERROR\|WARN' | grep -v 'Simulated error'; then
             echo "Unexpected ERROR logs in svc-xample-j container"
             exit 12
           fi

--- a/.github/workflows/xample-integration-test.yml
+++ b/.github/workflows/xample-integration-test.yml
@@ -54,6 +54,7 @@ jobs:
           timeout: 2000
           # Quit after 60 seconds
           retries: 30
+          log-response: true
 
       - name: "Wait for VRO to be ready"
         uses: nev7n/wait_for_response@v1

--- a/.github/workflows/xample-integration-test.yml
+++ b/.github/workflows/xample-integration-test.yml
@@ -114,7 +114,7 @@ jobs:
             echo "Unexpected ERROR logs in xample-workflows container"
             exit 11
           fi
-          if docker logs vro_svc-xample-j_1 | grep -B 25 'ERROR\|WARN' | grep -v 'Simulated error'; then
+          if docker logs vro_svc-xample-j_1 | grep -B 25 -A 4 'ERROR\|WARN' | grep -v 'Simulated error'; then
             echo "Unexpected ERROR logs in svc-xample-j container"
             exit 12
           fi

--- a/.github/workflows/xample-integration-test.yml
+++ b/.github/workflows/xample-integration-test.yml
@@ -54,19 +54,6 @@ jobs:
           retries: 30
           log-response: true
 
-      - name: 'Check queues of RabbitMQ'
-        uses: department-of-veterans-affairs/curl-action@v1.0.0
-        with:
-          url: 'http://localhost:15672/api/queues'
-          method: 'GET'
-          basic-auth-token: '${{env.RABBITMQ_BASIC_AUTH}}'
-          accept: 200
-          # Retry every 2 seconds
-          timeout: 2000
-          # Quit after 60 seconds
-          retries: 30
-          log-response: true
-
       - name: "Wait for VRO to be ready"
         uses: nev7n/wait_for_response@v1
         with:
@@ -123,33 +110,6 @@ jobs:
             echo "Unexpected ERROR logs in svc-xample-j container"
             exit 13
           fi
-      - name: 'Check (again) status of RabbitMQ'
-        if: always()
-        uses: department-of-veterans-affairs/curl-action@v1.0.0
-        with:
-          url: 'http://localhost:15672/api/vhosts'
-          method: 'GET'
-          basic-auth-token: '${{env.RABBITMQ_BASIC_AUTH}}'
-          accept: 200
-          # Retry every 2 seconds
-          timeout: 2000
-          # Quit after 60 seconds
-          retries: 30
-          log-response: true
-
-      - name: 'Check (again) queues of RabbitMQ'
-        if: always()
-        uses: department-of-veterans-affairs/curl-action@v1.0.0
-        with:
-          url: 'http://localhost:15672/api/queues'
-          method: 'GET'
-          basic-auth-token: '${{env.RABBITMQ_BASIC_AUTH}}'
-          accept: 200
-          # Retry every 2 seconds
-          timeout: 2000
-          # Quit after 60 seconds
-          retries: 30
-          log-response: true
 
       - name: "Clean shutdown of all containers"
         if: always()

--- a/.github/workflows/xample-integration-test.yml
+++ b/.github/workflows/xample-integration-test.yml
@@ -115,8 +115,10 @@ jobs:
             echo "Unexpected ERROR logs in xample-workflows container"
             exit 11
           fi
+          
+          docker logs vro_svc-xample-j_1 | grep -A 5 "Failed tests:"
+          
           if docker logs vro_svc-xample-j_1 | grep -B 25 -A 4 'ERROR\|WARN' | grep -v 'Simulated error'; then
-            echo $(docker logs vro_svc-xample-j_1 | grep -A 5 "Failed tests:")
             echo "Unexpected ERROR logs in svc-xample-j container"
             exit 12
           fi

--- a/.github/workflows/xample-integration-test.yml
+++ b/.github/workflows/xample-integration-test.yml
@@ -115,9 +115,8 @@ jobs:
             echo "Unexpected ERROR logs in xample-workflows container"
             exit 11
           fi
-          if docker logs vro_svc-xample-j_1 | grep -B 25 -A 4 'ERROR\|WARN' | grep -v 'Simulated error'; then
-            echo "Unexpected ERROR logs in svc-xample-j container"
-            echo "$(docker logs vro_svc-xample-j_1 | grep -A 5 'Failed tests:')"
+          if docker logs vro_svc-xample-j_1 | grep -A 5 'Failed tests:'; then
+            echo "test failures in svc-xample-j"
             exit 12
           fi
 

--- a/.github/workflows/xample-integration-test.yml
+++ b/.github/workflows/xample-integration-test.yml
@@ -52,7 +52,6 @@ jobs:
           timeout: 2000
           # Quit after 60 seconds
           retries: 30
-          log-response: true
 
       - name: "Wait for VRO to be ready"
         uses: nev7n/wait_for_response@v1

--- a/.github/workflows/xample-integration-test.yml
+++ b/.github/workflows/xample-integration-test.yml
@@ -119,7 +119,10 @@ jobs:
             echo "test failures in svc-xample-j"
             exit 12
           fi
-
+          if docker logs vro_svc-xample-j_1 | grep 'ERROR\|WARN' | grep -v 'Simulated error' | grep -v SimpleMessageListenerContainer ; then
+            echo "Unexpected ERROR logs in svc-xample-j container"
+            exit 13
+          fi
       - name: 'Check (again) status of RabbitMQ'
         if: always()
         uses: department-of-veterans-affairs/curl-action@v1.0.0

--- a/.github/workflows/xample-integration-test.yml
+++ b/.github/workflows/xample-integration-test.yml
@@ -115,11 +115,9 @@ jobs:
             echo "Unexpected ERROR logs in xample-workflows container"
             exit 11
           fi
-          
-          docker logs vro_svc-xample-j_1 | grep -A 5 "Failed tests:"
-          
           if docker logs vro_svc-xample-j_1 | grep -B 25 -A 4 'ERROR\|WARN' | grep -v 'Simulated error'; then
             echo "Unexpected ERROR logs in svc-xample-j container"
+            echo "$(docker logs vro_svc-xample-j_1 | grep -A 5 'Failed tests:')"
             exit 12
           fi
 

--- a/domain-xample/svc-xample-j/src/integrationTest/java/gov/va/vro/services/xample/XampleJavaMicroserviceTest.java
+++ b/domain-xample/svc-xample-j/src/integrationTest/java/gov/va/vro/services/xample/XampleJavaMicroserviceTest.java
@@ -49,6 +49,7 @@ public class XampleJavaMicroserviceTest {
   @BeforeEach
   private void setUp() {
     rabbitTemplate.setRetryTemplate(retryTemplate);
+    rabbitAdmin.purgeQueue(queueName);
   }
 
   private final SomeDtoModel request =
@@ -82,13 +83,6 @@ public class XampleJavaMicroserviceTest {
     assertEquals(StatusValue.DONE.toString(), response.getStatus());
     assertEquals(200, response.getHeader().getStatusCode());
     assertNull(response.getHeader().getStatusMessage());
-  }
-
-  @Test
-  void purgeQueue() throws IOException {
-    rabbitAdmin.purgeQueue(queueName);
-    assertNotNull(rabbitAdmin.getQueueInfo(queueName));
-    assertEquals(0, rabbitAdmin.getQueueInfo(queueName).getMessageCount());
   }
 
   @Test

--- a/domain-xample/svc-xample-j/src/integrationTest/java/gov/va/vro/services/xample/XampleJavaMicroserviceTest.java
+++ b/domain-xample/svc-xample-j/src/integrationTest/java/gov/va/vro/services/xample/XampleJavaMicroserviceTest.java
@@ -1,8 +1,7 @@
 package gov.va.vro.services.xample;
 
 import static gov.va.vro.services.xample.JavaMicroserviceApplication.*;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.*;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import gov.va.vro.model.xample.SomeDtoModel;
@@ -30,11 +29,6 @@ public class XampleJavaMicroserviceTest {
   @Autowired private RabbitTemplate rabbitTemplate;
 
   @Autowired private RabbitAdmin rabbitAdmin;
-
-  @BeforeEach
-  private void setUp() {
-    rabbitAdmin.purgeQueue(queueName, false);
-  }
 
   private final SomeDtoModel request =
       SomeDtoModel.builder().resourceId("320").diagnosticCode("B").build();
@@ -67,6 +61,13 @@ public class XampleJavaMicroserviceTest {
     assertEquals(StatusValue.DONE.toString(), response.getStatus());
     assertEquals(200, response.getHeader().getStatusCode());
     assertNull(response.getHeader().getStatusMessage());
+  }
+
+  @Test
+  void purgeQueue() throws IOException{
+    rabbitAdmin.purgeQueue(queueName);
+    assertNotNull(rabbitAdmin.getQueueInfo(queueName));
+    assertEquals(0, rabbitAdmin.getQueueInfo(queueName).getMessageCount());
   }
 
   @Test

--- a/domain-xample/svc-xample-j/src/integrationTest/java/gov/va/vro/services/xample/XampleJavaMicroserviceTest.java
+++ b/domain-xample/svc-xample-j/src/integrationTest/java/gov/va/vro/services/xample/XampleJavaMicroserviceTest.java
@@ -7,7 +7,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import gov.va.vro.model.xample.SomeDtoModel;
 import gov.va.vro.model.xample.StatusValue;
 import lombok.extern.slf4j.Slf4j;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.amqp.core.Message;
 import org.springframework.amqp.rabbit.core.RabbitAdmin;

--- a/domain-xample/svc-xample-j/src/integrationTest/java/gov/va/vro/services/xample/XampleJavaMicroserviceTest.java
+++ b/domain-xample/svc-xample-j/src/integrationTest/java/gov/va/vro/services/xample/XampleJavaMicroserviceTest.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import gov.va.vro.model.xample.SomeDtoModel;
 import gov.va.vro.model.xample.StatusValue;
 import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.amqp.core.Message;
 import org.springframework.amqp.rabbit.core.RabbitAdmin;
@@ -63,6 +64,7 @@ public class XampleJavaMicroserviceTest {
   }
 
   @Test
+  @Disabled
   void purgeQueue() throws IOException {
     rabbitAdmin.purgeQueue(queueName);
     assertNotNull(rabbitAdmin.getQueueInfo(queueName));

--- a/domain-xample/svc-xample-j/src/integrationTest/java/gov/va/vro/services/xample/XampleJavaMicroserviceTest.java
+++ b/domain-xample/svc-xample-j/src/integrationTest/java/gov/va/vro/services/xample/XampleJavaMicroserviceTest.java
@@ -36,7 +36,7 @@ public class XampleJavaMicroserviceTest {
 
   private final RetryTemplate retryTemplate = createRetryTemplate();
 
-  private static RetryTemplate createRetryTemplate(){
+  private static RetryTemplate createRetryTemplate() {
     ExponentialBackOffPolicy backOffPolicy = new ExponentialRandomBackOffPolicy();
     backOffPolicy.setInitialInterval(2000);
 
@@ -47,7 +47,7 @@ public class XampleJavaMicroserviceTest {
   }
 
   @BeforeEach
-  private void setUp(){
+  private void setUp() {
     rabbitTemplate.setRetryTemplate(retryTemplate);
   }
 

--- a/domain-xample/svc-xample-j/src/integrationTest/java/gov/va/vro/services/xample/XampleJavaMicroserviceTest.java
+++ b/domain-xample/svc-xample-j/src/integrationTest/java/gov/va/vro/services/xample/XampleJavaMicroserviceTest.java
@@ -65,6 +65,7 @@ public class XampleJavaMicroserviceTest {
     assertEquals(StatusValue.DONE.toString(), response.getStatus());
     assertEquals(200, response.getHeader().getStatusCode());
     assertNull(response.getHeader().getStatusMessage());
+    assertEquals(0,1);
   }
 
   @Autowired private ObjectMapper objectMapper;

--- a/domain-xample/svc-xample-j/src/integrationTest/java/gov/va/vro/services/xample/XampleJavaMicroserviceTest.java
+++ b/domain-xample/svc-xample-j/src/integrationTest/java/gov/va/vro/services/xample/XampleJavaMicroserviceTest.java
@@ -65,7 +65,6 @@ public class XampleJavaMicroserviceTest {
     assertEquals(StatusValue.DONE.toString(), response.getStatus());
     assertEquals(200, response.getHeader().getStatusCode());
     assertNull(response.getHeader().getStatusMessage());
-    assertEquals(0,1);
   }
 
   @Autowired private ObjectMapper objectMapper;

--- a/domain-xample/svc-xample-j/src/integrationTest/java/gov/va/vro/services/xample/XampleJavaMicroserviceTest.java
+++ b/domain-xample/svc-xample-j/src/integrationTest/java/gov/va/vro/services/xample/XampleJavaMicroserviceTest.java
@@ -36,12 +36,7 @@ public class XampleJavaMicroserviceTest {
   private void setUp() {
     rabbitAdmin.purgeQueue(queueName, true);
   }
-
-  @AfterEach
-  private void tearDown() {
-    rabbitAdmin.purgeQueue(queueName, true);
-  }
-
+  
   private final SomeDtoModel request =
       SomeDtoModel.builder().resourceId("320").diagnosticCode("B").build();
 

--- a/domain-xample/svc-xample-j/src/integrationTest/java/gov/va/vro/services/xample/XampleJavaMicroserviceTest.java
+++ b/domain-xample/svc-xample-j/src/integrationTest/java/gov/va/vro/services/xample/XampleJavaMicroserviceTest.java
@@ -63,7 +63,7 @@ public class XampleJavaMicroserviceTest {
   }
 
   @Test
-  void purgeQueue() throws IOException{
+  void purgeQueue() throws IOException {
     rabbitAdmin.purgeQueue(queueName);
     assertNotNull(rabbitAdmin.getQueueInfo(queueName));
     assertEquals(0, rabbitAdmin.getQueueInfo(queueName).getMessageCount());

--- a/domain-xample/svc-xample-j/src/integrationTest/java/gov/va/vro/services/xample/XampleJavaMicroserviceTest.java
+++ b/domain-xample/svc-xample-j/src/integrationTest/java/gov/va/vro/services/xample/XampleJavaMicroserviceTest.java
@@ -34,9 +34,9 @@ public class XampleJavaMicroserviceTest {
 
   @BeforeEach
   private void setUp() {
-    rabbitAdmin.purgeQueue(queueName, true);
+    rabbitAdmin.purgeQueue(queueName, false);
   }
-  
+
   private final SomeDtoModel request =
       SomeDtoModel.builder().resourceId("320").diagnosticCode("B").build();
 

--- a/domain-xample/svc-xample-j/src/integrationTest/java/gov/va/vro/services/xample/XampleJavaMicroserviceTest.java
+++ b/domain-xample/svc-xample-j/src/integrationTest/java/gov/va/vro/services/xample/XampleJavaMicroserviceTest.java
@@ -8,7 +8,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import gov.va.vro.model.xample.SomeDtoModel;
 import gov.va.vro.model.xample.StatusValue;
 import lombok.extern.slf4j.Slf4j;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.amqp.core.Message;


### PR DESCRIPTION
## What was the problem?

The continuous Integration (CI) tests for `xample-domain` are flaky: they appear to fail randomly for no apparent reason. 

As reported in https://github.com/department-of-veterans-affairs/abd-vro/issues/2345, this error is consistent in the logs of those failed tests:
> o.s.a.r.l.SimpleMessageListenerContainer : Failed to check/redeclare auto-delete queue(s). [...] Unexpected ERROR logs in svc-xample-j container.

Theory: 1) the `domain-xample` integration test code (java) occasionally fails to connect to the rabbitMQ service, even if the service is observed to be running*; 2) initial connection failures are not uncommon; and 3) that if given a modest number of retry attempts, the connection would succeed.

Associated tickets or Slack threads:
- https://github.com/department-of-veterans-affairs/abd-vro/issues/2345


## How does this fix it?
1. Introduce a retry policy on rabbitMQ actions, limited to the scope of the integration test.
2. Refine error interpretation: rather than assess an integration test failure if the word "ERROR" is found in a log file, ignore cases of "ERROR" that are associated with AMQP's "SimpleMessageListenerContainer" - with the theory that initial connection failures are not uncommon. 
3. ~To mitigate the previous item being too lax, assess an integration failure if the word "Test failures:" is found in the log file.~. (test failures will in fact cause the the log file assessment to be skipped)

This PR has an additional change to the integration test, I think minor (removal of an action I thought redundant).

## How to test this PR
- in particular, please assess whether the change to the error interpretation could be more refined
- Step 2[^secrel]



[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).

*the CI workflow verifies the rabbitMQ service is ready before moving on to executing the integration tests. https://github.com/department-of-veterans-affairs/abd-vro/blob/e3ec82a31b254bcb02e53b95004c844021025c67/.github/workflows/xample-integration-test.yml#L46-L50
