### PR TITLE
EP Merge: update lib-hoppy to use new per-message TTL

### DIFF
--- a/domain-ee/ee-ep-merge-app/src/python_src/config.py
+++ b/domain-ee/ee-ep-merge-app/src/python_src/config.py
@@ -4,8 +4,9 @@ from urllib.parse import quote, urlparse
 
 config = {
     'app_id': os.environ.get('APP_ID') or 'EP_MERGE',
-    'request_timeout': int(os.getenv('REQUEST_TIMEOUT') or 30),
+    'request_message_ttl': int(os.getenv('REQUEST_TTL') or 0),
     'request_retries': int(os.getenv('REQUEST_RETRIES') or 3),
+    'response_max_latency': int(os.getenv('RESPONSE_TIMEOUT') or 30),
     'response_delivery_attempts': int(os.getenv('RESPONSE_DELIVERY_ATTEMPTS') or 3),
 }
 

--- a/domain-ee/ee-ep-merge-app/src/python_src/service/hoppy_service.py
+++ b/domain-ee/ee-ep-merge-app/src/python_src/service/hoppy_service.py
@@ -33,9 +33,10 @@ class HoppyService:
             request_routing_key=req_queue,
             reply_queue_properties=reply_queue_props,
             reply_routing_key=reply_queue,
-            max_latency=config['request_timeout'],
-            max_retries=config['request_retries'],
+            request_message_ttl=config['request_message_ttl'],
+            response_max_latency=config['response_max_latency'],
             response_reject_and_requeue_attempts=config['response_delivery_attempts'],
+            max_retries=config['request_retries'],
         )
         self.clients[name] = client
 

--- a/domain-ee/ee-ep-merge-app/src/requirements.txt
+++ b/domain-ee/ee-ep-merge-app/src/requirements.txt
@@ -1,6 +1,6 @@
 datadog-api-client==2.25.*
 fastapi==0.109.*
-hoppy @ git+https://github.com/department-of-veterans-affairs/abd-vro.git@shared/lib-hoppy-0.6#subdirectory=shared/lib-hoppy
+hoppy @ git+https://github.com/department-of-veterans-affairs/abd-vro.git@shared/lib-hoppy-1.0.0#subdirectory=shared/lib-hoppy
 httpx==0.24.*
 psycopg2-binary==2.9.*
 pydantic==2.4.*


### PR DESCRIPTION
<!-- Ensure the PR title reflects the feature or bug name -->

## What was the problem?
<!-- brief description of how things worked before this PR -->
`lib-hoppy` has been updated to include a new per-message TTL property upon publishing messages to queues.

Associated tickets or Slack threads:
- #3175 
- following PR: #3180

## How to test this PR
- pull code
- Unit Test:
  - from /domain-ee/ee-ep-merge-app run `pytest`
- Integration Tests:
  - run [base platform](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Docker-Compose#platform-base)
  - from /domain-ee/ee-ep-merge-app run `pytest ./integration`
- End to End tests:
  - run this [CI](https://github.com/department-of-veterans-affairs/abd-vro/actions/workflows/ee-ep-merge-end-to-end.yml) action to verify successful integration test
  - run end to end tests locally:
    - `export BIP_CLAIM_URL=mock-bip-claims-api:20300`
    - run bgs and bip services and mocks:
      - `COMPOSE_PROFILES=“all” ./gradlew dockerComposeUp`
      - `COMPOSE_PROFILES="bip,bgs" ./gradlew -p mocks :dockerComposeUp`
    - `./gradlew :domain-ee:ee-ep-merge-app:endToEndTest`


[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
