### PR TITLE
Add support for test coverage reports via pytest-cov.

### DIFF
--- a/domain-ee/ee-ep-merge-app/src/requirements.txt
+++ b/domain-ee/ee-ep-merge-app/src/requirements.txt
@@ -5,6 +5,7 @@ httpx==0.24.*
 psycopg2-binary==2.9.*
 pydantic==2.4.*
 pytest==7.3.1
+pytest-cov==5.0.0
 pytest-env==1.0.1
 pytest-mock==3.11.1
 python-statemachine==2.1.*

--- a/domain-ee/ee-max-cfi-app/pyproject.toml
+++ b/domain-ee/ee-max-cfi-app/pyproject.toml
@@ -5,17 +5,9 @@ addopts = "-ra --cov=./src --cov-fail-under=80 --no-cov-on-fail --cov-report=ter
 testpaths = [
     "tests"
 ]
-env = [
-    "REQUEST_TIMEOUT = 1",
-    "REQUEST_RETRIES = 1",
-    "EP_MERGE_SPECIAL_ISSUE_CODE = TEST",
-    "EP400_CONTENTION_RETRIES = 2",
-    "EP400_CONTENTION_RETRY_RATE = 1"
-]
 
 [tool.coverage.run]
 # The following files are for development purposes and are not part of the coverage report
 omit = [
-    "src/python_src/graph_export.py",
     "src/python_src/pull_api_documentation.py",
 ]

--- a/domain-ee/ee-max-cfi-app/src/requirements.txt
+++ b/domain-ee/ee-max-cfi-app/src/requirements.txt
@@ -2,5 +2,6 @@ fastapi==0.109.*
 httpx==0.24.*
 pydantic==1.10.13
 pytest==7.3.1
+pytest-cov==5.0.0
 starlette>=0.27.0
 uvicorn[standard]==0.20.*


### PR DESCRIPTION
<!-- Ensure the PR title reflects the feature or bug name -->

## What was the problem?
<!-- brief description of how things worked before this PR -->
EE projects did not include test coverage. 

Associated tickets or Slack threads:
- #2988 

## How does this fix it?[^1]
<!-- description of how things will work after this PR -->
Adds [pytest-cov](https://pytest-cov.readthedocs.io/en/latest/readme.html) to domain-ee subprojects.

## How to test this PR
- Run via gradle: ```./gradlew :domain-ee:test```
- Run via `pytest` from individual project folder
