### PR TITLE
update grep for finding mock containers in CI check for healthy containers

### DIFF
--- a/.github/workflows/container-healthchecks.yml
+++ b/.github/workflows/container-healthchecks.yml
@@ -82,7 +82,7 @@ jobs:
           # Ignore mocks since they don't have health checks
           # TODO: add health check for svc-bgs-api; ignore it for now
           if docker container ls --format '{{.Names}} \t {{.Status}}' | grep -v "(healthy)" \
-            | grep -v "svc-bgs-api\|-mock-"; then
+            | grep -v "svc-bgs-api\|mock-"; then
             echo 'There are unexpected unhealthy containers!'
             exit 2
           fi

--- a/svc-bgs-api/src/lib/metric_logger.rb
+++ b/svc-bgs-api/src/lib/metric_logger.rb
@@ -32,7 +32,7 @@ class MetricLogger
       api_instance.validate
       $logger.info('Succeeded Datadog authentication check')
     rescue Exception => e
-      $logger.error("Failed Datadog authentication check: #{e.message}")
+      $logger.warn("Failed Datadog authentication check: #{e.message}")
     end
   end
 
@@ -79,7 +79,7 @@ class MetricLogger
       @metrics_api.submit_metrics(payload)
       $logger.info("submitted #{payload.series.first.metric}")
     rescue Exception => e
-      $logger.error("Error logging metric: #{metric} (count). Error: #{e.class}, Message: #{e.message}")
+      $logger.warn("Error logging metric: #{metric} (count). Error: #{e.class}, Message: #{e.message}")
     end
   end
 
@@ -105,7 +105,7 @@ class MetricLogger
         "submitted #{payload.series.first.metric}  #{payload_result.status}"
       )
     rescue Exception => e
-      $logger.error(
+      $logger.warn(
         "exception submitting request duration  #{e.message}"
       )
     end

--- a/svc-bip-api/src/main/java/gov/va/vro/bip/service/MetricLoggerService.java
+++ b/svc-bip-api/src/main/java/gov/va/vro/bip/service/MetricLoggerService.java
@@ -84,7 +84,7 @@ public class MetricLoggerService implements IMetricLoggerService {
               "submitted %s: %s",
               payload.getSeries().get(0).getMetric(), payloadResult.getStatus()));
     } catch (Exception e) {
-      log.error(
+      log.warn(
           String.format(
               "exception submitting %s: %s",
               payload.getSeries().get(0).getMetric(), e.getMessage()));
@@ -127,7 +127,7 @@ public class MetricLoggerService implements IMetricLoggerService {
               "submitted %s: %s",
               payload.getSeries().get(0).getMetric(), payloadResult.getStatus()));
     } catch (Exception e) {
-      log.error(
+      log.warn(
           String.format(
               "exception submitting %s: %s",
               payload.getSeries().get(0).getMetric(), e.getMessage()));


### PR DESCRIPTION
## What was the problem?
The `container-healthchecks` job in the suite of CI checks regularly fails due to a mock container not registering a healthy status. 
We have code in-place mean to remove mock containers from consideration for this test (because they don't have health checks); however, the container for `mock-bie-kafka` is named in a way that isn't caught by this code.
As a result, the job displays a Failure result, when we can see that it's only the mock container that was unhealthy. 

Sample run showing this problem: https://github.com/department-of-veterans-affairs/abd-vro/actions/runs/9975597466/job/27565759431?pr=3209
 
<img src='https://github.com/user-attachments/assets/b9aac958-1a02-41e7-8b6f-5011b612a26b' width='200'/>

## Solution proposed in this PR
1. Loosen from a match of `-mock-` to `mock-`. why: at least one mock container is named with `_mock-`, which doesn't satisfy the original pattern. 
2. Adjust logging level for failed Datadog API metrics submissions from `error` to `warning`. why: 1) I would consider these `warning` level rather than `error`; 2) for compatibility with the existing script used in the CI check for whether a container's logs appear healthy. In the build environment, the DD metrics submission will fail; and if these log messages appear at the `error` threshold, that will be enough for the script logic to interpret the container as unhealthy (which, when restricted to the DD metrics failures, is not accurate).

The better solution would be to track down why the container is being named with "_mock-" rather than "-mock-", and seeing if we can standardize to "-mock-"; however, I wasn't able to track this down.

