### PR TITLE
Added query parameter to get jobs with updated_at filter.

### DIFF
--- a/domain-ee/ee-ep-merge-app/integration/test_get_endpoints.py
+++ b/domain-ee/ee-ep-merge-app/integration/test_get_endpoints.py
@@ -14,19 +14,19 @@ JOB_IDS = []
 JOB_ID = uuid4()
 PENDING_ID = 1
 EP400_ID = 2
-CREATED_AT = NOW.isoformat()
-UPDATED_AT = (NOW + timedelta(seconds=1)).isoformat()
+CREATED_AT = NOW
+UPDATED_AT = NOW + timedelta(seconds=1)
 
 
-def create_job(state, job_id):
+def create_job(state, job_id, created_at: datetime = CREATED_AT, updated_at: datetime = UPDATED_AT):
     JOB_IDS.append(str(job_id))
     return {
         'job_id': job_id,
         'pending_claim_id': PENDING_ID,
         'ep400_claim_id': EP400_ID,
         'state': state,
-        'created_at': CREATED_AT,
-        'updated_at': UPDATED_AT,
+        'created_at': created_at.isoformat(),
+        'updated_at': updated_at.isoformat(),
     }
 
 
@@ -37,8 +37,8 @@ def assert_response(response, expected_state: JobState, status_code: int = 200):
     assert response_json['job']['pending_claim_id'] == PENDING_ID
     assert response_json['job']['ep400_claim_id'] == EP400_ID
     assert response_json['job']['state'] == expected_state
-    assert response_json['job']['created_at'] == CREATED_AT
-    assert response_json['job']['updated_at'] == UPDATED_AT
+    assert response_json['job']['created_at'] == CREATED_AT.isoformat()
+    assert response_json['job']['updated_at'] == UPDATED_AT.isoformat()
     return response_json
 
 
@@ -97,3 +97,65 @@ async def test_get_jobs_by_state(submit_jobs, states: list[JobState]):
 
         for job_json in json['jobs']:
             assert job_json['job_id'] in JOB_IDS
+
+
+@pytest.mark.asyncio(scope='session')
+async def test_get_jobs_by_updated_at_start_found():
+    created_at = datetime.now()
+    updated_at = created_at + timedelta(seconds=1)
+    JOB_STORE.submit_merge_job(create_job(JobState.PENDING, uuid4(), created_at, updated_at))
+
+    async with AsyncClient(app=app, base_url='http://test') as client:
+        response = await client.get(url=f'/merge?updated_at_start={created_at.isoformat()}')
+        assert response.status_code == 200
+        json = response.json()
+        assert json is not None
+        assert json['total'] == 1
+        assert len(json['jobs']) == 1
+        assert json['jobs'][0]['job_id'] in JOB_IDS
+        assert json['jobs'][0]['state'] == JobState.PENDING
+
+
+@pytest.mark.asyncio(scope='session')
+async def test_get_jobs_by_updated_at_start_not_found():
+    JOB_STORE.submit_merge_job(create_job(JobState.PENDING, uuid4()))
+
+    async with AsyncClient(app=app, base_url='http://test') as client:
+        response = await client.get(url=f'/merge?updated_at_start={(NOW + timedelta(days=1)).isoformat()}')
+        assert response.status_code == 200
+        json = response.json()
+        assert json is not None
+        assert json['total'] == 0
+        assert len(json['jobs']) == 0
+
+
+@pytest.mark.asyncio(scope='session')
+async def test_get_jobs_by_updated_at_end_found():
+    created_at = NOW - timedelta(days=1)
+    updated_at = created_at + timedelta(seconds=1)
+    JOB_STORE.submit_merge_job(create_job(JobState.PENDING, uuid4(), created_at, updated_at))
+
+    async with AsyncClient(app=app, base_url='http://test') as client:
+        response = await client.get(url=f'/merge?updated_at_end={updated_at.isoformat()}')
+        assert response.status_code == 200
+        json = response.json()
+        assert json is not None
+        assert json['total'] == 1
+        assert len(json['jobs']) == 1
+        assert json['jobs'][0]['job_id'] in JOB_IDS
+        assert json['jobs'][0]['state'] == JobState.PENDING
+
+
+@pytest.mark.asyncio(scope='session')
+async def test_get_jobs_by_updated_at_end_not_found():
+    created_at = NOW - timedelta(days=1)
+    updated_at = created_at + timedelta(seconds=1)
+    JOB_STORE.submit_merge_job(create_job(JobState.PENDING, uuid4(), created_at, updated_at))
+
+    async with AsyncClient(app=app, base_url='http://test') as client:
+        response = await client.get(url=f'/merge?updated_at_end={created_at.isoformat()}')
+        assert response.status_code == 200
+        json = response.json()
+        assert json is not None
+        assert json['total'] == 0
+        assert len(json['jobs']) == 0


### PR DESCRIPTION
<!-- Ensure the PR title reflects the feature or bug name -->

## What was the problem?
<!-- brief description of how things worked before this PR -->
Add query parameters to get merge jobs by most recent updated time within a time frame.

Associated tickets or Slack threads:
- #3163 

## How does this fix it?[^1]
<!-- description of how things will work after this PR -->
Adds query parameters for `updated_at_start` and `updated_at_end` to specify start/end of timeframe for filtering results.

## How to test this PR
- pull code
- Unit Test:
  - from /domain-ee/ee-ep-merge-app run pytest
- Integration Tests:
  - run [base platform](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Docker-Compose#platform-base)
  - from /domain-ee/ee-ep-merge-app run pytest ./integration
- End to End tests:
  - run this [CI](https://github.com/department-of-veterans-affairs/abd-vro/actions/workflows/ee-ep-merge-end-to-end.yml) action to verify successful integration test
  - run end to end tests locally:
    - `export BIP_CLAIM_URL=mock-bip-claims-api:20300`
    - run bgs and bip services and mocks:
      - `COMPOSE_PROFILES=“all” ./gradlew dockerComposeUp`
      - `COMPOSE_PROFILES="bip,bgs" ./gradlew -p mocks :dockerComposeUp`
    - `./gradlew :domain-ee:ee-ep-merge-app:endToEndTest`

[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
