### PR TITLE
#3031 turn off PUBLISH_IMAGES flag in scheduled secrel action

### DIFF
--- a/.github/workflows/secrel.yml
+++ b/.github/workflows/secrel.yml
@@ -92,7 +92,7 @@ jobs:
             PUBLISH_IMAGES=${{ inputs.publish_images }}
           elif [ "${{ github.event_name }}" == "schedule" ]; then
             RUN_SECREL=true
-            PUBLISH_IMAGES=true
+            PUBLISH_IMAGES=false
           fi
 
           {


### PR DESCRIPTION
## What was the problem?
<!-- brief description of how things worked before this PR -->

Associated tickets or Slack threads:
- #3031

## How does this fix it?[^1]
<!-- description of how things will work after this PR -->

## How to test this PR
- Step 1
- Step 2[^secrel]


[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
