### PR TITLE
updated logging to include claim_id and boolean for multi_contention

### DIFF
--- a/domain-cc/cc-app/src/python_src/api.py
+++ b/domain-cc/cc-app/src/python_src/api.py
@@ -129,7 +129,7 @@ def log_contention_stats(
 
     log_as_json(
         {
-            "claim_id": sanitize_log(claim.claim_id),
+            "vagov_claim_id": sanitize_log(claim.claim_id),
             "claim_type": sanitize_log(log_contention_type),
             "classification_code": classification_code,
             "classification_name": classification_name,


### PR DESCRIPTION
<!-- Ensure the PR title reflects the feature or bug name -->

## What was the problem?
<!-- brief description of how things worked before this PR -->
Identified that our current logging will not allow us to differentiate between single and multicontention claims, so we are adding a true/false identifier to separate claims.  We are also adding the claim_id to help us track contentions and claims together.  

Associated tickets or Slack threads:


## How does this fix it?[^1]


## How to test this PR
- Step 1
- Step 2[^secrel]


[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
