### PR TITLE
update CI checks for healthy containers

### DIFF
--- a/.github/workflows/container-healthchecks.yml
+++ b/.github/workflows/container-healthchecks.yml
@@ -82,7 +82,7 @@ jobs:
           # Ignore mocks since they don't have health checks
           # TODO: add health check for svc-bgs-api; ignore it for now
           if docker container ls --format '{{.Names}} \t {{.Status}}' | grep -v "(healthy)" \
-            | grep -v "-mock-\|svc-bgs-api"; then
+            | grep -v "svc-bgs-api\|-mock-"; then
             echo 'There are unexpected unhealthy containers!'
             exit 2
           fi


### PR DESCRIPTION
## What was the problem?

Minor issue observed with the continuous integration check on healthy containers: step `Check for unhealthy containers` has a buggy command that results in misleading log output (typically reports `grep: invalid max count`).  as snapshots, samples from [June 2024](https://github.com/department-of-veterans-affairs/abd-vro/actions/runs/9471826154/job/26095957958), [May 2024](https://github.com/department-of-veterans-affairs/abd-vro/actions/runs/8972674381/job/24641182980), [Apr 2024](https://github.com/department-of-veterans-affairs/abd-vro/actions/runs/8884632551/job/24394171524).

## How does this fix it?

adjust the `grep` command to avoid substring `-m` being interpreted as a flag for `--max-count`

To demonstrate the behavior, try these on an environment that has docker containers. (i ran these on local dev)
```
# set of containers we want to inspect
docker container ls --format '{{.Names}} \t {{.Status}}'

# this is what is in the default branch; it gives me a `grep: Invalid argument` error
docker container ls --format '{{.Names}} \t {{.Status}}' | grep -v "(healthy)" | grep -v "-mock-\|svc-bgs-api" 

# adds an escape char to the search for `-mock-`; returns expected results and no error
docker container ls --format '{{.Names}} \t {{.Status}}' | grep -v "(healthy)" | grep -v "\-mock-\|svc-bgs-api"

# equivalent to previous, but perhaps more readable ; this is the version submitted in the PR
docker container ls --format '{{.Names}} \t {{.Status}}' | grep -v "(healthy)" | grep -v "svc-bgs-api\|-mock-" 
```