### PR TITLE
change base java image

### DIFF
--- a/gradle-plugins/src/main/resources/docker/Dockerfile-java
+++ b/gradle-plugins/src/main/resources/docker/Dockerfile-java
@@ -2,7 +2,7 @@
 # It acts as the default Dockerfile for Java-based containers, i.e., those created by build.gradle
 # that use the local.java.docker.container-conventions plugin (directly or indirectly).
 # To override this file, create a Dockerfile file in your Gradle module.
-FROM eclipse-temurin:17-jre-alpine
+FROM eclipse-temurin:17.0.10_7-jre-alpine
 
 # curl is needed for HEALTHCHECK
 # hadolint ignore=DL3018


### PR DESCRIPTION
<!-- Ensure the PR title reflects the feature or bug name -->

## What was the problem?
<!-- brief description of how things worked before this PR -->
Version of the JRE base docker image changed in Docker Hub and broke our applications

Associated tickets or Slack threads:
- #?

## How does this fix it?[^1]
<!-- description of how things will work after this PR -->
Reverts back to old version of the JRE

## How to test this PR
- Step 1
- Step 2[^secrel]


[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
