### PR TITLE
Don't publish the postgres image or pass for SecRel scanning

### DIFF
--- a/.github/actions/publish-images/action.yml
+++ b/.github/actions/publish-images/action.yml
@@ -55,31 +55,35 @@ runs:
         echo -n "[" >> "$GITHUB_OUTPUT"
         source scripts/image_vars.src
         for PREFIX in "${VAR_PREFIXES_ARR[@]}"; do
-          # This IMG_TAG value will cause a new image to be publish (and scanned by SecRel)
-          IMG_TAG="${{ inputs.image_tag }}"
+          # Postgres is only used locally so doesn't need to be published
+          if [ "${{PREFIX}}" != 'postgres' ]; then
 
-          IMG_NAME="$(getVarValue "${PREFIX}" _IMG)"
-          echo "::group::Push image $IMG_NAME $IMG_TAG"
-          GHCR_PATH="ghcr.io/${{ github.repository }}/${IMG_NAME}"
-          if [ "$(imageTagExists "$IMG_NAME" "$IMG_TAG")" == "200" ]; then
-            echo "Image already exists: $IMG_NAME:$IMG_TAG -- not overwriting"
-            echo "* ($IMG_NAME:$IMG_TAG -- already exists, not overwriting)" >> "$GITHUB_STEP_SUMMARY"
-          else
-            GRADLE_IMG_NAME=$(getVarValue "${PREFIX}" _GRADLE_IMG)
+            # This IMG_TAG value will cause a new image to be publish (and scanned by SecRel)
+            IMG_TAG="${{ inputs.image_tag }}"
 
-            echo "Tagging '$GRADLE_IMG_NAME' as '$IMG_NAME:$IMG_TAG' and '$IMG_NAME:latest'"
-            docker tag "$GRADLE_IMG_NAME" "${GHCR_PATH}:$IMG_TAG"
-            docker push "${GHCR_PATH}:$IMG_TAG"
+            IMG_NAME="$(getVarValue "${PREFIX}" _IMG)"
+            echo "::group::Push image $IMG_NAME $IMG_TAG"
+            GHCR_PATH="ghcr.io/${{ github.repository }}/${IMG_NAME}"
+            if [ "$(imageTagExists "$IMG_NAME" "$IMG_TAG")" == "200" ]; then
+              echo "Image already exists: $IMG_NAME:$IMG_TAG -- not overwriting"
+              echo "* ($IMG_NAME:$IMG_TAG -- already exists, not overwriting)" >> "$GITHUB_STEP_SUMMARY"
+            else
+              GRADLE_IMG_NAME=$(getVarValue "${PREFIX}" _GRADLE_IMG)
 
-            docker tag "$GRADLE_IMG_NAME" "${GHCR_PATH}:latest"
-            docker push "${GHCR_PATH}:latest"
+              echo "Tagging '$GRADLE_IMG_NAME' as '$IMG_NAME:$IMG_TAG' and '$IMG_NAME:latest'"
+              docker tag "$GRADLE_IMG_NAME" "${GHCR_PATH}:$IMG_TAG"
+              docker push "${GHCR_PATH}:$IMG_TAG"
 
-            echo "* $IMG_NAME:$IMG_TAG" >> "$GITHUB_STEP_SUMMARY"
-            echo -n "\"${GHCR_PATH}:$IMG_TAG\"" >> "$GITHUB_OUTPUT"
+              docker tag "$GRADLE_IMG_NAME" "${GHCR_PATH}:latest"
+              docker push "${GHCR_PATH}:latest"
 
-            # For all but the last image include a comma
-            if [ ${PREFIX} != ${VAR_PREFIXES_ARR[-1]} ]; then
-              echo -n "," >> "$GITHUB_OUTPUT"
+              echo "* $IMG_NAME:$IMG_TAG" >> "$GITHUB_STEP_SUMMARY"
+              echo -n "\"${GHCR_PATH}:$IMG_TAG\"" >> "$GITHUB_OUTPUT"
+
+              # For all but the last image include a comma
+              if [ ${PREFIX} != ${VAR_PREFIXES_ARR[-1]} ]; then
+                echo -n "," >> "$GITHUB_OUTPUT"
+              fi
             fi
           fi
           echo "::endgroup::"

