### PR TITLE
EP Merge: Log metrics asynchronously

### DIFF
--- a/domain-ee/ee-ep-merge-app/src/python_src/util/metric_logger.py
+++ b/domain-ee/ee-ep-merge-app/src/python_src/util/metric_logger.py
@@ -69,7 +69,8 @@ async def increment(metrics: list[CountMetric]) -> None:
     body = MetricPayload(series=series)
 
     try:
-        await count_metrics_api.submit_metrics(body=body, content_encoding=MetricContentEncoding.DEFLATE)
+        # mypy Cannot determine type of 'submit_metrics' to be awaitable
+        await count_metrics_api.submit_metrics(body=body, content_encoding=MetricContentEncoding.DEFLATE)  # type: ignore
     except ApiException as e:
         logging.warning(f'event=logMetricFailed type=count metrics={metrics} status={e.status} reason={e.reason} body={e.body}')
     except Exception as e:
@@ -101,7 +102,8 @@ async def distribution(metrics: list[DistributionMetric]) -> None:
     body = DistributionPointsPayload(series=series)
 
     try:
-        await distribution_metrics_api.submit_distribution_points(content_encoding=DistributionPointsContentEncoding.DEFLATE, body=body)
+        # mypy Cannot determine type of 'submit_distribution_points' to be awaitable
+        await distribution_metrics_api.submit_distribution_points(content_encoding=DistributionPointsContentEncoding.DEFLATE, body=body)  # type: ignore
     except ApiException as e:
         logging.warning(f"event=logMetricFailed type=distribution metrics={metrics} status={e.status} reason={e.reason} body='{e.body}'")
     except Exception as e:

--- a/domain-ee/ee-ep-merge-app/src/python_src/util/metric_logger.py
+++ b/domain-ee/ee-ep-merge-app/src/python_src/util/metric_logger.py
@@ -5,7 +5,7 @@ from typing import NamedTuple
 import datadog_api_client.v1.api.metrics_api as metrics_v1
 import datadog_api_client.v2.api.metrics_api as metrics_v2
 from config import ENV
