### PR TITLE
Bump jinja2 from 3.1.3 to 3.1.4 in db-init

### DIFF
--- a/db-init/Dockerfile
+++ b/db-init/Dockerfile
@@ -7,7 +7,7 @@ apk upgrade
 apk --no-cache add libcrypto3 libssl3 openssl postgresql-client py3-pip
 rm -rf /var/cache/apk/*
 pip3 install --no-cache-dir sqlfluff==2.1.2
-pip3 install --no-cache-dir jinja2==3.1.3
+pip3 install --no-cache-dir jinja2==3.1.4
 EOR
 
 COPY database /flyway/sql


### PR DESCRIPTION
## summary of changes
upgrades jinja2 in `db-init` from 3.1.3 to 3.14 to address [CVE-2024-34064](https://www.cve.org/CVERecord?id=CVE-2024-34064), flagged by SecRel
