### PR TITLE
lib-hoppy: update/specify setuptools version to pass vulnerability scan

### DIFF
--- a/shared/lib-hoppy/pyproject.toml
+++ b/shared/lib-hoppy/pyproject.toml
@@ -1,11 +1,11 @@
 [build-system]
-requires = ["setuptools"]
+requires = ["setuptools >= 70.0.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "hoppy"
-description = "Python library for building VRO microservices that need to interact with Rabbit MQ"
-requires-python = ">=3.6"
+description = "Python library for building asynchrounous REST-like clients that perform requests and receive responses over Rabbit MQ"
+requires-python = ">= 3.10"
 dependencies = [
     "pika",
     "pytest",
@@ -35,4 +35,4 @@ testpaths = [
     "test",
     "integration" # depends on rabbitmq-service
 ]
-timeout=5
+timeout = 5


### PR DESCRIPTION

<!-- Ensure the PR title reflects the feature or bug name -->

## What was the problem?
<!-- brief description of how things worked before this PR -->
Aqua-Gate check failing for EP Merge due to unspecified version of `setuptools` using an older version with a vulnerability.

Associated tickets or Slack threads:
- [slack thread](https://dsva.slack.com/archives/C01Q7979Z7D/p1721147741263119?thread_ts=1721075539.214129&cid=C01Q7979Z7D)

## How does this fix it?[^1]
<!-- description of how things will work after this PR -->
Specify setuptools version, update description, and change required python version.


[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