-from datadog_api_client import ApiClient, Configuration
+from datadog_api_client import AsyncApiClient, Configuration
 from datadog_api_client.exceptions import ApiException
 from datadog_api_client.v1.model.distribution_point import DistributionPoint
 from datadog_api_client.v1.model.distribution_points_content_encoding import (
@@ -31,7 +31,7 @@ STANDARD_TAGS = [ENV_TAG, SERVICE_TAG]
 
 
 configuration = Configuration(enable_retry=True)
-api_client = ApiClient(configuration)
+api_client = AsyncApiClient(configuration)
 count_metrics_api = metrics_v2.MetricsApi(api_client)
 distribution_metrics_api = metrics_v1.MetricsApi(api_client)  # Metrics API does not have an endpoint for distribution metrics
 
@@ -46,7 +46,7 @@ class DistributionMetric(NamedTuple):
     value: float = 1
 
 
-def increment(metrics: list[CountMetric]) -> None:
+async def increment(metrics: list[CountMetric]) -> None:
     """
     Adds value to a count metric with by the name '{APP_PREFIX}.{metric.name.strip(".").lower()}'
     :param metrics: list of CountMetric objects
@@ -69,14 +69,14 @@ def increment(metrics: list[CountMetric]) -> None:
     body = MetricPayload(series=series)
 
     try:
-        count_metrics_api.submit_metrics(body=body, content_encoding=MetricContentEncoding.DEFLATE)
+        await count_metrics_api.submit_metrics(body=body, content_encoding=MetricContentEncoding.DEFLATE)
     except ApiException as e:
-        logging.warning(f'event=logMetricFailed metrics={metrics} type=count status={e.status} reason={e.reason} body={e.body}')
+        logging.warning(f'event=logMetricFailed type=count metrics={metrics} status={e.status} reason={e.reason} body={e.body}')
     except Exception as e:
-        logging.warning(f'event=logMetricFailed metrics={metrics} type=count type={type(e)} error="{e}"')
+        logging.warning(f'event=logMetricFailed type=count metrics={metrics} error_type={type(e)} error="{e}"')
 
 
-def distribution(metrics: list[DistributionMetric]) -> None:
+async def distribution(metrics: list[DistributionMetric]) -> None:
     """
     Adds value to a distribution metric with by the name '{APP_PREFIX}.{metric.name.strip(".").lower()}.distribution'
     :param metrics: list of DistributionMetric objects
@@ -101,8 +101,8 @@ def distribution(metrics: list[DistributionMetric]) -> None:
     body = DistributionPointsPayload(series=series)
 
     try:
-        distribution_metrics_api.submit_distribution_points(content_encoding=DistributionPointsContentEncoding.DEFLATE, body=body)
+        await distribution_metrics_api.submit_distribution_points(content_encoding=DistributionPointsContentEncoding.DEFLATE, body=body)
     except ApiException as e:
         logging.warning(f"event=logMetricFailed type=distribution metrics={metrics} status={e.status} reason={e.reason} body='{e.body}'")
     except Exception as e:
-        logging.warning(f"event=logMetricFailed type=distribution metrics={metrics} type={type(e)} error='{e}'")
+        logging.warning(f"event=logMetricFailed type=distribution metrics={metrics} error_type={type(e)} error='{e}'")

--- a/domain-ee/ee-ep-merge-app/src/requirements.txt
+++ b/domain-ee/ee-ep-merge-app/src/requirements.txt
@@ -1,4 +1,4 @@
-datadog-api-client==2.22.*
+datadog-api-client[async]==2.25.*
 fastapi==0.109.*
 hoppy @ git+https://github.com/department-of-veterans-affairs/abd-vro.git@shared/lib-hoppy-0.6#subdirectory=shared/lib-hoppy
 httpx==0.24.*

--- a/domain-ee/ee-ep-merge-app/tests/util/test_metric_logger.py
+++ b/domain-ee/ee-ep-merge-app/tests/util/test_metric_logger.py
@@ -1,0 +1,93 @@
+import pytest
+from datadog_api_client.v2.model.metric_intake_type import MetricIntakeType
+
+from src.python_src.util.metric_logger import (
+    CountMetric,
+    DistributionMetric,
+    distribution,
+    increment,
+)
+
+
+@pytest.fixture()
+def count_metrics_api(mocker):
+    return mocker.patch('src.python_src.util.metric_logger.count_metrics_api')
+
+
+@pytest.fixture()
+def distribution_metrics_api(mocker):
+    return mocker.patch('src.python_src.util.metric_logger.distribution_metrics_api')
+
+
+@pytest.mark.asyncio()
+async def test_increment_with_one_metric_to_increment(count_metrics_api):
+    metrics = [CountMetric(name='test_metric', value=1)]
+
+    await increment(metrics)
+
+    body = count_metrics_api.submit_metrics.call_args[1]['body']
+
+    assert len(body.series) == 1
+    assert body.series[0].metric == 'ep_merge.test_metric'
+    assert body.series[0].type == MetricIntakeType.COUNT
+    assert len(body.series[0].points) == 1
+    assert body.series[0].points[0].value == 1
+
+
+@pytest.mark.asyncio()
+async def test_increment_with_multiple_metrics_to_increment(count_metrics_api):
+    metrics = [CountMetric(name='test_metric_1', value=1), CountMetric(name='test_metric_2', value=2)]
+
+    await increment(metrics)
+
+    body = count_metrics_api.submit_metrics.call_args[1]['body']
+
+    assert len(body.series) == 2
+    assert all(s.type == MetricIntakeType.COUNT for s in body.series)
+
+    assert body.series[0].metric == 'ep_merge.test_metric_1'
+    assert len(body.series[0].points) == 1
+    assert body.series[0].points[0].value == 1
+
+    assert body.series[1].metric == 'ep_merge.test_metric_2'
+    assert len(body.series[1].points) == 1
+    assert body.series[1].points[0].value == 2
+
+
+@pytest.mark.asyncio()
+async def test_increment_with_one_metric_to_distribution(distribution_metrics_api):
+    metrics = [DistributionMetric(name='test_metric', value=1.5)]
+
+    await distribution(metrics)
+
+    body = distribution_metrics_api.submit_distribution_points.call_args[1]['body']
+
+    assert len(body.series) == 1
+    assert body.series[0].metric == 'ep_merge.test_metric.distribution'
+    assert len(body.series[0].points) == 1
+    points = body.series[0].points[0].value[1]
+    assert len(points) == 1
+    assert points[0] == 1.5
+
+
+@pytest.mark.asyncio()
+async def test_increment_with_multiple_metrics_to_distribution(distribution_metrics_api):
+    metrics = [DistributionMetric(name='test_metric_1', value=1.1), DistributionMetric(name='test_metric_2', value=2.2)]
+
+    await distribution(metrics)
+
+    body = distribution_metrics_api.submit_distribution_points.call_args[1]['body']
+
+    assert len(body.series) == 2
+
+    assert body.series[0].metric == 'ep_merge.test_metric_1.distribution'
+    assert len(body.series[0].points) == 1
+    points = body.series[0].points[0].value[1]
+    assert len(points) == 1
+    assert points[0] == 1.1
+
+    assert body.series[1].metric == 'ep_merge.test_metric_2.distribution'
+    assert len(body.series[1].points) == 1
+    points = body.series[1].points[0].value[1]
+    assert len(points) == 1
+    assert points[0] == 2.2


### PR DESCRIPTION
<!-- Ensure the PR title reflects the feature or bug name -->

## What was the problem?
<!-- brief description of how things worked before this PR -->
Previous requests to log metrics were logged synchronously.

Associated tickets or Slack threads:
- #2783 

## How does this fix it?[^1]
<!-- description of how things will work after this PR -->
Uses datadog_api_client [AsyncApiClient](https://github.com/DataDog/datadog-api-client-python?tab=readme-ov-file#asyncio-support) to send requests to log metrics

## How to test this PR
- pull code
- Unit Test:
  - from /domain-ee/ee-ep-merge-app run pytest
- Integration Tests:
  - run [base platform](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Docker-Compose#platform-base)
  - from /domain-ee/ee-ep-merge-app run pytest ./integration
- End to End tests:
  - run this [CI](https://github.com/department-of-veterans-affairs/abd-vro/actions/workflows/ee-ep-merge-end-to-end.yml) action to verify successful integration test
  - run end to end tests locally:
    - `export BIP_CLAIM_URL=mock-bip-claims-api:20300`
    - run bgs and bip services and mocks:
      - `COMPOSE_PROFILES=“all” ./gradlew dockerComposeUp`
      - `COMPOSE_PROFILES="bip,bgs" ./gradlew -p mocks :dockerComposeUp`
    - `./gradlew :domain-ee:ee-ep-merge-app:endToEndTest`


[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
