### PR TITLE
Add logging for transaction latency

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -39,12 +39,10 @@ jobs:
     secrets: inherit
 
   container-healthchecks:
-    needs: nondraft-pr
     uses: ./.github/workflows/container-healthchecks.yml
     secrets: inherit
 
   xample-domain:
-    needs: nondraft-pr
     uses: ./.github/workflows/xample-integration-test.yml
     secrets: inherit
 
@@ -54,12 +52,10 @@ jobs:
     secrets: inherit
 
   svc-bip-api:
-    needs: nondraft-pr
     uses: ./.github/workflows/svc-bip-api-integration-test.yml
     secrets: inherit
 
   svc-bie-kafka-end-to-end:
-    needs: nondraft-pr
     uses: ./.github/workflows/bie-kafka-end2end-test.yml
     secrets: inherit
 

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -39,10 +39,12 @@ jobs:
     secrets: inherit
 
   container-healthchecks:
+    needs: nondraft-pr
     uses: ./.github/workflows/container-healthchecks.yml
     secrets: inherit
 
   xample-domain:
+    needs: nondraft-pr
     uses: ./.github/workflows/xample-integration-test.yml
     secrets: inherit
 
@@ -52,10 +54,12 @@ jobs:
     secrets: inherit
 
   svc-bip-api:
+    needs: nondraft-pr
     uses: ./.github/workflows/svc-bip-api-integration-test.yml
     secrets: inherit
 
   svc-bie-kafka-end-to-end:
+    needs: nondraft-pr
     uses: ./.github/workflows/bie-kafka-end2end-test.yml
     secrets: inherit
 

--- a/domain-xample/xample-workflows/src/main/java/gov/va/vro/routes/xample/BieXampleRoutes.java
+++ b/domain-xample/xample-workflows/src/main/java/gov/va/vro/routes/xample/BieXampleRoutes.java
@@ -24,9 +24,10 @@ public class BieXampleRoutes {
       })
   public void handleMessage(BieMessagePayload payload) {
     try {
+      long transactionStartTime = System.nanoTime();
       dbHelper.saveContentionEvent(payload);
       payload.setStatus(200);
-      log.info("Saved Contention Event to DB");
+      log.info("Saved Contention Event to DB. Transaction duration: {}", (System.nanoTime() - transactionStartTime));
 
       String jsonBody = objectMapper.writeValueAsString(payload);
       log.info("ReceivedMessageEventBody: " + jsonBody);

--- a/svc-bie-kafka/src/main/java/gov/va/vro/services/bie/service/BieRabbitService.java
+++ b/svc-bie-kafka/src/main/java/gov/va/vro/services/bie/service/BieRabbitService.java
@@ -14,7 +14,13 @@ public class BieRabbitService implements AmqpMessageSender {
 
   @Override
   public void send(final String exchange, final String routingKey, final Object payload) {
+    long transactionStartTime = System.nanoTime();
     rabbitTemplate.convertAndSend(exchange, routingKey, payload);
-    log.info("event=messageSent exchange={} topic={} msg={}", exchange, routingKey, payload);
+    log.info(
+        "event=messageSent exchange={} topic={} msg={}, duration={}",
+        exchange,
+        routingKey,
+        payload,
+        (System.nanoTime() - transactionStartTime));
   }
 }

--- a/svc-bip-api/src/main/java/gov/va/vro/bip/service/MetricLoggerService.java
+++ b/svc-bip-api/src/main/java/gov/va/vro/bip/service/MetricLoggerService.java
@@ -113,14 +113,14 @@ public class MetricLoggerService implements IMetricLoggerService {
   public void submitRequestDuration(
       long requestStartNanoseconds, long requestEndNanoseconds, String[] tags) {
 
+    double elapsedTime =
+        getElapsedTimeInMilliseconds(requestStartNanoseconds, requestEndNanoseconds);
+
     DistributionPointsPayload payload =
-        createDistributionPointsPayload(
-            METRIC.REQUEST_DURATION,
-            getTimestamp(),
-            getElapsedTimeInMilliseconds(requestStartNanoseconds, requestEndNanoseconds),
-            tags);
+        createDistributionPointsPayload(METRIC.REQUEST_DURATION, getTimestamp(), elapsedTime, tags);
 
     try {
+      log.info(String.format("duration=%.2f tags=%s", elapsedTime, String.join(",", tags)));
       IntakePayloadAccepted payloadResult = metricsApi.submitDistributionPoints(payload);
       log.info(
           String.format(


### PR DESCRIPTION
<!-- Ensure the PR title reflects the feature or bug name -->

## What was the problem?
We need visibility into latency on the VRO apps. 

Associated tickets or Slack threads:
- #3261

## How does this fix it? 
This PR outputs latency data into log messages. Log messages can be parsed for the latency data.

Better approach: use the datadog API client to relay this data as metrics. The metrics approach is more readable from the perspective of the maintaining the codebase, and less involved with respect to surfacing the data in datadog graphs.

Under the assumption the logging mechanism is relatively low complexity - we are already exposing logs in datadog, and datadog has mechanisms for parsing messages - and knowing that this data is needed in order to inform other work - 
I want to prioritize the log implementation.
