### PR TITLE
Update dev-tools Dockerfile to install AWS CLI

### DIFF
--- a/dev-tools/Dockerfile
+++ b/dev-tools/Dockerfile
@@ -1,10 +1,29 @@
 FROM bitnami/minideb:bookworm
 
+# Set SHELL option to handle pipes more safely
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
 # hadolint ignore=DL3018,DL3009
 RUN apt-get update && \
-    install_packages curl sudo && \
-    install_packages postgresql-client
+    install_packages sudo curl unzip gnupg ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
 
+# Install AWS CLI
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \
+    unzip awscliv2.zip && \
+    ./aws/install && \
+    rm -rf awscliv2.zip aws
+
+# Download and import PostgreSQL GPG key
+RUN curl -s https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
+
+# Add PostgreSQL repository and install the latest PostgreSQL client
+RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ bookworm-pgdg main" > /etc/apt/sources.list.d/pgdg.list && \
+    apt-get update && \
+    install_packages postgresql-client-16 && \
+    rm -rf /var/lib/apt/lists/*
+
+# Add user 'tron'
 RUN adduser --disabled-password tron
 
 USER tron

--- a/dev-tools/Dockerfile
+++ b/dev-tools/Dockerfile
@@ -1,7 +1,7 @@
-# Use Amazon AWS CLI image as the base image
-FROM amazon/aws-cli:2.16.5
+# Use the official AWS CLI image for the first stage
+FROM amazon/aws-cli:2.16.5 as awscli
 
-# Use bitnami/minideb:bookworm as a second stage to install PostgreSQL client
+# Use the bitnami/minideb:bookworm as the base image for the second stage
 FROM bitnami/minideb:bookworm
 
 # Set SHELL option to handle pipes more safely
@@ -12,10 +12,10 @@ RUN apt-get update && \
     install_packages sudo curl unzip gnupg ca-certificates && \
     rm -rf /var/lib/apt/lists/*
 
-# Copy AWS CLI from the first stage
-COPY --from=amazon/aws-cli:latest /usr/local/aws-cli /usr/local/aws-cli
+# Copy AWS CLI from the awscli stage
+COPY --from=awscli /usr/local/aws-cli /usr/local/aws-cli
 
-# Set AWS CLI binary to the PATH
+# Make the AWS CLI binaries available in PATH
 ENV PATH="/usr/local/aws-cli/v2/current/bin:${PATH}"
 
 # Download and import PostgreSQL GPG key

--- a/dev-tools/Dockerfile
+++ b/dev-tools/Dockerfile
@@ -1,3 +1,7 @@
+# Use Amazon AWS CLI image as the base image
+FROM amazon/aws-cli:2.16.5
+
+# Use bitnami/minideb:bookworm as a second stage to install PostgreSQL client
 FROM bitnami/minideb:bookworm
 
 # Set SHELL option to handle pipes more safely
@@ -8,11 +12,11 @@ RUN apt-get update && \
     install_packages sudo curl unzip gnupg ca-certificates && \
     rm -rf /var/lib/apt/lists/*
 
-# Install AWS CLI
-RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \
-    unzip awscliv2.zip && \
-    ./aws/install && \
-    rm -rf awscliv2.zip aws
+# Copy AWS CLI from the first stage
+COPY --from=amazon/aws-cli:latest /usr/local/aws-cli /usr/local/aws-cli
+
+# Set AWS CLI binary to the PATH
+ENV PATH="/usr/local/aws-cli/v2/current/bin:${PATH}"
 
 # Download and import PostgreSQL GPG key
 RUN curl -s https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -

--- a/dev-tools/Dockerfile
+++ b/dev-tools/Dockerfile
@@ -9,7 +9,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # hadolint ignore=DL3018,DL3009
 RUN apt-get update && \
-    install_packages sudo curl unzip gnupg ca-certificates && \
+    install_packages sudo curl unzip gnupg ca-certificates groff && \
     rm -rf /var/lib/apt/lists/*
 
 # Copy AWS CLI from the awscli stage

--- a/dev-tools/build.gradle
+++ b/dev-tools/build.gradle
@@ -1,3 +1,19 @@
 plugins {
   id 'shared.docker.container-conventions'
 }
+
+// Task to copy the Dockerfile to the build/docker directory
+task copyDockerfile(type: Copy) {
+  from 'Dockerfile'
+  into 'build/docker'
+}
+
+// Task to build the Docker image using the Dockerfile in the build/docker directory
+task buildDockerImage(type: Exec) {
+  dependsOn copyDockerfile
+  workingDir 'build/docker'
+  commandLine 'docker', 'build', '-t', 'dev-tools', '.'
+}
+
+// Ensure the build task depends on the buildDockerImage task
+build.dependsOn buildDockerImage


### PR DESCRIPTION
Updated dev-tools Dockerfile to install AWS CLI in order to implement specific AWS metrics to our RDS database using AWS Parameters.  

Associated tickets or Slack threads:
- #2943 

## How does this fix it?[^1]
AWS CLI has been successfully installed in the dev-tool pod.

## How to test this PR
- In the dev-tools pod, run `aws --version` 

<img width="1086" alt="Screenshot 2024-06-11 at 2 08 14 PM" src="https://github.com/department-of-veterans-affairs/abd-vro/assets/151670616/ec0b114a-0590-4f40-9724-ebc2b26f214b">
