### PR TITLE
Kafka RBAC changes for Prod env

### DIFF
--- a/svc-bie-kafka/src/main/resources/application-prod.yaml
+++ b/svc-bie-kafka/src/main/resources/application-prod.yaml
@@ -29,4 +29,4 @@ spring:
         trust-store-type: "PKCS12"
 
 bie:
-  kafka-topic-prefix: "PROD"
+  kafka-topic-infix: "PROD"

--- a/svc-bie-kafka/src/main/resources/application-prod.yaml
+++ b/svc-bie-kafka/src/main/resources/application-prod.yaml
@@ -1,35 +1,32 @@
 spring:
   kafka:
-    bootstrap-servers: "${BIE_KAFKA_PLACEHOLDERS_BROKERS:kafka.prod.bip.va.gov:443}"
+    bootstrap-servers: "${BIE_KAFKA_PLACEHOLDERS_BROKERS:bip-kafka.prod.bip.va.gov:443}"
     properties:
-      schema:
-        registry:
-          url: "${BIE_KAFKA_PLACEHOLDERS_BROKERS:https://schemaregistry.prod.bip.va.gov:443}"
-          ssl:
-            protocol: SSL
-            keystore:
-              type: PKCS12
-              location: "${KEYSTORE_FILE}"
-              password: "${BIE_KAFKA_KEYSTORE_PASSWORD}"
-            truststore:
-              type: PKCS12
-              location: "${TRUSTSTORE_FILE}"
-              password: "${BIE_KAFKA_TRUSTSTORE_PASSWORD}"
+      basic.auth.credentials.source: USER_INFO
+      basic.auth.user.info: "${BIE_KAFKA_RBAC_USERNAME}:${BIE_KAFKA_RBAC_PASSWORD}"
+      schema.registry:
+        basic.auth.credentials.source: USER_INFO
+        basic.auth.user.info: "${BIE_KAFKA_RBAC_USERNAME}:${BIE_KAFKA_RBAC_PASSWORD}"
+        url: "${BIE_KAFKA_PLACEHOLDERS_BROKERS:https://bip-schemaregistry.prod.bip.va.gov}"
+        ssl:
+          truststore.location: "${TRUSTSTORE_FILE}"
+          truststore.password: "${BIE_KAFKA_TRUSTSTORE_PASSWORD}"
+          truststore.type: "PKCS12"
+      security.protocol: SASL_SSL
+      sasl:
+        mechanism: PLAIN
+        jaas:
+          config: "org.apache.kafka.common.security.plain.PlainLoginModule required username=\"${BIE_KAFKA_RBAC_USERNAME}\" password=\"${BIE_KAFKA_RBAC_PASSWORD}\";"
     consumer:
-      group-id: "${BIE_KAFKA_PLACEHOLDERS_GROUP_ID:vro-bie-prod-vro}"
+      group-id: "${BIE_KAFKA_PLACEHOLDERS_GROUP_ID:EXT_VRO_PROD}"
       key-deserializer: "org.apache.kafka.common.serialization.StringDeserializer"
       value-deserializer: "io.confluent.kafka.serializers.KafkaAvroDeserializer"
-      properties:
-        security.protocol: SSL
-        ssl:
-          keystore:
-            type: PKCS12
-            location: "${KEYSTORE_FILE}"
-            password: "${BIE_KAFKA_KEYSTORE_PASSWORD}"
-          truststore:
-            type: PKCS12
-            location: "${TRUSTSTORE_FILE}"
-            password: "${BIE_KAFKA_TRUSTSTORE_PASSWORD}"
+      security:
+        protocol: SASL_SSL
+      ssl:
+        trust-store-location: "file:${TRUSTSTORE_FILE}"
+        trust-store-password: "${BIE_KAFKA_TRUSTSTORE_PASSWORD}"
+        trust-store-type: "PKCS12"
 
 bie:
-  kakfa-topic-prefix: "PROD_"
+  kafka-topic-prefix: "PROD"


### PR DESCRIPTION
## What was the problem?
At this time, Kafka is not able to connect and receive data in Prod.

Associated tickets or Slack threads:
- #2560 

## How does this fix it?[^1]
Updating Kafka to use RBAC in Prod environment for authentication and authorization will ensure we remain compliant. 

## How to test this PR
- Check Prod Kafka logs on Lens to confirm successful connection.