--- a/.github/actions/publish-images/action.yml
+++ b/.github/actions/publish-images/action.yml
@@ -56,7 +56,7 @@ runs:
         source scripts/image_vars.src
         for PREFIX in "${VAR_PREFIXES_ARR[@]}"; do
           # Postgres is only used locally so doesn't need to be published
-          if [ "${{PREFIX}}" != 'postgres' ]; then
+          if [ "${PREFIX}" != 'postgres' ]; then
 
             # This IMG_TAG value will cause a new image to be publish (and scanned by SecRel)
             IMG_TAG="${{ inputs.image_tag }}"

--- a/.github/workflows/secrel.yml
+++ b/.github/workflows/secrel.yml
@@ -189,19 +189,22 @@ jobs:
             IMAGE_LIST="["
 
             if [ "${{inputs.image_name}}" == 'all' ]; then
-            for PREFIX in "${VAR_PREFIXES_ARR[@]}"; do
-            IMG_NAME="$(getVarValue "${PREFIX}" _IMG)"
-            GHCR_PATH="ghcr.io/${{github.repository}}/${IMG_NAME}"
-            IMAGE_LIST+="\"${GHCR_PATH}:latest\","
-            done
+              for PREFIX in "${VAR_PREFIXES_ARR[@]}"; do
+                # postgres container is only used locally
+                if [ "${{PREFIX}}" != 'postgres' ]; then
+                  IMG_NAME="$(getVarValue "${PREFIX}" _IMG)"
+                  GHCR_PATH="ghcr.io/${{github.repository}}/${IMG_NAME}"
+                  IMAGE_LIST+="\"${GHCR_PATH}:latest\","
+                fi
+              done
 
-            # Remove the trailing comma
-            IMAGE_LIST=${IMAGE_LIST%?}
+              # Remove the trailing comma
+              IMAGE_LIST=${IMAGE_LIST%?}
             else
-            IMG_TAG="${{inputs.image_tag}}"
-            IMG_NAME="$(getVarValue "$(bashVarPrefix "${{inputs.image_name}}")" _IMG)"
-            GHCR_PATH="ghcr.io/${{github.repository}}/${IMG_NAME}"
-            IMAGE_LIST+="\"${GHCR_PATH}:${IMG_TAG}\""
+              IMG_TAG="${{inputs.image_tag}}"
+              IMG_NAME="$(getVarValue "$(bashVarPrefix "${{inputs.image_name}}")" _IMG)"
+              GHCR_PATH="ghcr.io/${{github.repository}}/${IMG_NAME}"
+              IMAGE_LIST+="\"${GHCR_PATH}:${IMG_TAG}\""
             fi
 
             IMAGE_LIST+="]"

--- a/.github/workflows/secrel.yml
+++ b/.github/workflows/secrel.yml
@@ -191,7 +191,7 @@ jobs:
             if [ "${{inputs.image_name}}" == 'all' ]; then
               for PREFIX in "${VAR_PREFIXES_ARR[@]}"; do
                 # postgres container is only used locally
-                if [ "${{PREFIX}}" != 'postgres' ]; then
+                if [ "${PREFIX}" != 'postgres' ]; then
                   IMG_NAME="$(getVarValue "${PREFIX}" _IMG)"
                   GHCR_PATH="ghcr.io/${{github.repository}}/${IMG_NAME}"
                   IMAGE_LIST+="\"${GHCR_PATH}:latest\","


### PR DESCRIPTION
<!-- Ensure the PR title reflects the feature or bug name -->

## What was the problem?
<!-- brief description of how things worked before this PR -->
We don't use the Postgres container in production any more but the publishing makes us continue to have SecRel scanning on it. 

Associated tickets or Slack threads:
- #3008 

## How does this fix it?[^1]
<!-- description of how things will work after this PR -->
Stop publishing postgres and scanning with SecRel

## How to test this PR
- Ran the workflows which are changed by this PR and confirmed that they are running without error and no longer publishing the Postgres container.


[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
