### PR TITLE
debug xample-domain integration test

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -44,6 +44,7 @@ jobs:
     secrets: inherit
 
   xample-domain:
+    needs: nondraft-pr
     uses: ./.github/workflows/xample-integration-test.yml
     secrets: inherit
 

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -44,7 +44,6 @@ jobs:
     secrets: inherit
 
   xample-domain:
-    needs: nondraft-pr
     uses: ./.github/workflows/xample-integration-test.yml
     secrets: inherit
 

--- a/.github/workflows/xample-integration-test.yml
+++ b/.github/workflows/xample-integration-test.yml
@@ -8,7 +8,7 @@ on:
   workflow_call:
 
 env:
-  COMPOSE_PROFILES: ""
+  COMPOSE_PROFILES: "platform"
 
 jobs:
   integration-test:

--- a/.github/workflows/xample-integration-test.yml
+++ b/.github/workflows/xample-integration-test.yml
@@ -52,32 +52,9 @@ jobs:
           # Quit after 60 seconds
           retries: 30
 
-      - name: "Wait for VRO to be ready"
-        uses: nev7n/wait_for_response@v1
-        with:
-          url: 'http://localhost:8111/actuator/health'
-          responseCode: 200
-          # Retry every 2 seconds
-          interval: 2000
-          # Quit after 60 seconds
-          timeout: 60000
-
       - name: "Run the integration test"
         run: |
           source scripts/setenv.sh
-
-          # https://superuser.com/a/442395
-          STATUS_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST "http://localhost:8110/v3/xample-resource" \
-            -H "accept: application/json" -H "Content-Type: application/json" \
-            -d '{"resourceId":"1234","diagnosticCode":"J"}')
-          # Note: diagnosticCode must be J in order for the request to be routed to the svc-xample-j microservice,
-          # as coded in Xample's Camel route (XampleRoutes.java#L130-L131).
-
-          if [ "$STATUS_CODE" != 201 ]; then
-            echo "Unexpected status code: $STATUS_CODE"
-            exit 10
-          fi
-
           ./gradlew -p domain-xample integrationTest
 
       - name: "Collect docker logs"


### PR DESCRIPTION
## What was the problem?
debugging what appears to be a CI failure in the `xample-domain/integration-test` consistent across the past few days : 

>  Task :dockerComposeUp FAILED
[...]
Service "rabbitmq-service" was pulled in as a dependency of service "svc-bip-api" but is not enabled by the active profiles. You may fix this by adding a common profile to "rabbitmq-service" and "svc-bip-api".
 
sample of CI failures on `develop`: [May 16](https://github.com/department-of-veterans-affairs/abd-vro/actions/runs/9113527904/job/25055274882),  [May 14](https://github.com/department-of-veterans-affairs/abd-vro/actions/runs/9086815654/job/24973340633), [May 13](https://github.com/department-of-veterans-affairs/abd-vro/actions/runs/9063971419/job/24901112760)

## How does this fix it? 
- modify the `COMPOSE_PROFILES` for the `xample-domain` CI workflow 
- remove section of the affected integration test that was referencing a removed app

## How to test this PR
Verify that the CI tests on `xample-domain` are informative and do not fail. sample successful run observed on c503557d. 
