### PR TITLE
EP Merge: Fix memory leak

### DIFF
--- a/domain-ee/ee-ep-merge-app/src/python_src/service/ep_merge_machine.py
+++ b/domain-ee/ee-ep-merge-app/src/python_src/service/ep_merge_machine.py
@@ -458,8 +458,8 @@ class EpMergeMachine(StateMachine):  # type: ignore[misc]
     ) -> GeneralResponse | None:
         if not isinstance(expected_statuses, list):
             expected_statuses = [expected_statuses]
+
         try:
-            loop = asyncio.new_event_loop()
             req = self.make_hoppy_request(
                 hoppy_client,
                 self.job.job_id,
@@ -470,7 +470,7 @@ class EpMergeMachine(StateMachine):  # type: ignore[misc]
                 retry_wait_time,
                 will_retry_condition,
             )
-            return loop.run_until_complete(req)
+            return asyncio.run(req)
         except ValidationError as e:
             self.add_client_error(hoppy_client.name, e.errors(include_url=False, include_input=False))
         except ResponseException as e:

--- a/domain-ee/ee-ep-merge-app/src/python_src/util/metric_logger.py
+++ b/domain-ee/ee-ep-merge-app/src/python_src/util/metric_logger.py
@@ -69,7 +69,8 @@ async def increment(metrics: list[CountMetric]) -> None:
     body = MetricPayload(series=series)
 
     try:
-        await count_metrics_api.submit_metrics(body=body, content_encoding=MetricContentEncoding.DEFLATE)
+        # mypy Cannot determine type of 'submit_metrics' to be awaitable
+        await count_metrics_api.submit_metrics(body=body, content_encoding=MetricContentEncoding.DEFLATE)  # type: ignore
     except ApiException as e:
         logging.warning(f'event=logMetricFailed type=count metrics={metrics} status={e.status} reason={e.reason} body={e.body}')
     except Exception as e:
@@ -101,7 +102,8 @@ async def distribution(metrics: list[DistributionMetric]) -> None:
     body = DistributionPointsPayload(series=series)
 
     try:
-        await distribution_metrics_api.submit_distribution_points(content_encoding=DistributionPointsContentEncoding.DEFLATE, body=body)
+        # mypy Cannot determine type of 'submit_distribution_points' to be awaitable
+        await distribution_metrics_api.submit_distribution_points(content_encoding=DistributionPointsContentEncoding.DEFLATE, body=body)  # type: ignore
     except ApiException as e:
         logging.warning(f"event=logMetricFailed type=distribution metrics={metrics} status={e.status} reason={e.reason} body='{e.body}'")
     except Exception as e:

--- a/domain-ee/ee-ep-merge-app/src/python_src/util/metric_logger.py
+++ b/domain-ee/ee-ep-merge-app/src/python_src/util/metric_logger.py
@@ -5,7 +5,7 @@ from typing import NamedTuple
 import datadog_api_client.v1.api.metrics_api as metrics_v1
 import datadog_api_client.v2.api.metrics_api as metrics_v2
 from config import ENV
