### PR TITLE
Logging Updates v2

### DIFF
--- a/domain-cc/cc-app/src/python_src/api.py
+++ b/domain-cc/cc-app/src/python_src/api.py
@@ -107,6 +107,7 @@ def log_contention_stats(
     contention: Contention,
     classified_contention: ClassifiedContention,
 ):
+    """make necessary logging calls to preserve compatibility w/ existing LHDI datadog dashboards"""
     # if classification:
     #     classification_code = classification.classification_code
     #     classification_name = classification.classification_name
@@ -267,11 +268,6 @@ def link_vbms_claim_id(claim_link_info: ClaimLinkInfo):
     return {
         "success": True,
     }
-
-
-def call_logging_functions(contention: Contention):
-    """make necessary logging calls to preserve compatibility w/ existing LHDI datadog dashboards"""
-    pass
 
 
 def get_classification_code(contention: Contention) -> Optional[int]:

--- a/domain-cc/cc-app/src/python_src/api.py
+++ b/domain-cc/cc-app/src/python_src/api.py
@@ -213,7 +213,7 @@ def classify_contention(contention: Contention) -> ClassifiedContention:
         classification_code=classification_code,
         classification_name=classification_name,
         diagnostic_code=contention.diagnostic_code,
-        contention_text=contention.contention_type,
+        contention_type=contention.contention_type,
     )
 
 

--- a/domain-cc/cc-app/src/python_src/api.py
+++ b/domain-cc/cc-app/src/python_src/api.py
@@ -227,6 +227,9 @@ def va_gov_claim_classifier(claim: VaGovClaim) -> ClassifierResponse:
         contentions=classified_contentions,
         claim_id=claim.claim_id,
         form526_submission_id=claim.form526_submission_id,
+        is_fully_classified=False,
+        num_processed_contentions=len(classified_contentions),
+        num_classified_contentions=0,
     )
-    log_as_json(response)  # move to decorator or middleware
+    log_as_json(response.dict())  # move to decorator or middleware
     return response

