### PR TITLE
Fix ruby file loading issue for metric logger

### DIFF
--- a/svc-bgs-api/src/lib/bgs_client.rb
+++ b/svc-bgs-api/src/lib/bgs_client.rb
@@ -3,7 +3,7 @@
 require 'active_support/time'
 require 'active_support/core_ext/object/blank'
 require 'bgs'
-require 'metric_logger'
+require_relative 'metric_logger'
 
 # patch bgs_ext with a createNote implementation that follows our spec better
 BGS::DevelopmentNotesService.class_eval do


### PR DESCRIPTION
## What was the problem?
Readiness probe is failing for deployed versions of `svc-bgs-api` (have only deployed to pre-prod environments; seeing this error consistently). 

```Readiness probe failed: /usr/local/lib/ruby/3.3.0/bundled_gems.rb:74:in `require': cannot load such file -- metric_logger (LoadError) from /usr/local/lib/ruby/3.3.0/bundled_gems.rb:74:in `block (2 levels) in replace_require' from /app/lib/bgs_client.rb:6:in `<top (required)>' from /app/healthcheck/readiness_script.rb:6:in `require_relative' from /app/healthcheck/readiness_script.rb:6:in `<main>'```

The `metric_logger` in question is not an external gem, and was recently introduced  - this is the first time we're trying to deploy it.  It might be that we should be using `require_relative` to load it, instead of `require`.  Going off of this reasoning:
> require is usually called when requiring gems loaded in gemfile. Though require can be used to both execute gems and external dependencies, the preferable method to load relative paths is require_relative. require_relative is a subset of require and is a convenient method to use when you are referring to a file that is relative to the current file you are working on (basically, within the same project directory).     (source: [Understanding Require vs. Require_relative vs. Require_all](https://medium.com/@ellishim/understanding-require-vs-require-relative-vs-require-all-80e3b26d89e6))


## The solution
Use `require_relative` instead of `require` for loading `metric_logger`.

## How I tested this
- ran unit tests
- introduced a typo (`require_relative 'metric_loggerz'`) and verified unit tests broke; and verified unit tests succeeded without the typo
- verified that deployments of this to `dev` and `qa` do not trigger the readiness probe failure

## note on deploying this to production
Likely 7/3. I'm not prepared to troubleshoot if the deployment fails today. 