### PR TITLE
fix flaky integration tests in svc-bie-kafka 

### DIFF
--- a/.github/workflows/bie-kafka-end2end-test.yml
+++ b/.github/workflows/bie-kafka-end2end-test.yml
@@ -122,8 +122,8 @@ jobs:
         run: |
           source scripts/setenv.sh
 
-          # Retry to 20 times to allow time for message to travel from kafka to database
-          for i in {1..20}; do
+          # Retry to 10 times to allow time for message to travel from kafka to database
+          for i in {1..10}; do
             sleep 10
             echo "Attempt $i"
             # For debugging

--- a/.github/workflows/bie-kafka-end2end-test.yml
+++ b/.github/workflows/bie-kafka-end2end-test.yml
@@ -122,8 +122,8 @@ jobs:
         run: |
           source scripts/setenv.sh
 
-          # Retry to 5 times to allow time for message to travel from kafka to database
-          for i in {1..5}; do
+          # Retry to 20 times to allow time for message to travel from kafka to database
+          for i in {1..20}; do
             sleep 10
             echo "Attempt $i"
             # For debugging

--- a/.github/workflows/bie-kafka-end2end-test.yml
+++ b/.github/workflows/bie-kafka-end2end-test.yml
@@ -103,8 +103,8 @@ jobs:
           responseCode: 200
           # Retry every 2 seconds
           interval: 2000
-          # Quit after 60 seconds
-          timeout: 60000
+          # Quit after 90 seconds
+          timeout: 90000
 
       - name: 'Create Kafka topic and send message'
         run: |

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -18,52 +18,11 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  nondraft-pr:
-    # Adding an `if:` that evaluates to false for this nondraft-pr job prevents other dependent jobs from running.
-    # For github.event.pull_request fields, see
-    # https://docs.github.com/en/webhooks-and-events/webhooks/webhook-events-and-payloads#pull_request
-    if: github.event_name != 'pull_request' ||
-      (github.event_name == 'pull_request' && !github.event.pull_request.draft )
-    runs-on: ubuntu-latest
-    steps:
-    - name: "DEBUG"
-      run: |
-        echo "${{ github.event_name }} ${{ github.event.pull_request.draft }}"
-
   lint-and-test:
     uses: ./.github/workflows/test-code.yml
     secrets: inherit
-
-  codeql:
-    uses: ./.github/workflows/codeql-analysis.yml
-    secrets: inherit
-
-  container-healthchecks:
-    needs: nondraft-pr
-    uses: ./.github/workflows/container-healthchecks.yml
-    secrets: inherit
-
-  xample-domain:
-    needs: nondraft-pr
-    uses: ./.github/workflows/xample-integration-test.yml
-    secrets: inherit
-
-  svc-bgs-api:
-    needs: nondraft-pr
-    uses: ./.github/workflows/svc-bgs-api-integration-test.yml
-    secrets: inherit
-
-  svc-bip-api:
-    needs: nondraft-pr
-    uses: ./.github/workflows/svc-bip-api-integration-test.yml
-    secrets: inherit
-
+    
   svc-bie-kafka-end-to-end:
-    needs: nondraft-pr
     uses: ./.github/workflows/bie-kafka-end2end-test.yml
     secrets: inherit
 
-  ee-ep-merge-end-to-end:
-    needs: nondraft-pr
-    uses: ./.github/workflows/ee-ep-merge-end-to-end.yml
-    secrets: inherit

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -18,11 +18,52 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  nondraft-pr:
+    # Adding an `if:` that evaluates to false for this nondraft-pr job prevents other dependent jobs from running.
+    # For github.event.pull_request fields, see
+    # https://docs.github.com/en/webhooks-and-events/webhooks/webhook-events-and-payloads#pull_request
+    if: github.event_name != 'pull_request' ||
+      (github.event_name == 'pull_request' && !github.event.pull_request.draft )
+    runs-on: ubuntu-latest
+    steps:
+    - name: "DEBUG"
+      run: |
+        echo "${{ github.event_name }} ${{ github.event.pull_request.draft }}"
+
   lint-and-test:
     uses: ./.github/workflows/test-code.yml
     secrets: inherit
-    
+
+  codeql:
+    uses: ./.github/workflows/codeql-analysis.yml
+    secrets: inherit
+
+  container-healthchecks:
+    needs: nondraft-pr
+    uses: ./.github/workflows/container-healthchecks.yml
+    secrets: inherit
+
+  xample-domain:
+    needs: nondraft-pr
+    uses: ./.github/workflows/xample-integration-test.yml
+    secrets: inherit
+
+  svc-bgs-api:
+    needs: nondraft-pr
+    uses: ./.github/workflows/svc-bgs-api-integration-test.yml
+    secrets: inherit
+
+  svc-bip-api:
+    needs: nondraft-pr
+    uses: ./.github/workflows/svc-bip-api-integration-test.yml
+    secrets: inherit
+
   svc-bie-kafka-end-to-end:
