### PR TITLE
Feature - add API spec for multi-contention classification

### DIFF
--- a/domain-cc/cc-app/src/python_src/api.py
+++ b/domain-cc/cc-app/src/python_src/api.py
@@ -213,7 +213,7 @@ def classify_contention(contention: Contention) -> ClassifiedContention:
         classification_code=classification_code,
         classification_name=classification_name,
         diagnostic_code=contention.diagnostic_code,
-        contention_text=contention.contention_type,
+        contention_type=contention.contention_type,
     )
 
 

--- a/domain-cc/cc-app/src/python_src/api.py
+++ b/domain-cc/cc-app/src/python_src/api.py
@@ -227,6 +227,9 @@ def va_gov_claim_classifier(claim: VaGovClaim) -> ClassifierResponse:
         contentions=classified_contentions,
         claim_id=claim.claim_id,
         form526_submission_id=claim.form526_submission_id,
+        is_fully_classified=False,
+        num_processed_contentions=len(classified_contentions),
+        num_classified_contentions=0,
     )
-    log_as_json(response)  # move to decorator or middleware
+    log_as_json(response.dict())  # move to decorator or middleware
     return response

--- a/domain-cc/cc-app/src/python_src/pydantic_models.py
+++ b/domain-cc/cc-app/src/python_src/pydantic_models.py
@@ -63,7 +63,7 @@ class Contention(BaseModel):
 class VaGovClaim(BaseModel):
     claim_id: int
     form526_submission_id: int
-    contentions: conlist(Contention, min_items=1)
+    contentions: conlist(Contention, min_length=1)
 
 
 class ClassifiedContention(BaseModel):
@@ -74,7 +74,7 @@ class ClassifiedContention(BaseModel):
 
 
 class ClassifierResponse(BaseModel):
-    contentions: conlist(ClassifiedContention, min_items=1)
+    contentions: conlist(ClassifiedContention, min_length=1)
     claim_id: int
     form526_submission_id: int
     is_fully_classified: bool

--- a/domain-cc/cc-app/src/python_src/pydantic_models.py
+++ b/domain-cc/cc-app/src/python_src/pydantic_models.py
@@ -1,6 +1,8 @@
 from typing import Optional
 
+from fastapi import HTTPException
 from pydantic import BaseModel, model_validator
+from pydantic.types import conlist
 
 
 class Claim(BaseModel):
@@ -39,3 +41,40 @@ class ClaimLinkInfo(BaseModel):
 
     va_gov_claim_id: int
     vbms_claim_id: int
+
+
+class Contention(BaseModel):
+    contention_text: str
+    contention_type: str  # "disabilityActionType" in the VA.gov API
+    diagnostic_code: Optional[int]  # only required for contention_type: "claim_for_increase"
+
+    @model_validator(mode="before")
+    def check_dc_for_cfi(cls, values):
+        contention_type = values.get("contention_type")
+        diagnostic_code = values.get("diagnostic_code")
+
+        if contention_type == "claim_for_increase" and not diagnostic_code:
+            raise HTTPException(
+                422, "diagnostic_code is required for contention_type claim_for_increase"
+            )
+
+
+class VaGovClaim(BaseModel):
+    claim_id: int
+    form526_submission_id: int
+    contentions: conlist(Contention, min_items=1)
+
+
+class ClassifiedContention(BaseModel):
+    classification: Optional[PredictedClassification]
+    diagnostic_code: Optional[int]  # only required for contention_type: "claim_for_increase"
+    contention_type: str  # "disabilityActionType" in the VA.gov API
+
+
+class ClassifierResponse(BaseModel):
+    contentions: conlist(ClassifiedContention, min_items=1)
+    claim_id: int
+    form526_submission_id: int
+    is_fully_classified: bool
+    num_processed_contentions: int
+    num_classified_contentions: int

--- a/domain-cc/cc-app/src/python_src/pydantic_models.py
+++ b/domain-cc/cc-app/src/python_src/pydantic_models.py
@@ -66,7 +66,8 @@ class VaGovClaim(BaseModel):
 
 
 class ClassifiedContention(BaseModel):
-    classification: Optional[PredictedClassification]
+    classification_code: Optional[int]
+    classification_name: Optional[str]
     diagnostic_code: Optional[int]  # only required for contention_type: "claim_for_increase"
     contention_type: str  # "disabilityActionType" in the VA.gov API
 

--- a/domain-cc/cc-app/src/python_src/pydantic_models.py
+++ b/domain-cc/cc-app/src/python_src/pydantic_models.py
@@ -55,7 +55,8 @@ class Contention(BaseModel):
 
         if contention_type == "claim_for_increase" and not diagnostic_code:
             raise HTTPException(
-                422, "diagnostic_code is required for contention_type claim_for_increase"
+                422,
+                "diagnostic_code is required for contention_type claim_for_increase",
             )
 
 

--- a/domain-cc/cc-app/src/python_src/pydantic_models.py
+++ b/domain-cc/cc-app/src/python_src/pydantic_models.py
@@ -46,9 +46,10 @@ class ClaimLinkInfo(BaseModel):
 class Contention(BaseModel):
     contention_text: str
     contention_type: str  # "disabilityActionType" in the VA.gov API
-    diagnostic_code: Optional[int]  # only required for contention_type: "claim_for_increase"
+    diagnostic_code: Optional[int] = None  # only required for contention_type: "claim_for_increase"
 
     @model_validator(mode="before")
+    @classmethod
     def check_dc_for_cfi(cls, values):
         contention_type = values.get("contention_type")
         diagnostic_code = values.get("diagnostic_code")
@@ -58,6 +59,7 @@ class Contention(BaseModel):
                 422,
                 "diagnostic_code is required for contention_type claim_for_increase",
             )
+        return values
 
 
 class VaGovClaim(BaseModel):
@@ -69,7 +71,7 @@ class VaGovClaim(BaseModel):
 class ClassifiedContention(BaseModel):
     classification_code: Optional[int]
     classification_name: Optional[str]
-    diagnostic_code: Optional[int]  # only required for contention_type: "claim_for_increase"
+    diagnostic_code: Optional[int] = None  # only required for contention_type: "claim_for_increase"
     contention_type: str  # "disabilityActionType" in the VA.gov API
 
 


### PR DESCRIPTION
<!-- Ensure the PR title reflects the feature or bug name -->

## What was the problem?
<!-- brief description of how things worked before this PR -->
This PR starts the work for the multi-contention classifier endpoint outlined in the ticket below.

This draft is intended to provide the API specification so engineers on the team can review API inputs and outputs 
and answer these questions
 - is there sufficient data from the inputs to update `call_logging_functions()` to emit messages in the same format as the legacy `/classifier` endpoint
 - what code changes are required to update `call_logging_functions()` accordingly?

Associated tickets or Slack threads:
- https://github.com/department-of-veterans-affairs/vagov-claim-classification/issues/472

## How does this fix it?[^1]
<!-- description of how things will work after this PR -->

## How to test this PR
- run the uvicorn server locally per [project README.md
](https://github.com/department-of-veterans-affairs/abd-vro/blob/develop/domain-cc/README.md)
- initiate a POST request to `/va-gov-claim-classifier`
- see example below:

![Screenshot 2024-05-22 at 2 12 26 PM](https://github.com/department-of-veterans-affairs/abd-vro/assets/17188013/395d3761-59d1-4b18-930e-809eaf5db1f1)


[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
