### PR TITLE
Update k8s pdb for svc-bip-api

### DIFF
--- a/helm/deploy.sh
+++ b/helm/deploy.sh
@@ -82,7 +82,16 @@ case "$HELM_CHART" in
     HELM_ARGS="$HELM_ARGS --set-string imageTag=$devtools_VER";;
 esac
 
-
+set -x
+# Exit with error code when command fails so that GH Action fails
+set -e
+helm upgrade "$RELEASE_NAME" "helm/$HELM_CHART" -n "${NAMESPACE}" \
+  --install --reset-values \
+  --set-string "global.imageTag=${IMAGE_TAG}" \
+  --set-string "global.commitSha=${GITHUB_SHA}" \
+  --set-string "global.triggeringActor=${TRIGGERING_ACTOR}" \
+  ${HELM_ARGS}
+set +x
 
 k8sInfo(){
   echo "==================================="
@@ -94,25 +103,7 @@ k8sInfo(){
     {"\tname: "}{.name}
     {"\timage: "}{.image}{end}'
   kubectl -n "${NAMESPACE}" get pvc
-  kubectl -n "${NAMESPACE}" get pdb
   kubectl -n "${NAMESPACE}" get services
   kubectl -n "${NAMESPACE}" get events
 }
 [ "${K8S_INFO}" == "true" ] && k8sInfo
-
-
-set -x
-# Exit with error code when command fails so that GH Action fails
-set -e
-
-kubectl delete pdb "${RELEASE_NAME}-pdb" -n "$NAMESPACE" --v=6
-
-helm upgrade "$RELEASE_NAME" "helm/$HELM_CHART" -n "${NAMESPACE}" \
-  --install --reset-values \
-  --set-string "global.imageTag=${IMAGE_TAG}" \
-  --set-string "global.commitSha=${GITHUB_SHA}" \
-  --set-string "global.triggeringActor=${TRIGGERING_ACTOR}" \
-  ${HELM_ARGS}
-set +x
-
-k8sInfo

--- a/helm/svc-bip-api/templates/pdb.yaml
+++ b/helm/svc-bip-api/templates/pdb.yaml
@@ -2,6 +2,12 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: vro-svc-bip-api-pdb
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  annotations:
+    meta.helm.sh/release-name: vro-svc-bip-api
+    meta.helm.sh/release-namespace: va-abd-rrd-{{.Values.global.environment}}
+    
 spec:
   minAvailable: 1
   selector:


### PR DESCRIPTION
## What was the problem?
Error encountered when attempting to deploy the pod disruption budget (PDB) policy to environment qa for the first time.

> Unable to continue with update: PodDisruptionBudget "vro-svc-bip-api-pdb" in namespace "va-abd-rrd-qa" exists and cannot be imported into the current release: invalid ownership metadata; label validation error: missing key "app.kubernetes.io/managed-by": must be set to "Helm"; annotation validation error: missing key "meta.helm.sh/release-name": must be set to "vro-svc-bip-api"; annotation validation error: missing key "meta.helm.sh/release-namespace": must be set to "va-abd-rrd-qa" (from: [deployment log jun 2024](https://github.com/department-of-veterans-affairs/abd-vro-internal/actions/runs/9501399846/job/26186837959))


## How to test this PR
- verify`svc-bip-api` deploys to dev and qa without issue
- flag: dev, qa, and sandbox share a cluster in which a pdb for `svc-bip-api` was previously succesfully introduced (via ArgoCD work); will we see different behavior when deploying to another cluster where the pdb has not previously been introduced?
- note: as part of testing this PR, we executed a `kubectl delete pdb` ref: [73b477](https://github.com/department-of-veterans-affairs/abd-vro/blob/73b477936be5b3f2e0c0d2e39ec3d5c73c4ea3df/helm/deploy.sh#L108) in the nonprod cluster


## reference material
- https://stackoverflow.com/a/69005327