+    needs: nondraft-pr
     uses: ./.github/workflows/bie-kafka-end2end-test.yml
     secrets: inherit
 
+  ee-ep-merge-end-to-end:
+    needs: nondraft-pr
+    uses: ./.github/workflows/ee-ep-merge-end-to-end.yml
+    secrets: inherit


### PR DESCRIPTION
<!-- Ensure the PR title reflects the feature or bug name -->

## What was the problem?
<!-- brief description of how things worked before this PR -->

Associated tickets or Slack threads:
- #2868 




Samples of past failures:

date | failed step | SHA | CI url 
---|---|---|---
4/8 | Check for saved DB entry in Postgres | 8a712091b7f22f5eb111ca7988e1c18d63b75f80 |  [GH Action](https://github.com/department-of-veterans-affairs/abd-vro/actions/runs/8602899355/job/23573510970)
4/9 | Build the images (failed to find flyway:10.11-alpine, status code 503) | 6d22e47bec16146db6b5544ed48688d179e8e4fc | [GH Action](https://github.com/department-of-veterans-affairs/abd-vro/actions/runs/8618932564/job/23622471738)
4/10 | Check for saved DB entry in Postgres | e6a21f94db391dac078570785d1c4ad1aba65ac0 | [GH Action](https://github.com/department-of-veterans-affairs/abd-vro/actions/runs/8637027652/job/23678295282)
4/10 | Check for saved DB entry in Postgres | f7dca880d16309ead724bf14de6a7079283d6f7e | [GH Action](https://github.com/department-of-veterans-affairs/abd-vro/actions/runs/8637027652/job/23678295282)
4/17 |  Wait for svc-bie-kafka to be ready  |  97b535f889da7a91387ac5fd7df4114080068ca0 | [GH action](https://github.com/department-of-veterans-affairs/abd-vro/actions/runs/8724565075/job/23935453963)
4/17 |  Wait for svc-bie-kafka to be ready  |  36b1e9c1f3bc55af0246596716fe2f1dd3f177c3 | [GH action](https://github.com/department-of-veterans-affairs/abd-vro/actions/runs/8729852224/job/23952619078)
4/18 |  Wait for svc-bie-kafka to be ready  |  cde8eb03601eca15717b1926244ca710a9f11d85 | [GH action](https://github.com/department-of-veterans-affairs/abd-vro/actions/runs/8741497285/job/23987666712)
4/18 |  Wait for svc-bie-kafka to be ready  |  966faf03ecb305a871ad2384baa7c6dfcc4166d5 | [GH action](https://github.com/department-of-veterans-affairs/abd-vro/actions/runs/8744768931/job/23998369876) 
4/18 | Wait for svc-bie-kafka to be ready | a9fe0c6e9d81b0a67920340e8dc8c3587ddd2a8e  | [GH action](https://github.com/department-of-veterans-affairs/abd-vro/actions/runs/8744785193/job/23998417025)
4/18 | Wait for svc-bie-kafka to be ready | 1a4f255ea | [GH action](https://github.com/department-of-veterans-affairs/abd-vro/actions/runs/8744916328/job/23998838078)
4/18 |  Wait for svc-bie-kafka to be ready | 102932c | [GH action](https://github.com/department-of-veterans-affairs/abd-vro/actions/runs/8746200919/job/24002619210)
4/18 | Wait for svc-bie-kafka to be ready | 9222c6e | [GH action](https://github.com/department-of-veterans-affairs/abd-vro/actions/runs/8746827426/job/24004333962) 
4/22 | Check for saved DB entry in Postgres | 50dc058 | [GH action](https://github.com/department-of-veterans-affairs/abd-vro/actions/runs/8787550703/job/24113013709)
4/24 |  Install kafkacat and postgresql  (failed to fetch a package) | fc48834 | [GH action](https://github.com/department-of-veterans-affairs/abd-vro/actions/runs/8815510489/job/24197627927)
4/26 | Check for saved DB entry in Postgres |   d3cf017692c909095b206b9d5aa78bd104b21ca9 | [GH action](https://github.com/department-of-veterans-affairs/abd-vro/actions/runs/8854475758/job/24317588608)




## How does this fix it?[^1]
<!-- description of how things will work after this PR -->
Increase timeouts / number of attempts. 

On the main branch, this CI test averages 8-9 minutes per run and sets a timeout of 60 seconds and 50 seconds for the `Wait for svc-bie-kafka to be ready` and `Check for saved DB entry in Postgres` tasks, respectively;  this PR increases those to 90 seconds and 100 seconds, respectively; potentially adding ~1.5 minutes to the execution time (~15% increase). We expect that increased timeouts will reduce the number of flaky test failures (instances that succeed on a subsequent attempt); and if not, we can revert this change (and bump back down the execution time to 8-9 minutes). 

A more thorough approach would be to investigate why it takes so long for the respective services/tasks to complete. This PR is a crude, high-level approach.

