### PR TITLE
set correct cron

### DIFF
--- a/.github/workflows/secrel.yml
+++ b/.github/workflows/secrel.yml
@@ -9,8 +9,7 @@ on:
   # Run on a schedule, at 1100 UTC/0700 EST every weekday MON-FRI
   # Per the documentation: Scheduled workflows will only run on the default (develop) branch
   schedule:
-#    - cron: "0 11 * * 1-5"
-    - cron: "*/30 * * * 1-5"
+    - cron: "0 11 * * 1-5"
 
   # Run SecRel on Dependabot PRs, automatically
   pull_request:


### PR DESCRIPTION
## What was the problem?
We want to automate SecRel runs to be performed each morning.  This PR is the final code push for fixing CI tests and configuring the SecRel action to run each morning at 0700 ET.

Associated tickets or Slack threads:
- #3031

## How does this fix it?[^1]
A cron has been configured in secrel.yml to schedule SecRel runs daily, M-F, at 1100 UTC/0700 ET.

## How to test this PR
- View GitHub actions history to see regular "schedule" runs.


[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
