### PR TITLE
adjust mock-bgs-api Dockerfile 

### DIFF
--- a/mocks/mock-bgs-api/src/docker/Dockerfile
+++ b/mocks/mock-bgs-api/src/docker/Dockerfile
@@ -7,11 +7,6 @@ ENV HEALTHCHECK_PORT=${HEALTHCHECK_PORT_ARG}
 
 #copy the mock definition file, our entrypoint and helper script to load the file
 COPY bgs-castlemock.xml entrypoint.sh init-after-tomcat-starts.sh /
-
-RUN adduser --no-create-home --disabled-password tron
-
-RUN chmod a+x /*.sh  && chown -R tron /
-
-USER tron
+RUN chmod a+x /entrypoint.sh /init-after-tomcat-starts.sh
 
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
## What was the problem?
`mock-bgs-api` container is failing to start up in CI runs. 

Snippet from the logs suggest an error encountered executing the Dockerfile:
```
2024-07-12T21:54:48.8975877Z Dockerfile:13
2024-07-12T21:54:48.8976253Z --------------------
2024-07-12T21:54:48.8976831Z   11 |     RUN adduser --no-create-home --disabled-password tron
2024-07-12T21:54:48.8977155Z   12 |     
2024-07-12T21:54:48.8977625Z   13 | >>> RUN chmod a+x /*.sh  && chown -R tron /
2024-07-12T21:54:48.8977948Z   14 |     
2024-07-12T21:54:48.8978289Z   15 |     USER tron
2024-07-12T21:54:48.8978647Z --------------------
2024-07-12T21:54:48.8979743Z ERROR: failed to solve: process "/bin/sh -c chmod a+x /*.sh  && chown -R tron /" did not complete successfully: exit code: 1
2024-07-12T21:54:48.8979760Z 
2024-07-12T21:54:48.8980175Z FAILURE: Build failed with an exception.
2024-07-12T21:54:48.8980181Z 
2024-07-12T21:54:48.8980532Z * What went wrong:
2024-07-12T21:54:48.8981025Z Execution failed for task ':mock-bgs-api:docker'.
2024-07-12T21:54:48.8981605Z > Process 'command 'docker'' finished with non-zero exit value 1
```


## How does this fix it?[^1]
The Dockerfile in question was adjusted in recent PR #3169, as part of other changes. 

https://github.com/department-of-veterans-affairs/abd-vro/pull/3169/files#diff-95b28342727462e48b1337997edc60b6db06ea906e8431cd33cc5e0493e2a6ec

This PR reverts the edits to the Dockerfile.

This container is NOT run in the production environment; if it starts up and runs sufficiently to allow CI tests to pass, I propose the risk of negative side effects is low. 

## How to test this PR
- verify that CI checks that leverage mock bgs are able to succeed .  sample of successful CI tests: https://github.com/department-of-veterans-affairs/abd-vro/actions/runs/9946892867/job/27478420096?pr=3194 