--- a/domain-cc/cc-app/src/python_src/api.py
+++ b/domain-cc/cc-app/src/python_src/api.py
@@ -119,10 +119,14 @@ def log_contention_stats(
     log_contention_text = (
         contention_text if is_mapped_text else "unmapped contention text"
     )
+    if contention.contention_type == "INCREASE":
+        log_contention_type = "claim_for_increase"
+    else:
+        log_contention_type = contention.contention_type.lower()
 
     log_as_json(
         {
-            "claim_type": sanitize_log(contention.contention_type.lower()),
+            "claim_type": sanitize_log(log_contention_type),
             "classification_code": classification_code,
             "classification_name": classification_name,
             "contention_text": log_contention_text,
@@ -269,7 +273,7 @@ def get_classification_code(contention: Contention) -> Optional[int]:
     classification code (if available)
     """
     classification_code = None
-    if contention.contention_type == "claim_for_increase":
+    if contention.contention_type == "INCREASE":
         classification_code = dc_lookup_table.get(contention.diagnostic_code, None)
 
     if contention.contention_text and not classification_code:

--- a/domain-cc/cc-app/src/python_src/pydantic_models.py
+++ b/domain-cc/cc-app/src/python_src/pydantic_models.py
@@ -63,7 +63,7 @@ class Contention(BaseModel):
 class VaGovClaim(BaseModel):
     claim_id: int
     form526_submission_id: int
-    contentions: conlist(Contention, min_items=1)
+    contentions: conlist(Contention, min_length=1)
 
 
 class ClassifiedContention(BaseModel):
@@ -74,7 +74,7 @@ class ClassifiedContention(BaseModel):
 
 
 class ClassifierResponse(BaseModel):
-    contentions: conlist(ClassifiedContention, min_items=1)
+    contentions: conlist(ClassifiedContention, min_length=1)
     claim_id: int
     form526_submission_id: int
     is_fully_classified: bool

--- a/domain-cc/cc-app/src/python_src/pydantic_models.py
+++ b/domain-cc/cc-app/src/python_src/pydantic_models.py
@@ -1,6 +1,8 @@
 from typing import Optional
 
+from fastapi import HTTPException
 from pydantic import BaseModel, model_validator
+from pydantic.types import conlist
 
 
 class Claim(BaseModel):
@@ -39,3 +41,40 @@ class ClaimLinkInfo(BaseModel):
 
     va_gov_claim_id: int
     vbms_claim_id: int
+
+
+class Contention(BaseModel):
+    contention_text: str
+    contention_type: str  # "disabilityActionType" in the VA.gov API
+    diagnostic_code: Optional[int]  # only required for contention_type: "claim_for_increase"
+
+    @model_validator(mode="before")
+    def check_dc_for_cfi(cls, values):
+        contention_type = values.get("contention_type")
+        diagnostic_code = values.get("diagnostic_code")
+
+        if contention_type == "claim_for_increase" and not diagnostic_code:
+            raise HTTPException(
+                422, "diagnostic_code is required for contention_type claim_for_increase"
+            )
+
+
+class VaGovClaim(BaseModel):
+    claim_id: int
+    form526_submission_id: int
+    contentions: conlist(Contention, min_items=1)
+
+
+class ClassifiedContention(BaseModel):
+    classification: Optional[PredictedClassification]
+    diagnostic_code: Optional[int]  # only required for contention_type: "claim_for_increase"
+    contention_type: str  # "disabilityActionType" in the VA.gov API
+
+
+class ClassifierResponse(BaseModel):
+    contentions: conlist(ClassifiedContention, min_items=1)
+    claim_id: int
+    form526_submission_id: int
+    is_fully_classified: bool
+    num_processed_contentions: int
+    num_classified_contentions: int

--- a/domain-cc/cc-app/src/python_src/pydantic_models.py
+++ b/domain-cc/cc-app/src/python_src/pydantic_models.py
@@ -66,7 +66,8 @@ class VaGovClaim(BaseModel):
 
 
 class ClassifiedContention(BaseModel):
-    classification: Optional[PredictedClassification]
+    classification_code: Optional[int]
+    classification_name: Optional[str]
     diagnostic_code: Optional[int]  # only required for contention_type: "claim_for_increase"
     contention_type: str  # "disabilityActionType" in the VA.gov API
 

--- a/domain-cc/cc-app/src/python_src/pydantic_models.py
+++ b/domain-cc/cc-app/src/python_src/pydantic_models.py
@@ -55,7 +55,8 @@ class Contention(BaseModel):
 
         if contention_type == "claim_for_increase" and not diagnostic_code:
             raise HTTPException(
-                422, "diagnostic_code is required for contention_type claim_for_increase"
+                422,
+                "diagnostic_code is required for contention_type claim_for_increase",
             )
 
 

--- a/domain-cc/cc-app/src/python_src/pydantic_models.py
+++ b/domain-cc/cc-app/src/python_src/pydantic_models.py
@@ -8,13 +8,13 @@ from pydantic.types import conlist
 class Claim(BaseModel):
     claim_id: int
     form526_submission_id: int
-    diagnostic_code: Optional[int] = (
-        None  # only required for claim_type: "claim_for_increase"
-    )
+    diagnostic_code: Optional[
+        int
+    ] = None  # only required for claim_type: "claim_for_increase"
     claim_type: str = "claim_for_increase"
-    contention_text: Optional[str] = (
-        None  # marked optional to retain compatibility with v1
-    )
+    contention_text: Optional[
+        str
+    ] = None  # marked optional to retain compatibility with v1
 
     @model_validator(mode="before")
     @classmethod
@@ -46,7 +46,9 @@ class ClaimLinkInfo(BaseModel):
 class Contention(BaseModel):
     contention_text: str
     contention_type: str  # "disabilityActionType" in the VA.gov API
-    diagnostic_code: Optional[int] = None  # only required for contention_type: "claim_for_increase"
+    diagnostic_code: Optional[
+        int
+    ] = None  # only required for contention_type: "claim_for_increase"
 
     @model_validator(mode="before")
     @classmethod
@@ -54,7 +56,7 @@ class Contention(BaseModel):
         contention_type = values.get("contention_type")
         diagnostic_code = values.get("diagnostic_code")
 
-        if contention_type == "claim_for_increase" and not diagnostic_code:
+        if contention_type == "INCREASE" and not diagnostic_code:
             raise HTTPException(
                 422,
                 "diagnostic_code is required for contention_type claim_for_increase",
@@ -71,7 +73,9 @@ class VaGovClaim(BaseModel):
 class ClassifiedContention(BaseModel):
     classification_code: Optional[int]
     classification_name: Optional[str]
-    diagnostic_code: Optional[int] = None  # only required for contention_type: "claim_for_increase"
+    diagnostic_code: Optional[
+        int
+    ] = None  # only required for contention_type: "claim_for_increase"
     contention_type: str  # "disabilityActionType" in the VA.gov API
 
 

--- a/domain-cc/cc-app/src/python_src/pydantic_models.py
+++ b/domain-cc/cc-app/src/python_src/pydantic_models.py
@@ -46,9 +46,10 @@ class ClaimLinkInfo(BaseModel):
 class Contention(BaseModel):
     contention_text: str
     contention_type: str  # "disabilityActionType" in the VA.gov API
-    diagnostic_code: Optional[int]  # only required for contention_type: "claim_for_increase"
+    diagnostic_code: Optional[int] = None  # only required for contention_type: "claim_for_increase"
 
     @model_validator(mode="before")
+    @classmethod
     def check_dc_for_cfi(cls, values):
         contention_type = values.get("contention_type")
         diagnostic_code = values.get("diagnostic_code")
@@ -58,6 +59,7 @@ class Contention(BaseModel):
                 422,
                 "diagnostic_code is required for contention_type claim_for_increase",
             )
+        return values
 
 
 class VaGovClaim(BaseModel):
@@ -69,7 +71,7 @@ class VaGovClaim(BaseModel):
 class ClassifiedContention(BaseModel):
     classification_code: Optional[int]
     classification_name: Optional[str]
-    diagnostic_code: Optional[int]  # only required for contention_type: "claim_for_increase"
+    diagnostic_code: Optional[int] = None  # only required for contention_type: "claim_for_increase"
     contention_type: str  # "disabilityActionType" in the VA.gov API
 
 

--- a/domain-cc/cc-app/tests/test_multicontention_claims.py
+++ b/domain-cc/cc-app/tests/test_multicontention_claims.py
@@ -1,0 +1,122 @@
+from fastapi.testclient import TestClient
+
+
+def test_vagov_classifier_mixed_types(client: TestClient):
+    """
+    Tests response of multi-contention claims matches expected values
+    """
+    json_post_dict = {
+        "claim_id": 100,
+        "form526_submission_id": 500,
+        "contentions": [
+            {
+                "contention_text": "tinnitus (ringing or hissing in ears)",
+                "contention_type": "NEW",
+            },
+            {
+                "contention_text": "asthma",
+                "contention_type": "INCREASE",
+                "diagnostic_code": 8550,
+            },
+            {
+                "contention_text": "free text entry",
+                "contention_type": "NEW",
+                "diagnostic_code": None,
+            },
+        ],
+    }
+    response = client.post("/va-gov-claim-classifier", json=json_post_dict)
+    assert response.status_code == 200
+    assert response.json()["contentions"] == [
+        {
+            "classification_code": 3140,
+            "classification_name": "Hearing Loss",
+            "diagnostic_code": None,
+            "contention_type": "NEW",
+        },
+        {
+            "classification_code": 9012,
+            "classification_name": "Respiratory",
+            "diagnostic_code": 8550,
+            "contention_type": "INCREASE",
+        },
+        {
+            "classification_code": None,
+            "classification_name": None,
+            "diagnostic_code": None,
+            "contention_type": "NEW",
+        },
+    ]
+
+
+def test_vagov_classifier_empty_contentions(client: TestClient):
+    """
+    Tests 422 is returned when contentions is empty
+    """
+    json_post_dict = {
+        "claim_id": 100,
+        "form526_submission_id": 500,
+        "contentions": [],
+    }
+    response = client.post("/va-gov-claim-classifier", json=json_post_dict)
+    assert response.status_code == 422
+
+
+def test_single_contention(client: TestClient):
+    """
+    Tests response of single contention claim matches expected values
+    """
+    json_post_dict = {
+        "claim_id": 100,
+        "form526_submission_id": 500,
+        "contentions": [
+            {
+                "contention_text": "asthma",
+                "contention_type": "NEW",
+            },
+        ],
+    }
+    response = client.post("/va-gov-claim-classifier", json=json_post_dict)
+    assert response.status_code == 200
+    assert response.json()["contentions"] == [
+        {
+            "classification_code": 9012,
+            "classification_name": "Respiratory",
+            "diagnostic_code": None,
+            "contention_type": "NEW",
+        }
+    ]
+
+
+def test_order_response(client: TestClient):
+    """
+    Tests to make sure that the order of the response matches the
+    order of input
+    """
+    json_post_dict = json_post_dict = {
+        "claim_id": 100,
+        "form526_submission_id": 500,
+        "contentions": [
+            {
+                "contention_text": "tinnitus (ringing or hissing in ears)",
+                "contention_type": "NEW",
+            },
+            {
+                "contention_text": "asthma",
+                "contention_type": "INCREASE",
+                "diagnostic_code": 8550,
+            },
+            {
+                "contention_text": "free text entry",
+                "contention_type": "NEW",
+                "diagnostic_code": None,
+            },
+        ],
+    }
+    response = client.post("/va-gov-claim-classifier", json=json_post_dict)
+    expected_order = [3140, 9012, None]
+    for i in range(len(response.json()["contentions"])):
+        assert (
+            response.json()["contentions"][i]["classification_code"]
+            == expected_order[i]
+        )


### PR DESCRIPTION
<!-- Ensure the PR title reflects the feature or bug name -->

## What was the problem?
This updates CC's logging to include logging for multi-contention claims.  These changes will allow us to update our dashboard with data after releasing multi-contention claims in production.  

Associated tickets or Slack threads:
- [#472](https://app.zenhub.com/workspaces/contention-classification-640a24db5dcd08457cebbc79/issues/gh/department-of-veterans-affairs/vagov-claim-classification/472)

## How does this fix it?[^1]
<!-- description of how things will work after this PR -->

## How to test this PR
- Step 1
- Step 2[^secrel]


[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
