### PR TITLE
Investigate Flakey EP Merge End2End tests

### DIFF
--- a/.github/workflows/ee-ep-merge-end-to-end.yml
+++ b/.github/workflows/ee-ep-merge-end-to-end.yml
@@ -8,7 +8,6 @@ on:
   workflow_call:
 
 env:
-  COMPOSE_PROFILES: 'bip,bgs,platform'
   VRO_DEV_SECRETS_FOLDER: "${{ github.workspace }}/.cache/abd-vro-dev-secrets"
 
 jobs:
@@ -68,7 +67,7 @@ jobs:
           ./gradlew :domain-ee:ee-ep-merge-app:integrationTest
         timeout-minutes: 15
 
-      - name: "Start svc-bip-api and mock-bip-claims-api"
+      - name: "Start svc-bip-api, svc-bgs-api, and mock-bip-claims-api and mock-bgs-api"
         run: |
           source scripts/setenv.sh
 
@@ -77,13 +76,24 @@ jobs:
 
           export -p | sed 's/declare -x //'
 
-          ./gradlew :dockerComposeUp
-          ./gradlew -p mocks docker
-          ./gradlew -p mocks :dockerComposeUp
+          COMPOSE_PROFILES="platform,bip,bgs" ./gradlew :dockerComposeUp
+          COMPOSE_PROFILES="bip,bgs" ./gradlew -p mocks docker
+          COMPOSE_PROFILES="bip,bgs" ./gradlew -p mocks :dockerComposeUp
 
       - name: 'Wait for other containers to start'
         run: sleep 60s
         shell: bash
+
+      - name: 'Wait for svc-bip-api container to start'
+        uses: department-of-veterans-affairs/curl-action@v1.0.0
+        with:
+          url: 'http://localhost:10401/actuator/health'
+          method: 'GET'
+          accept: 200
+          # Retry every 2 seconds
+          timeout: 2000
+          # Quit after 120 seconds
+          retries: 60
 
       - name: 'Check disk space (Post-Build)'
         uses: ./.github/actions/check-disk-space
@@ -93,6 +103,20 @@ jobs:
         run: |
           ./gradlew :domain-ee:ee-ep-merge-app:endToEndTest
         timeout-minutes: 15