-from datadog_api_client import ApiClient, Configuration
+from datadog_api_client import AsyncApiClient, Configuration
 from datadog_api_client.exceptions import ApiException
 from datadog_api_client.v1.model.distribution_point import DistributionPoint
 from datadog_api_client.v1.model.distribution_points_content_encoding import (
@@ -31,7 +31,7 @@ STANDARD_TAGS = [ENV_TAG, SERVICE_TAG]
 
 
 configuration = Configuration(enable_retry=True)
-api_client = ApiClient(configuration)
+api_client = AsyncApiClient(configuration)
 count_metrics_api = metrics_v2.MetricsApi(api_client)
 distribution_metrics_api = metrics_v1.MetricsApi(api_client)  # Metrics API does not have an endpoint for distribution metrics
 
@@ -46,7 +46,7 @@ class DistributionMetric(NamedTuple):
     value: float = 1
 
 
-def increment(metrics: list[CountMetric]) -> None:
+async def increment(metrics: list[CountMetric]) -> None:
     """
     Adds value to a count metric with by the name '{APP_PREFIX}.{metric.name.strip(".").lower()}'
     :param metrics: list of CountMetric objects
@@ -69,14 +69,14 @@ def increment(metrics: list[CountMetric]) -> None:
     body = MetricPayload(series=series)
 
     try:
-        count_metrics_api.submit_metrics(body=body, content_encoding=MetricContentEncoding.DEFLATE)
+        await count_metrics_api.submit_metrics(body=body, content_encoding=MetricContentEncoding.DEFLATE)
     except ApiException as e:
-        logging.warning(f'event=logMetricFailed metrics={metrics} type=count status={e.status} reason={e.reason} body={e.body}')
+        logging.warning(f'event=logMetricFailed type=count metrics={metrics} status={e.status} reason={e.reason} body={e.body}')
     except Exception as e:
-        logging.warning(f'event=logMetricFailed metrics={metrics} type=count type={type(e)} error="{e}"')
+        logging.warning(f'event=logMetricFailed type=count metrics={metrics} error_type={type(e)} error="{e}"')
 
 
-def distribution(metrics: list[DistributionMetric]) -> None:
+async def distribution(metrics: list[DistributionMetric]) -> None:
     """
     Adds value to a distribution metric with by the name '{APP_PREFIX}.{metric.name.strip(".").lower()}.distribution'
     :param metrics: list of DistributionMetric objects
@@ -101,8 +101,8 @@ def distribution(metrics: list[DistributionMetric]) -> None:
     body = DistributionPointsPayload(series=series)
 
     try:
-        distribution_metrics_api.submit_distribution_points(content_encoding=DistributionPointsContentEncoding.DEFLATE, body=body)
+        await distribution_metrics_api.submit_distribution_points(content_encoding=DistributionPointsContentEncoding.DEFLATE, body=body)
     except ApiException as e:
         logging.warning(f"event=logMetricFailed type=distribution metrics={metrics} status={e.status} reason={e.reason} body='{e.body}'")
     except Exception as e:
-        logging.warning(f"event=logMetricFailed type=distribution metrics={metrics} type={type(e)} error='{e}'")
+        logging.warning(f"event=logMetricFailed type=distribution metrics={metrics} error_type={type(e)} error='{e}'")

--- a/domain-ee/ee-ep-merge-app/src/requirements.txt
+++ b/domain-ee/ee-ep-merge-app/src/requirements.txt
@@ -1,4 +1,4 @@
-datadog-api-client==2.22.*
+datadog-api-client[async]==2.25.*
 fastapi==0.109.*
 hoppy @ git+https://github.com/department-of-veterans-affairs/abd-vro.git@shared/lib-hoppy-0.6#subdirectory=shared/lib-hoppy
 httpx==0.24.*

--- a/domain-ee/ee-ep-merge-app/src/requirements.txt
+++ b/domain-ee/ee-ep-merge-app/src/requirements.txt
@@ -1,4 +1,4 @@
-datadog-api-client[async]==2.25.*
+datadog-api-client==2.25.*
 fastapi==0.109.*
 hoppy @ git+https://github.com/department-of-veterans-affairs/abd-vro.git@shared/lib-hoppy-0.6#subdirectory=shared/lib-hoppy
 httpx==0.24.*

--- a/domain-ee/ee-ep-merge-app/tests/util/test_metric_logger.py
+++ b/domain-ee/ee-ep-merge-app/tests/util/test_metric_logger.py
@@ -19,11 +19,10 @@ def distribution_metrics_api(mocker):
     return mocker.patch('src.python_src.util.metric_logger.distribution_metrics_api')
 
 
-@pytest.mark.asyncio()
-async def test_increment_with_one_metric_to_increment(count_metrics_api):
+def test_increment_with_one_metric_to_increment(count_metrics_api):
     metrics = [CountMetric(name='test_metric', value=1)]
 
-    await increment(metrics)
+    increment(metrics)
 
     body = count_metrics_api.submit_metrics.call_args[1]['body']
 
@@ -34,11 +33,10 @@ async def test_increment_with_one_metric_to_increment(count_metrics_api):
     assert body.series[0].points[0].value == 1
 
 
-@pytest.mark.asyncio()
-async def test_increment_with_multiple_metrics_to_increment(count_metrics_api):
+def test_increment_with_multiple_metrics_to_increment(count_metrics_api):
     metrics = [CountMetric(name='test_metric_1', value=1), CountMetric(name='test_metric_2', value=2)]
 
-    await increment(metrics)
+    increment(metrics)
 
     body = count_metrics_api.submit_metrics.call_args[1]['body']
 
@@ -54,11 +52,10 @@ async def test_increment_with_multiple_metrics_to_increment(count_metrics_api):
     assert body.series[1].points[0].value == 2
 
 
-@pytest.mark.asyncio()
-async def test_increment_with_one_metric_to_distribution(distribution_metrics_api):
+def test_increment_with_one_metric_to_distribution(distribution_metrics_api):
     metrics = [DistributionMetric(name='test_metric', value=1.5)]
 
-    await distribution(metrics)
+    distribution(metrics)
 
     body = distribution_metrics_api.submit_distribution_points.call_args[1]['body']
 
@@ -70,11 +67,10 @@ async def test_increment_with_one_metric_to_distribution(distribution_metrics_ap
     assert points[0] == 1.5
 
 
-@pytest.mark.asyncio()
-async def test_increment_with_multiple_metrics_to_distribution(distribution_metrics_api):
+def test_increment_with_multiple_metrics_to_distribution(distribution_metrics_api):
     metrics = [DistributionMetric(name='test_metric_1', value=1.1), DistributionMetric(name='test_metric_2', value=2.2)]
 
-    await distribution(metrics)
+    distribution(metrics)
 
     body = distribution_metrics_api.submit_distribution_points.call_args[1]['body']
 

--- a/domain-ee/ee-ep-merge-app/tests/util/test_metric_logger.py
+++ b/domain-ee/ee-ep-merge-app/tests/util/test_metric_logger.py
@@ -1,0 +1,93 @@
+import pytest
+from datadog_api_client.v2.model.metric_intake_type import MetricIntakeType
+
+from src.python_src.util.metric_logger import (
+    CountMetric,
+    DistributionMetric,
+    distribution,
+    increment,
+)
+
+
+@pytest.fixture()
+def count_metrics_api(mocker):
+    return mocker.patch('src.python_src.util.metric_logger.count_metrics_api')
+
+
+@pytest.fixture()
+def distribution_metrics_api(mocker):
+    return mocker.patch('src.python_src.util.metric_logger.distribution_metrics_api')
+
+
+@pytest.mark.asyncio()
+async def test_increment_with_one_metric_to_increment(count_metrics_api):
+    metrics = [CountMetric(name='test_metric', value=1)]
+
+    await increment(metrics)
+
+    body = count_metrics_api.submit_metrics.call_args[1]['body']
+
+    assert len(body.series) == 1
+    assert body.series[0].metric == 'ep_merge.test_metric'
+    assert body.series[0].type == MetricIntakeType.COUNT
+    assert len(body.series[0].points) == 1
+    assert body.series[0].points[0].value == 1
+
+
+@pytest.mark.asyncio()
+async def test_increment_with_multiple_metrics_to_increment(count_metrics_api):
+    metrics = [CountMetric(name='test_metric_1', value=1), CountMetric(name='test_metric_2', value=2)]
+
+    await increment(metrics)
+
+    body = count_metrics_api.submit_metrics.call_args[1]['body']
+
+    assert len(body.series) == 2
+    assert all(s.type == MetricIntakeType.COUNT for s in body.series)
+
+    assert body.series[0].metric == 'ep_merge.test_metric_1'
+    assert len(body.series[0].points) == 1
+    assert body.series[0].points[0].value == 1
+
+    assert body.series[1].metric == 'ep_merge.test_metric_2'
+    assert len(body.series[1].points) == 1
+    assert body.series[1].points[0].value == 2
+
+
+@pytest.mark.asyncio()
+async def test_increment_with_one_metric_to_distribution(distribution_metrics_api):
+    metrics = [DistributionMetric(name='test_metric', value=1.5)]
+
+    await distribution(metrics)
+
+    body = distribution_metrics_api.submit_distribution_points.call_args[1]['body']
+
+    assert len(body.series) == 1
+    assert body.series[0].metric == 'ep_merge.test_metric.distribution'
+    assert len(body.series[0].points) == 1
+    points = body.series[0].points[0].value[1]
+    assert len(points) == 1
+    assert points[0] == 1.5
+
+
+@pytest.mark.asyncio()
+async def test_increment_with_multiple_metrics_to_distribution(distribution_metrics_api):
+    metrics = [DistributionMetric(name='test_metric_1', value=1.1), DistributionMetric(name='test_metric_2', value=2.2)]
+
+    await distribution(metrics)
+
+    body = distribution_metrics_api.submit_distribution_points.call_args[1]['body']
+
+    assert len(body.series) == 2
+
+    assert body.series[0].metric == 'ep_merge.test_metric_1.distribution'
+    assert len(body.series[0].points) == 1
+    points = body.series[0].points[0].value[1]
+    assert len(points) == 1
+    assert points[0] == 1.1
+
+    assert body.series[1].metric == 'ep_merge.test_metric_2.distribution'
+    assert len(body.series[1].points) == 1
+    points = body.series[1].points[0].value[1]
+    assert len(points) == 1
+    assert points[0] == 2.2

--- a/svc-bgs-api/src/Gemfile
+++ b/svc-bgs-api/src/Gemfile
@@ -8,7 +8,6 @@ gem 'bunny', '>= 2.13.0'
 gem 'activesupport', '~> 6.0'
 gem 'bgs_ext', git: 'https://github.com/department-of-veterans-affairs/bgs-ext.git', require: 'bgs'
 gem 'rexml', '>= 3.2.7'
-gem 'rack', '>= 3.0.6.1'
 
 group :development, :test do
   gem 'rspec'

--- a/svc-bgs-api/src/Gemfile.lock
+++ b/svc-bgs-api/src/Gemfile.lock
@@ -37,8 +37,11 @@ GEM
       builder (>= 2.1.2)
       rexml (~> 3.0)
     httpclient (2.8.3)
-    httpi (3.0.1)
-      rack
+    httpi (3.0.2)
+      base64
+      mutex_m
+      nkf
+      rack (< 3)
     i18n (1.14.5)
       concurrent-ruby (~> 1.0)
     mail (2.8.1)
@@ -48,6 +51,7 @@ GEM
       net-smtp
     mini_mime (1.1.5)
     minitest (5.23.1)
+    mutex_m (0.2.0)
     net-imap (0.4.12)
       date
       net-protocol
@@ -57,6 +61,7 @@ GEM
       timeout
     net-smtp (0.5.0)
       net-protocol
+    nkf (0.2.0)
     nokogiri (1.16.5-arm64-darwin)
       racc (~> 1.4)
     nokogiri (1.16.5-x86_64-linux)
@@ -65,7 +70,7 @@ GEM
       bigdecimal
     public_suffix (5.0.5)
     racc (1.8.0)
-    rack (3.1.3)
+    rack (2.2.9)
     rbtree (0.4.6)
     rexml (3.3.0)
       strscan
@@ -114,7 +119,6 @@ DEPENDENCIES
   bgs_ext!
   bunny (>= 2.13.0)
   cgi (~> 0.3.6)
-  rack (>= 3.0.6.1)
   rexml (>= 3.2.7)
   rspec
 


### PR DESCRIPTION
<!-- Ensure the PR title reflects the feature or bug name -->

## What was the problem?
While working on  #2783 to make the calls to datadog asynchronous, I noticed that the current implementation of EP Merge app uses creates an `asyncio` event loop but never closes this loop. The investigation/troubleshooting on that ticket, led me to realize we had a memory leak as was evidenced by the dashboard chart linked in the description. 

I proceeded to run some tests locally to verify that was in fact the issue.

The 5 minute fixed rate tests demonstrated this effect. The tests sent 2 concurrent requests / second to the EP merge app deployed to a docker container. This allows independent tracking of memory and CPU usage similar to that of a container deployed on LHDI. Note, the traffic, however, is not similar because in production we hardly ever receive concurrent requests due to such a narrowed scope in eligible merges. 

## Tests
### Cases: 
1. Currently deployed functionality of not closing the `asyncio` event loop
2. Closing created event loop using `asyncio.run(...)`

### Setup:
* Deployed via docker along with rabbitmq, postgres, and all dependent micro-services and their mocks (BIP, BGS) 
  * Monitor memory usage of container
* Fixed rate:
  * 2 concurrent requests per second to submit merge jobs
  * 5 minutes

### Results
#### Case 1: current deployment
* Starting Memory: 78 MB
* Ending Memory: 1.91 GB 
* Requests: 625
* Error Rate: 0%
* Successful Merge Rate: 100%

![Image](https://github.com/department-of-veterans-affairs/abd-vro/assets/135860892/7b7bc2fd-4c11-4c8c-bf7b-1925f9cfc6b4)

#### Case 2: closing loop
* Starting Memory: 78 MB
* Ending Memory: 88 MB
* Requests: 621
* Error Rate: 0%
* Successful Merge Rate: 100%

![Image](https://github.com/department-of-veterans-affairs/abd-vro/assets/135860892/035a8451-c930-4c32-80d8-2eeb8d0fea9a)



## How does this fix it?[^1]
Uses `asyncio.run(...)` which closes the event loop upon finishing coroutine.

## How to test this PR
- pull code
- Unit Test:
  - from /domain-ee/ee-ep-merge-app run pytest
- Integration Tests:
  - run [base platform](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Docker-Compose#platform-base)
  - from /domain-ee/ee-ep-merge-app run pytest ./integration
- End to End tests:
  - run this [CI](https://github.com/department-of-veterans-affairs/abd-vro/actions/workflows/ee-ep-merge-end-to-end.yml) action to verify successful integration test
  - run end to end tests locally:
    - `export BIP_CLAIM_URL=mock-bip-claims-api:20300`
    - run bgs and bip services and mocks:
      - `COMPOSE_PROFILES=“all” ./gradlew dockerComposeUp`
      - `COMPOSE_PROFILES="bip,bgs" ./gradlew -p mocks :dockerComposeUp`
    - `./gradlew :domain-ee:ee-ep-merge-app:endToEndTest`

