### PR TITLE
removed json log

### DIFF
--- a/domain-xample/xample-workflows/src/main/java/gov/va/vro/routes/xample/BieXampleRoutes.java
+++ b/domain-xample/xample-workflows/src/main/java/gov/va/vro/routes/xample/BieXampleRoutes.java
@@ -38,7 +38,6 @@ public class BieXampleRoutes extends EndpointRouteBuilder {
     final String queueName = "saveToDB-" + exchangeName;
     RabbitMqCamelUtils.fromRabbitmqFanoutExchange(this, exchangeName, queueName)
         .routeId(exchangeName + "-saveToDb-route")
-        .log("Received ${headers} ${body.getClass()}: ${body}")
         .convertBodyTo(BieMessagePayload.class)
         .log("Converted to ${body.getClass()}: ${body}")
         .log("Saving Contention Event to DB")


### PR DESCRIPTION
<!-- Ensure the PR title reflects the feature or bug name -->

## What was the problem?
Apache Camel logs the JSON message body before it converts to the Java `BieMessagePayload` class. This process ignores some restrictions we introduced in the Java class via annotations, causing some fields that we do not want to show in the logs to be printed out as well.

Associated tickets or Slack threads:
- #2810 

## How does this fix it?[^1]
Removed logging of the JSON string; only log once the JSON string is converted into our Java class.

## How to test this PR
- Verify in the example-workflow log that no `description` field is displayed.


[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
