### PR TITLE
3224 build image tag array when image already exists for schedule runs

### DIFF
--- a/.github/actions/publish-images/action.yml
+++ b/.github/actions/publish-images/action.yml
@@ -64,9 +64,20 @@ runs:
             IMG_NAME="$(getVarValue "${PREFIX}" _IMG)"
             echo "::group::Push image $IMG_NAME $IMG_TAG"
             GHCR_PATH="ghcr.io/${{ github.repository }}/${IMG_NAME}"
+
             if [ "$(imageTagExists "$IMG_NAME" "$IMG_TAG")" == "200" ]; then
               echo "Image already exists: $IMG_NAME:$IMG_TAG -- not overwriting"
               echo "* ($IMG_NAME:$IMG_TAG -- already exists, not overwriting)" >> "$GITHUB_STEP_SUMMARY"
+
+              if [ "${{ github.event_name }}" == "schedule" ]; then
+                echo "* $IMG_NAME:$IMG_TAG" >> "$GITHUB_STEP_SUMMARY"
+                echo -n "\"${GHCR_PATH}:$IMG_TAG\"" >> "$GITHUB_OUTPUT"
+
+                # For all but the last image include a comma
+                if [ ${PREFIX} != ${VAR_PREFIXES_ARR[-1]} ]; then
+                  echo -n "," >> "$GITHUB_OUTPUT"
+                fi
+              fi
             else
               GRADLE_IMG_NAME=$(getVarValue "${PREFIX}" _GRADLE_IMG)
 


### PR DESCRIPTION
## What was the problem?
Scheduled SecRel runs did are not performing scans because images have already been built during the previous PR merge.

Associated tickets or Slack threads:
- #3224 

## How does this fix it?[^1]
In the action script, when we find an image which has already been updated, for scheduled runs we will still add the image name and tag to the output list of images used further down the SecRel pipeline.

## How to test this PR
- Step 1 wait for automated secrel scan to run and observe the results.  Currently, the Aqua and Snyk checks are skipped because there are no image tags to scan - this should no longer be the case with this PR.


[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
