### PR TITLE
EP Merge: Fix issue with get pending contentions 204

### DIFF
--- a/domain-ee/ee-ep-merge-app/src/python_src/service/ep_merge_machine.py
+++ b/domain-ee/ee-ep-merge-app/src/python_src/service/ep_merge_machine.py
@@ -223,7 +223,13 @@ class EpMergeMachine(StateMachine):  # type: ignore[misc]
     @running_get_pending_contentions.enter
     def on_get_pending_contentions(self, event):
         request = get_contentions.Request(claim_id=self.job.pending_claim_id)
-        response = self.make_request(request=request, hoppy_client=HOPPY.get_client(ClientName.GET_CLAIM_CONTENTIONS), response_type=get_contentions.Response)
+        expected_statuses = [200, 204]
+        response = self.make_request(
+            request=request,
+            hoppy_client=HOPPY.get_client(ClientName.GET_CLAIM_CONTENTIONS),
+            response_type=get_contentions.Response,
+            expected_statuses=expected_statuses,
+        )
         self.send(event=event, pending_contentions_response=response)
 
     @running_get_ep400_contentions.enter


### PR DESCRIPTION
<!-- Ensure the PR title reflects the feature or bug name -->

## What was the problem?
<!-- brief description of how things worked before this PR -->
A bug has been observed in production which occurs when the pending claim returned a 204 on getting the contentions. This 204 resulted in the merge job failing due to 204 not being an acceptable status of that request, even tho the contentions from the EP400 could have been moved over successfully. 

Associated tickets or Slack threads:
- #2998 

## How does this fix it?[^1]
<!-- description of how things will work after this PR -->
Allows 204s on the request to get contentions for the pending claim. 

## How to test this PR
- pull code
- Unit Test:
  - from /domain-ee/ee-ep-merge-app run pytest
- Integration Tests:
  - run [base platform](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Docker-Compose#platform-base)
  - from /domain-ee/ee-ep-merge-app run pytest ./integration
- End to End tests:
  - run this [CI](https://github.com/department-of-veterans-affairs/abd-vro/actions/workflows/ee-ep-merge-end-to-end.yml) action to verify successful integration test
  - run end to end tests locally:
    - `export BIP_CLAIM_URL=mock-bip-claims-api:20300`
    - run bgs and bip services and mocks:
      - `COMPOSE_PROFILES="bip,bgs" ./gradlew :app:dockerComposeUp`
      - `COMPOSE_PROFILES="bip,bgs" ./gradlew -p mocks :dockerComposeUp`
    - `./gradlew :domain-ee:ee-ep-merge-app:endToEndTest`

[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
