### PR TITLE
resolve local cc schema doesn't exist isssue

### DIFF
--- a/db-init/src/main/resources/database/migrations/domain-cc/V2.0__Install_Alembic_Schema.sql
+++ b/db-init/src/main/resources/database/migrations/domain-cc/V2.0__Install_Alembic_Schema.sql
@@ -1,3 +1,6 @@
+-- Create the schema if it doesn't exist
+CREATE SCHEMA IF NOT EXISTS #[alembic_schemaname];
+
 DO $$
 BEGIN
     IF NOT EXISTS (SELECT FROM pg_catalog.pg_roles WHERE rolname = '#[alembic_username]') THEN


### PR DESCRIPTION
<!-- Ensure the PR title reflects the feature or bug name -->

## What was the problem?
when running local docker container, db-init flyway migration failure due to `domain-cc` does not exist

Associated tickets or Slack threads:
- #3057 

## How does this fix it?[^1]
add condition to create the schema if it doesn't exist




[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