+
+      - name: "Collect docker logs"
+        if: always()
+        uses: jwalton/gh-docker-logs@v2
+        with:
+          dest: './ep-merge-container-logs'
+
+      - name: "Upload artifact"
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ep-merge-container-logs
+          path: ./ep-merge-container-logs/**
+          retention-days: 14
 
       - name: 'Clean shutdown of all containers'
         if: always()

--- a/svc-bip-api/src/main/java/gov/va/vro/bip/config/DatadogClientConfig.java
+++ b/svc-bip-api/src/main/java/gov/va/vro/bip/config/DatadogClientConfig.java
@@ -2,20 +2,20 @@ package gov.va.vro.bip.config;
 
 import com.datadog.api.client.ApiClient;
 import com.datadog.api.client.RetryConfig;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import com.datadog.api.client.v1.api.MetricsApi;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
 
 import java.util.HashMap;
 
-@Data
 @Configuration
-@NoArgsConstructor
 @ConfigurationProperties(prefix = "spring.datadog")
 @Slf4j
+@Conditional(NonLocalEnvironmentCondition.class)
 public class DatadogClientConfig {
 
   @Value("${spring.datadog.site}")
@@ -27,7 +27,13 @@ public class DatadogClientConfig {
   @Value("${spring.datadog.app_key}")
   private String app_key;
 
-  public ApiClient getApiClient() throws Exception {
+  @Bean
+  public MetricsApi metricsApi(ApiClient apiClient) {
+    return new MetricsApi(apiClient);
+  }
+
+  @Bean
+  public ApiClient apiClient() throws Exception {
     ApiClient apiClient = null;
     try {
       if (site != null && api_key != null) {

--- a/svc-bip-api/src/main/java/gov/va/vro/bip/config/LocalEnvironmentCondition.java
+++ b/svc-bip-api/src/main/java/gov/va/vro/bip/config/LocalEnvironmentCondition.java
@@ -1,0 +1,24 @@
+package gov.va.vro.bip.config;
+
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.context.annotation.Condition;
+import org.springframework.context.annotation.ConditionContext;
+import org.springframework.core.type.AnnotatedTypeMetadata;
+
+import java.util.stream.Stream;
+
+public class LocalEnvironmentCondition implements Condition {
+
+  private final String[] LOCAL_ENVS = new String[] {"local", "test"};
+
+  @Override
+  public boolean matches(ConditionContext context, AnnotatedTypeMetadata metadata) {
+    String env = context.getEnvironment().getProperty("bip.env");
+
+    if (StringUtils.isBlank(env)) {
+      return false;
+    }
+
+    return Stream.of(LOCAL_ENVS).anyMatch(e -> StringUtils.equals(e, env));
+  }
+}

--- a/svc-bip-api/src/main/java/gov/va/vro/bip/config/NonLocalEnvironmentCondition.java
+++ b/svc-bip-api/src/main/java/gov/va/vro/bip/config/NonLocalEnvironmentCondition.java
@@ -1,0 +1,16 @@
+package gov.va.vro.bip.config;
+
+import org.springframework.context.annotation.Condition;
+import org.springframework.context.annotation.ConditionContext;
+import org.springframework.core.type.AnnotatedTypeMetadata;
+
+public class NonLocalEnvironmentCondition implements Condition {
+
+  private final LocalEnvironmentCondition localEnvironmentCondition =
+      new LocalEnvironmentCondition();
+
+  @Override
+  public boolean matches(ConditionContext context, AnnotatedTypeMetadata metadata) {
+    return !localEnvironmentCondition.matches(context, metadata);
+  }
+}

--- a/svc-bip-api/src/main/java/gov/va/vro/bip/config/RabbitMqConfig.java
+++ b/svc-bip-api/src/main/java/gov/va/vro/bip/config/RabbitMqConfig.java
@@ -1,5 +1,6 @@
 package gov.va.vro.bip.config;
 
+import gov.va.vro.bip.service.IMetricLoggerService;
 import gov.va.vro.bip.service.InvalidPayloadRejectingFatalExceptionStrategy;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -24,6 +25,7 @@ public class RabbitMqConfig implements RabbitListenerConfigurer {
 
   private final RabbitMqConfigProperties props;
   private final JacksonConfig jacksonConfig;
+  private final IMetricLoggerService metricLoggerService;
 
   @Value("${exchangeName}")
   String exchangeName;
@@ -34,7 +36,8 @@ public class RabbitMqConfig implements RabbitListenerConfigurer {
     factory.setMessageConverter(
         (jacksonConfig.jackson2MessageConverter(jacksonConfig.objectMapper())));
     factory.setErrorHandler(
-        new ConditionalRejectingErrorHandler(new InvalidPayloadRejectingFatalExceptionStrategy()));
+        new ConditionalRejectingErrorHandler(
+            new InvalidPayloadRejectingFatalExceptionStrategy(metricLoggerService)));
     return factory;
   }
 

--- a/svc-bip-api/src/main/java/gov/va/vro/bip/service/BipApiService.java
+++ b/svc-bip-api/src/main/java/gov/va/vro/bip/service/BipApiService.java
@@ -62,7 +62,7 @@ public class BipApiService implements IBipApiService {
 
   final ObjectMapper mapper;
 
-  final MetricLoggerService metricLogger = new MetricLoggerService();
+  final IMetricLoggerService metricLogger;
 
   @Override
   public GetClaimResponse getClaimDetails(long claimId) {

--- a/svc-bip-api/src/main/java/gov/va/vro/bip/service/BipRequestErrorHandler.java
+++ b/svc-bip-api/src/main/java/gov/va/vro/bip/service/BipRequestErrorHandler.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import gov.va.vro.bip.model.BipMessage;
 import gov.va.vro.bip.model.BipPayloadResponse;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.amqp.core.Message;
 import org.springframework.amqp.rabbit.listener.api.RabbitListenerErrorHandler;
@@ -23,15 +24,12 @@ import java.util.Optional;
 @Slf4j
 @Primary
 @Component
+@RequiredArgsConstructor
 public class BipRequestErrorHandler implements RabbitListenerErrorHandler {
 
   private final ObjectMapper mapper;
 
-  private final MetricLoggerService metricLoggerService = new MetricLoggerService();
-
-  public BipRequestErrorHandler(ObjectMapper mapper) {
-    this.mapper = mapper;
-  }
+  private final IMetricLoggerService metricLoggerService;
 
   @Override
   public Object handleError(

--- a/svc-bip-api/src/main/java/gov/va/vro/bip/service/IMetricLoggerService.java
+++ b/svc-bip-api/src/main/java/gov/va/vro/bip/service/IMetricLoggerService.java
@@ -1,0 +1,33 @@
+package gov.va.vro.bip.service;
+
+import com.datadog.api.client.v1.model.DistributionPointsPayload;
+import com.datadog.api.client.v1.model.MetricsPayload;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.ArrayList;
+
+public interface IMetricLoggerService {
+
+  ArrayList<String> getTagsForSubmission(String[] customTags);
+
+  MetricsPayload createMetricsPayload(@NotNull METRIC metric, double value, String[] tags);
+
+  void submitCount(@NotNull METRIC metric, String[] tags);
+
+  void submitCount(@NotNull METRIC metric, double value, String[] tags);
+
+  DistributionPointsPayload createDistributionPointsPayload(
+      @NotNull METRIC metric, double timestamp, double value, String[] tags);
+
+  void submitRequestDuration(
+      long requestStartNanoseconds, long requestEndNanoseconds, String[] tags);
+
+  enum METRIC {
+    REQUEST_START,
+    REQUEST_DURATION,
+    RESPONSE_COMPLETE,
+    RESPONSE_ERROR,
+    LISTENER_ERROR,
+    MESSAGE_CONVERSION_ERROR
+  }
+}

--- a/svc-bip-api/src/main/java/gov/va/vro/bip/service/InvalidPayloadRejectingFatalExceptionStrategy.java
+++ b/svc-bip-api/src/main/java/gov/va/vro/bip/service/InvalidPayloadRejectingFatalExceptionStrategy.java
@@ -1,5 +1,6 @@
 package gov.va.vro.bip.service;
 
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.amqp.rabbit.listener.FatalExceptionStrategy;
@@ -11,9 +12,10 @@ import org.springframework.stereotype.Component;
 
 @Slf4j
 @Component
+@RequiredArgsConstructor
 public class InvalidPayloadRejectingFatalExceptionStrategy implements FatalExceptionStrategy {
 
-  private final MetricLoggerService metricLoggerService = new MetricLoggerService();
+  private final IMetricLoggerService metricLoggerService;
 
   @Override
   public boolean isFatal(@NotNull Throwable t) {

--- a/svc-bip-api/src/main/java/gov/va/vro/bip/service/NoopMetricLoggerService.java
+++ b/svc-bip-api/src/main/java/gov/va/vro/bip/service/NoopMetricLoggerService.java
@@ -1,0 +1,40 @@
+package gov.va.vro.bip.service;
+
+import com.datadog.api.client.v1.model.DistributionPointsPayload;
+import com.datadog.api.client.v1.model.MetricsPayload;
+import gov.va.vro.bip.config.LocalEnvironmentCondition;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+
+@Service
+@Conditional(LocalEnvironmentCondition.class)
+public class NoopMetricLoggerService implements IMetricLoggerService {
+
+  @Override
+  public ArrayList<String> getTagsForSubmission(String[] customTags) {
+    return new ArrayList<>();
+  }
+
+  @Override
+  public MetricsPayload createMetricsPayload(METRIC metric, double value, String[] tags) {
+    return new MetricsPayload();
+  }
+
+  @Override
+  public void submitCount(METRIC metric, String[] tags) {}
+
+  @Override
+  public void submitCount(METRIC metric, double value, String[] tags) {}
+
+  @Override
+  public DistributionPointsPayload createDistributionPointsPayload(
+      METRIC metric, double timestamp, double value, String[] tags) {
+    return new DistributionPointsPayload();
+  }
+
+  @Override
+  public void submitRequestDuration(
+      long requestStartNanoseconds, long requestEndNanoseconds, String[] tags) {}
+}

--- a/svc-bip-api/src/test/java/gov/va/vro/bip/config/RabbitMqApiConfigTest.java
+++ b/svc-bip-api/src/test/java/gov/va/vro/bip/config/RabbitMqApiConfigTest.java
@@ -1,7 +1,9 @@
 package gov.va.vro.bip.config;
 
+import com.datadog.api.client.v1.api.MetricsApi;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import gov.va.vro.bip.service.BipRequestErrorHandler;
+import gov.va.vro.bip.service.MetricLoggerService;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.amqp.core.DirectExchange;
@@ -14,14 +16,18 @@ import java.util.HashMap;
 
 class RabbitMqApiConfigTest {
 
+  private final MetricLoggerService metricLoggerService = new MetricLoggerService(new MetricsApi());
+
   @Test
   @SuppressWarnings({"unchecked", "rawtypes"})
   public void testRabbitMqConfig() {
     RabbitMqConfig rmqConfig =
-        new RabbitMqConfig(new RabbitMqConfigProperties(), new JacksonConfig());
+        new RabbitMqConfig(
+            new RabbitMqConfigProperties(), new JacksonConfig(), metricLoggerService);
     DirectExchange directExchange = rmqConfig.bipApiExchange();
     Assertions.assertNotNull(directExchange);
-    RabbitListenerErrorHandler errorHandler = new BipRequestErrorHandler(new ObjectMapper());
+    RabbitListenerErrorHandler errorHandler =
+        new BipRequestErrorHandler(new ObjectMapper(), metricLoggerService);
     try {
       var headers = new HashMap<>();
       headers.put("replyChannel", "mock ReplyChannel");

--- a/svc-bip-api/src/test/java/gov/va/vro/bip/service/BipApiServiceTest.java
+++ b/svc-bip-api/src/test/java/gov/va/vro/bip/service/BipApiServiceTest.java
@@ -94,6 +94,8 @@ public class BipApiServiceTest {
 
   private final ObjectMapper mapper = new JacksonConfig().objectMapper();
 
+  @Mock private MetricLoggerService metricLoggerService;
+
   @Mock private RestTemplate restTemplate;
 
   @BeforeEach
@@ -106,7 +108,7 @@ public class BipApiServiceTest {
     bipApiProps.setStationId(STATION_ID);
     bipApiProps.setClaimClientId(CLAIM_USERID);
 
-    service = new BipApiService(restTemplate, bipApiProps, mapper);
+    service = new BipApiService(restTemplate, bipApiProps, mapper, metricLoggerService);
   }
 
   private String formatClaimUrl(String format, Long claimId) {

--- a/svc-bip-api/src/test/java/gov/va/vro/bip/service/MetricLoggerServiceTest.java
+++ b/svc-bip-api/src/test/java/gov/va/vro/bip/service/MetricLoggerServiceTest.java
@@ -3,6 +3,7 @@ package gov.va.vro.bip.service;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.datadog.api.client.v1.api.MetricsApi;
 import com.datadog.api.client.v1.model.DistributionPointItem;
 import com.datadog.api.client.v1.model.DistributionPointsPayload;
 import com.datadog.api.client.v1.model.MetricsPayload;
@@ -14,7 +15,7 @@ import java.util.Objects;
 
 public class MetricLoggerServiceTest {
 
-  private MetricLoggerService mls = new MetricLoggerService();
+  private MetricLoggerService mls = new MetricLoggerService(new MetricsApi());
 
   @Test
   void testGetFullMetricString() {


### PR DESCRIPTION
## What was the problem?
ep-merge application e2e tests have been failing since a recent update to metric logging within svc-bip-api.  This PR is an attempt to clean up the spring implementation and add environmental support to omit metric logging in local/test regions where the services are not configured to perform metric logging.

Associated tickets or Slack threads:
- #3114 

## How does this fix it?[^1]
We're now building multiple MetricLoggers or initializing the DataDogConfiguration only once, and we're now only setting up metric logging in non-local/test environments.

## How to test this PR
- Step 1 CI tests for ep-merge e2e integration should pass.


[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
