### PR TITLE
Update the tomcat.embed dependency for snyk remediation

### DIFF
--- a/.github/workflows/delete-published-images.yml
+++ b/.github/workflows/delete-published-images.yml
@@ -74,7 +74,6 @@ jobs:
         - vro-xample-workflows
         - vro-cc-app
         - vro-ee-max-cfi-app
-        - vro-mock-bgs-api
     runs-on: ubuntu-latest
     steps:
     - name: "Delete old images in GHCR"

--- a/.github/workflows/secrel.yml
+++ b/.github/workflows/secrel.yml
@@ -51,7 +51,6 @@ on:
           - db-init
           - app
           - rabbitmq
-          - mock-bgs-api
       image_tag:
         description: "Image tag to run SecRel on. If 'all' is selected, then 'latest' will always be used. This does not define the image tag during publishing"
         required: true

--- a/.github/workflows/update-deployment.yml
+++ b/.github/workflows/update-deployment.yml
@@ -30,7 +30,6 @@ on:
         - domain-ee-ep-merge-app
         - dev-tools
         - db-init
-        - mock-bgs-api
 
       image_tag:
         description: 'Image tag: first 7 of commit hash or "latest"'

--- a/gradle-plugins/src/main/groovy/shared.java.vro-dep-constraints.gradle
+++ b/gradle-plugins/src/main/groovy/shared.java.vro-dep-constraints.gradle
@@ -9,10 +9,10 @@ plugins {
 
 ext {
     mapstruct_version="1.4.2.Final"
-    spring_framework_version="6.0.13"
+    spring_framework_version="6.1.10"
     snakeyaml_version="2.2"
     jackson_databind_version="2.16"
-    spring_core_version="6.1.3"
+    spring_core_version="6.1.10"
 }
 
 afterEvaluate {

--- a/gradle-plugins/src/main/groovy/shared.java.vro-dep-constraints.gradle
+++ b/gradle-plugins/src/main/groovy/shared.java.vro-dep-constraints.gradle
@@ -61,7 +61,7 @@ dependencies {
         implementation 'org.apache.commons:commons-compress:1.24.0'
 
         // for tomcat
-        implementation 'org.apache.tomcat.embed:tomcat-embed-core:10.1.14'
+        implementation 'org.apache.tomcat.embed:tomcat-embed-core:10.1.25'
 
         implementation 'org.springframework.amqp:spring-amqp:3.0.10'
         implementation 'org.springframework.security:spring-security-config:6.1.5'

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,7 +16,7 @@ hibernate_types_version=3.7.3
 postgresql_version=42.7.2
 
 spring_security_version=6.2.3
-spring_boot_version=3.2.3
+spring_boot_version=3.3.0
 spring_doc_version=2.2.0
 swagger_version=2.2.16
 

--- a/mocks/gradle.properties
+++ b/mocks/gradle.properties
@@ -5,6 +5,6 @@ dockerRegistry=va
 # so disableSafeguard so that tasks from the included builds will be executed.
 taskinfo.disableSafeguard=true
 
-spring_boot_version=3.2.3
+spring_boot_version=3.3.0
 io_jsonwebtoken_version=0.11.5
 spring_doc_version=2.2.0

--- a/mocks/mock-bgs-api/src/docker/Dockerfile
+++ b/mocks/mock-bgs-api/src/docker/Dockerfile
@@ -7,6 +7,11 @@ ENV HEALTHCHECK_PORT=${HEALTHCHECK_PORT_ARG}
 
 #copy the mock definition file, our entrypoint and helper script to load the file
 COPY bgs-castlemock.xml entrypoint.sh init-after-tomcat-starts.sh /
-RUN chmod a+x /entrypoint.sh /init-after-tomcat-starts.sh
+
+RUN adduser --no-create-home --disabled-password tron
+
+RUN chmod a+x /*.sh  && chown -R tron /
+
+USER tron
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/scripts/image-names.sh
+++ b/scripts/image-names.sh
@@ -31,8 +31,7 @@ IMAGES=( postgres \
   xample-workflows \
   cc-app \
   ee-max-cfi-app \
-  ee-ep-merge-app \
-  mock-bgs-api)
+  ee-ep-merge-app )
 echo
 echo "=== ${#IMAGES[@]} VRO images"
 for INDEX in "${!IMAGES[@]}"; do

--- a/scripts/image_vars.src
+++ b/scripts/image_vars.src
@@ -5,14 +5,14 @@
 
 # Array of VRO images
 # shellcheck disable=SC2034
-VRO_IMAGES_ARR=( postgres rabbitmq db-init dev-tools svc-bgs-api svc-bie-kafka svc-bip-api xample-workflows cc-app ee-max-cfi-app ee-ep-merge-app mock-bgs-api )
+VRO_IMAGES_ARR=( postgres rabbitmq db-init dev-tools svc-bgs-api svc-bie-kafka svc-bip-api xample-workflows cc-app ee-max-cfi-app ee-ep-merge-app )
 # Usage: for IMG in ${VRO_IMAGES_ARR[@]}; do echo "- $IMG"; done
-export VRO_IMAGES="postgres rabbitmq db-init dev-tools svc-bgs-api svc-bie-kafka svc-bip-api xample-workflows cc-app ee-max-cfi-app ee-ep-merge-app mock-bgs-api"
+export VRO_IMAGES="postgres rabbitmq db-init dev-tools svc-bgs-api svc-bie-kafka svc-bip-api xample-workflows cc-app ee-max-cfi-app ee-ep-merge-app"
 
 # Array of variable prefixes
 # shellcheck disable=SC2034
-VAR_PREFIXES_ARR=( postgres rabbitmq dbinit devtools svcbgsapi svcbiekafka svcbipapi xampleworkflows ccapp eemaxcfiapp eeepmergeapp mockbgsapi )
-export VAR_PREFIXES="postgres rabbitmq dbinit devtools svcbgsapi svcbiekafka svcbipapi xampleworkflows ccapp eemaxcfiapp eeepmergeapp mockbgsapi"
+VAR_PREFIXES_ARR=( postgres rabbitmq dbinit devtools svcbgsapi svcbiekafka svcbipapi xampleworkflows ccapp eemaxcfiapp eeepmergeapp )
+export VAR_PREFIXES="postgres rabbitmq dbinit devtools svcbgsapi svcbiekafka svcbipapi xampleworkflows ccapp eemaxcfiapp eeepmergeapp"
 
 ## Helper functions
 # Usage example to get the variable value for app_GRADLE_IMG: GRADLE_IMG_TAG=`getVarValue app _GRADLE_IMG`
@@ -78,6 +78,3 @@ export eemaxcfiapp_IMG="vro-ee-max-cfi-app"
 
 export eeepmergeapp_GRADLE_IMG="va/abd_vro-ee-ep-merge-app"
 export eeepmergeapp_IMG="vro-ee-ep-merge-app"
-
-export mockbgsapi_GRADLE_IMG="va/abd_vro-mock-bgs-api"
-export mockbgsapi_IMG="vro-mock-bgs-api"

--- a/settings.gradle
+++ b/settings.gradle
@@ -50,6 +50,4 @@ include ':domain-xample:svc-hoppy-usage'
 include ':domain-cc:cc-app'
 include ':domain-ee:ee-max-cfi-app'
 include ':domain-ee:ee-ep-merge-app'
-include ':rabbitmq'
-
-include ':mocks:mock-bgs-api'
+include 'rabbitmq'

--- a/svc-bip-api/gradle.properties
+++ b/svc-bip-api/gradle.properties
@@ -1,3 +1,3 @@
 # For port numbering convention, see https://github.com/department-of-veterans-affairs/abd-vro/wiki/Software-Conventions#port-numbers
 healthcheck_port=10401
-spring_boot_version=3.2.3
+spring_boot_version=3.3.0


### PR DESCRIPTION
Resolve SecRel Errors 

## What was the problem?
SecRel failure occurred when Snyk Detected a [High severity - Insufficient Session Expiration vulnerability in org.apache.tomcat.embed:tomcat-embed-core](https://github.com/department-of-veterans-affairs/abd-vro-internal/security/code-scanning/1833)

Associated tickets or Slack threads:
- #?

## How does this fix it?[^1]
Snyk and Aqua errors have been remediated.

## How to test this PR
- PR branch passes SecRel


[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
