### PR TITLE
Expose Special issue types endpoint throughout the BIP API service

### DIFF
--- a/mocks/docker-compose.yml
+++ b/mocks/docker-compose.yml
@@ -29,17 +29,6 @@ x-common-sde-security: &common-sde-security
 services:
   # Containers with the `mock-` prefix are used for development and testing.
 
-  mock-slack:
-    profiles: ["all","slack"]
-    image: va/vro_mocks-mock-slack:latest
-    <<: [*common-sde-security, *common-security-opt]
-    ports:
-      - "20100:20100"
-    environment:
-      <<: *common-vars
-    networks:
-      - vro_intranet
-
   mock-bie-kafka:
     profiles: ["all","kafka"]
     image: va/vro_mocks-mock-bie-kafka:latest

--- a/mocks/mock-bip-claims-api/src/main/java/gov/va/vro/mockbipclaims/api/ContentionsApi.java
+++ b/mocks/mock-bip-claims-api/src/main/java/gov/va/vro/mockbipclaims/api/ContentionsApi.java
@@ -5,6 +5,7 @@ import gov.va.vro.mockbipclaims.model.bip.request.CreateContentionsRequest;
 import gov.va.vro.mockbipclaims.model.bip.request.UpdateContentionsRequest;
 import gov.va.vro.mockbipclaims.model.bip.response.ContentionSummariesResponse;
 import gov.va.vro.mockbipclaims.model.bip.response.CreateContentionsResponse;
+import gov.va.vro.mockbipclaims.model.bip.response.SpecialIssueTypesResponse;
 import gov.va.vro.mockbipclaims.model.bip.response.UpdateContentionsResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -324,7 +325,9 @@ public interface ContentionsApi {
   /**
    * GET /contentions/special_issue_types : Returns special issue types.
    *
-   * <p>Not fully implemented in mock since only used for connectivity testing.
+   * <p>Now a fully implemented mock since EP Merge project required a Special Issue Type lookup
+   * mechanism. For the purposes of the mock, getSpecialIssueTypes is going to respond with the json
+   * file: mocks/mock-bip-claims-api/src/main/resources/mock-special-issues.json.
    */
   @Operation(
       operationId = "getSpecialIssueTypes",
@@ -336,10 +339,10 @@ public interface ContentionsApi {
             content = {
               @Content(
                   mediaType = "application/json",
-                  schema = @Schema(implementation = UpdateContentionsResponse.class)),
+                  schema = @Schema(implementation = SpecialIssueTypesResponse.class)),
               @Content(
                   mediaType = "application/problem+json",
-                  schema = @Schema(implementation = UpdateContentionsResponse.class))
+                  schema = @Schema(implementation = SpecialIssueTypesResponse.class))
             }),
         @ApiResponse(
             responseCode = "401",
@@ -375,5 +378,5 @@ public interface ContentionsApi {
       method = RequestMethod.GET,
       value = "/contentions/special_issue_types",
       produces = {"application/json", "application/problem+json"})
-  ResponseEntity<String> getSpecialIssueTypes();
+  ResponseEntity<SpecialIssueTypesResponse> getSpecialIssueTypes();
 }

--- a/mocks/mock-bip-claims-api/src/main/java/gov/va/vro/mockbipclaims/config/AppConfig.java
+++ b/mocks/mock-bip-claims-api/src/main/java/gov/va/vro/mockbipclaims/config/AppConfig.java
@@ -3,8 +3,10 @@ package gov.va.vro.mockbipclaims.config;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import gov.va.vro.mockbipclaims.model.bip.SpecialIssueType;
 import gov.va.vro.mockbipclaims.model.store.ClaimStore;
 import gov.va.vro.mockbipclaims.model.store.ClaimStoreItem;
+import gov.va.vro.mockbipclaims.model.store.SpecialIssueTypesStore;
 import gov.va.vro.mockbipclaims.model.store.UpdatesStore;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -18,6 +20,9 @@ import java.io.InputStream;
 public class AppConfig {
   @Value("classpath:mock-claims.json")
   private Resource mockClaimsResource;
+
+  @Value("classpath:mock-special-issues.json")
+  private Resource mockSpecialIssuesResource;
 
   @Bean
   public JwtProps jwtProps() {
@@ -48,6 +53,26 @@ public class AppConfig {
       claimStore.put(item);
     }
     return claimStore;
+  }
+
+  /**
+   * Creates a basic HashMap based store.
+   *
+   * @return The Claimstore.
+   * @throws IOException If mock claims data cannot be read
+   */
+  @Bean
+  public SpecialIssueTypesStore createSpecialIssueTypesStore() throws IOException {
+    SpecialIssueTypesStore typesStore = new SpecialIssueTypesStore();
+
+    InputStream stream = mockSpecialIssuesResource.getInputStream();
+    ObjectMapper mapper = createObjectMapper();
+    SpecialIssueType[] items = mapper.readValue(stream, SpecialIssueType[].class);
+    for (int index = 0; index < items.length; ++index) {
+      SpecialIssueType item = items[index];
+      typesStore.put(item);
+    }
+    return typesStore;
   }
 
   /**

--- a/mocks/mock-bip-claims-api/src/main/java/gov/va/vro/mockbipclaims/controller/ContentionsController.java
+++ b/mocks/mock-bip-claims-api/src/main/java/gov/va/vro/mockbipclaims/controller/ContentionsController.java
@@ -143,7 +143,10 @@ public class ContentionsController extends BaseController implements Contentions
     return new ResponseEntity<>(response, HttpStatus.OK);
   }
 
-  /** Responds with the json in file: mocks/mock-bip-claims-api/src/main/resources/mock-special-issues.json*/
+  /**
+   * Responds with the json in file:
+   * mocks/mock-bip-claims-api/src/main/resources/mock-special-issues.json
+   */
   @Override
   public ResponseEntity<SpecialIssueTypesResponse> getSpecialIssueTypes() {
     log.info("Returning mock special issue types...");

--- a/mocks/mock-bip-claims-api/src/main/java/gov/va/vro/mockbipclaims/controller/ContentionsController.java
+++ b/mocks/mock-bip-claims-api/src/main/java/gov/va/vro/mockbipclaims/controller/ContentionsController.java
@@ -143,7 +143,7 @@ public class ContentionsController extends BaseController implements Contentions
     return new ResponseEntity<>(response, HttpStatus.OK);
   }
 
-  /** Not fully implemented. Only used for connectivity testing. */
+  /** Responds with the json in file: mocks/mock-bip-claims-api/src/main/resources/mock-special-issues.json*/
   @Override
   public ResponseEntity<SpecialIssueTypesResponse> getSpecialIssueTypes() {
     log.info("Returning mock special issue types...");

--- a/mocks/mock-bip-claims-api/src/main/java/gov/va/vro/mockbipclaims/controller/ContentionsController.java
+++ b/mocks/mock-bip-claims-api/src/main/java/gov/va/vro/mockbipclaims/controller/ContentionsController.java
@@ -14,9 +14,11 @@ import gov.va.vro.mockbipclaims.model.bip.request.CreateContentionsRequest;
 import gov.va.vro.mockbipclaims.model.bip.request.UpdateContentionsRequest;
 import gov.va.vro.mockbipclaims.model.bip.response.ContentionSummariesResponse;
 import gov.va.vro.mockbipclaims.model.bip.response.CreateContentionsResponse;
+import gov.va.vro.mockbipclaims.model.bip.response.SpecialIssueTypesResponse;
 import gov.va.vro.mockbipclaims.model.bip.response.UpdateContentionsResponse;
 import gov.va.vro.mockbipclaims.model.store.ClaimStore;
 import gov.va.vro.mockbipclaims.model.store.ClaimStoreItem;
+import gov.va.vro.mockbipclaims.model.store.SpecialIssueTypesStore;
 import gov.va.vro.mockbipclaims.model.store.UpdatesStore;
 import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
@@ -35,6 +37,8 @@ import java.util.Random;
 @RequiredArgsConstructor
 public class ContentionsController extends BaseController implements ContentionsApi {
   private final ClaimStore claimStore;
+
+  private final SpecialIssueTypesStore typesStore;
 
   private final UpdatesStore actionStore;
 
@@ -141,8 +145,10 @@ public class ContentionsController extends BaseController implements Contentions
 
   /** Not fully implemented. Only used for connectivity testing. */
   @Override
-  public ResponseEntity<String> getSpecialIssueTypes() {
-    log.info("Returning an empty array as special issues...");
-    return new ResponseEntity<>("[]", HttpStatus.OK);
+  public ResponseEntity<SpecialIssueTypesResponse> getSpecialIssueTypes() {
+    log.info("Returning mock special issue types...");
+    SpecialIssueTypesResponse response = new SpecialIssueTypesResponse();
+    response.setCodeNamePairs(typesStore.all());
+    return new ResponseEntity<>(response, HttpStatus.OK);
   }
 }

--- a/mocks/mock-bip-claims-api/src/main/java/gov/va/vro/mockbipclaims/model/bip/SpecialIssueType.java
+++ b/mocks/mock-bip-claims-api/src/main/java/gov/va/vro/mockbipclaims/model/bip/SpecialIssueType.java
@@ -1,0 +1,24 @@
+package gov.va.vro.mockbipclaims.model.bip;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.OffsetDateTime;
+
+@Schema(
+    name = "SpecialIssueType",
+    description =
+        """
+        An issue type that is used to describe a special type of contention
+        """)
+@Data
+public class SpecialIssueType {
+  @NotNull private String name;
+  @NotNull private String code;
+  private String description;
+
+  @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+  private OffsetDateTime deactiveDate;
+}

--- a/mocks/mock-bip-claims-api/src/main/java/gov/va/vro/mockbipclaims/model/bip/response/SpecialIssueTypesResponse.java
+++ b/mocks/mock-bip-claims-api/src/main/java/gov/va/vro/mockbipclaims/model/bip/response/SpecialIssueTypesResponse.java
@@ -1,0 +1,11 @@
+package gov.va.vro.mockbipclaims.model.bip.response;
+
+import gov.va.vro.mockbipclaims.model.bip.ProviderResponse;
+import gov.va.vro.mockbipclaims.model.bip.SpecialIssueType;
+import lombok.Data;
+
+/** SpecialIssueTypesResponse. */
+@Data
+public class SpecialIssueTypesResponse extends ProviderResponse {
+  private SpecialIssueType[] codeNamePairs;
+}

--- a/mocks/mock-bip-claims-api/src/main/java/gov/va/vro/mockbipclaims/model/store/SpecialIssueTypesStore.java
+++ b/mocks/mock-bip-claims-api/src/main/java/gov/va/vro/mockbipclaims/model/store/SpecialIssueTypesStore.java
@@ -1,0 +1,42 @@
+package gov.va.vro.mockbipclaims.model.store;
+
+import gov.va.vro.mockbipclaims.model.bip.SpecialIssueType;
+import lombok.NoArgsConstructor;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@NoArgsConstructor
+public class SpecialIssueTypesStore {
+  Map<String, SpecialIssueType> store = new HashMap<>();
+
+  /**
+   * Retrieves all SpecialIssueTypes.
+   *
+   * @return Claim Store item
+   */
+  public SpecialIssueType[] all() {
+    var values = store.values();
+    return values.toArray(new SpecialIssueType[values.size()]);
+  }
+
+  /**
+   * Retrieves the SpecialIssueType by code.
+   *
+   * @param code unique identifier of a special issue type
+   * @return SpecialIssueType
+   */
+  public SpecialIssueType get(String code) {
+    return store.get(code);
+  }
+
+  /**
+   * Puts a new item in SpecialIssueType Store.
+   *
+   * @param item New SpecialIssueType to be stored
+   */
+  public void put(SpecialIssueType item) {
+    var code = item.getCode();
+    store.put(code, item);
+  }
+}

--- a/mocks/mock-bip-claims-api/src/main/resources/mock-special-issues.json
+++ b/mocks/mock-bip-claims-api/src/main/resources/mock-special-issues.json
@@ -1,0 +1,453 @@
+[
+  {
+    "name": "Sarcoidosis",
+    "code": "SARCO",
+    "description": "ALL"
+  },
+  {
+    "name": "Asbestos",
+    "code": "ASB",
+    "description": "ALL"
+  },
+  {
+    "name": "Hepatitis C",
+    "code": "HEPC",
+    "description": "ALL"
+  },
+  {
+    "name": "HIV",
+    "code": "HIV",
+    "description": "ALL"
+  },
+  {
+    "name": "Mustard Gas",
+    "code": "MG",
+    "description": "ALL"
+  },
+  {
+    "name": "Radiation",
+    "code": "RDN",
+    "description": "ALL"
+  },
+  {
+    "name": "POW",
+    "code": "POW",
+    "description": "ALL"
+  },
+  {
+    "name": "38 USC 1151",
+    "code": "38USC1151",
+    "description": "ALL"
+  },
+  {
+    "name": "Environmental Hazard in Gulf War",
+    "code": "GW",
+    "description": "ALL"
+  },
+  {
+    "name": "ChemBio",
+    "code": "CB"
+  },
+  {
+    "name": "SHAD",
+    "code": "SHAD"
+  },
+  {
+    "name": "RO Special issue 1",
+    "code": "ROSI1"
+  },
+  {
+    "name": "RO Special issue 2",
+    "code": "ROSI2"
+  },
+  {
+    "name": "VACO Special issue 1",
+    "code": "COSI1"
+  },
+  {
+    "name": "VACO Special issue 2",
+    "code": "COSI2"
+  },
+  {
+    "name": "Amyotrophic Lateral Sclerosis (ALS)",
+    "code": "ALS"
+  },
+  {
+    "name": "Medical Foster Home",
+    "code": "MFH"
+  },
+  {
+    "name": "Enhanced Disability Severance Pay",
+    "code": "EDSP"
+  },
+  {
+    "name": "Pilot Program Fully Dev Claim",
+    "code": "PPFDC",
+    "deactiveDate": "2010-05-04T13:45:16-05:00"
+  },
+  {
+    "name": "Pilot Prog Not Fully Dev Claim-Not rcvd full dev",
+    "code": "PPNFDNRFD",
+    "deactiveDate": "2010-05-04T13:45:16-05:00"
+  },
+  {
+    "name": "Pilot Prog Not Fully Dev Claim-Resched VAE",
+    "code": "PPNFDRVAE",
+    "deactiveDate": "2010-05-04T13:45:16-05:00"
+  },
+  {
+    "name": "Pilot Prog Not Fully Dev Claim-Addl dev after init",
+    "code": "PPNFDADAPI",
+    "deactiveDate": "2010-05-04T13:45:16-05:00"
+  },
+  {
+    "name": "Pilot Prog Not Fully Dev Claim-Other delay",
+    "code": "PPNFDOD",
+    "deactiveDate": "2010-05-04T13:45:16-05:00"
+  },
+  {
+    "name": "Fully Developed Claim",
+    "code": "FDC"
+  },
+  {
+    "name": "Agent Orange - Vietnam",
+    "code": "AOIV"
+  },
+  {
+    "name": "Agent Orange",
+    "code": "AO",
+    "description": "ALL",
+    "deactiveDate": "2010-05-06T15:05:58-05:00"
+  },
+  {
+    "name": "RO Special Issue 3",
+    "code": "ROSPISTHR"
+  },
+  {
+    "name": "RO Special Issue 4",
+    "code": "ROSPISFOR"
+  },
+  {
+    "name": "VACO Special Issue 3",
+    "code": "VACSPISTHR"
+  },
+  {
+    "name": "VACO Special Issue 4",
+    "code": "VACSPISFOR"
+  },
+  {
+    "name": "PTSD - Combat",
+    "code": "PTSD/1"
+  },
+  {
+    "name": "PTSD - Non-Combat",
+    "code": "PTSD/2"
+  },
+  {
+    "name": "Non-PTSD Personal Trauma",
+    "code": "PTSD/4"
+  },
+  {
+    "name": "PTSD",
+    "code": "PTSD",
+    "description": "ALL",
+    "deactiveDate": "2010-08-12T09:50:44-05:00"
+  },
+  {
+    "name": "Personal Trauma PTSD",
+    "code": "TRM",
+    "description": "ALL",
+    "deactiveDate": "2010-08-12T09:50:44-05:00"
+  },
+  {
+    "name": "PTSD - Personal Trauma",
+    "code": "PTSD/3"
+  },
+  {
+    "name": "Environmental Hazard - Camp Lejeune",
+    "code": "EHCL"
+  },
+  {
+    "name": "Gulf War Presumptive",
+    "code": "GWP"
+  },
+  {
+    "name": "Combat Related Death",
+    "code": "CRD"
+  },
+  {
+    "name": "Military Sexual Trauma (MST)",
+    "code": "MST"
+  },
+  {
+    "name": "Express Claim Excluded-Additional Evidence",
+    "code": "EXPCLMXADE",
+    "deactiveDate": "2011-05-17T11:33:21-05:00"
+  },
+  {
+    "name": "Express Claim Excluded-Failed to Report for Exam",
+    "code": "EXPCLMXFRE",
+    "deactiveDate": "2011-05-17T11:33:21-05:00"
+  },
+  {
+    "name": "Washington RO Burial Processing",
+    "code": "WROBP",
+    "deactiveDate": "2011-05-19T14:07:43-05:00"
+  },
+  {
+    "name": "Rapid Eval",
+    "code": "RPDEVL",
+    "deactiveDate": "2011-05-19T14:08:09-05:00"
+  },
+  {
+    "name": "Walk in Pilot - Immediate Decision",
+    "code": "WLKIPIMMD",
+    "deactiveDate": "2011-05-19T14:08:31-05:00"
+  },
+  {
+    "name": "Walk in Pilot - Interim Decision",
+    "code": "WLKIPINTD",
+    "deactiveDate": "2011-05-19T14:08:31-05:00"
+  },
+  {
+    "name": "Walk in Pilot - Dev Required",
+    "code": "WLKIPDR",
+    "deactiveDate": "2011-05-19T14:08:31-05:00"
+  },
+  {
+    "name": "Walk in Pilot Term - Time Limit Expired",
+    "code": "WLKIPTTLE",
+    "deactiveDate": "2011-05-19T14:08:31-05:00"
+  },
+  {
+    "name": "Walk in Pilot Term - Seq Claim",
+    "code": "WLKIPTSQC",
+    "deactiveDate": "2011-05-19T14:08:31-05:00"
+  },
+  {
+    "name": "Walk in Pilot Term - Other Rsn",
+    "code": "WLKIPTOR",
+    "deactiveDate": "2011-05-19T14:08:31-05:00"
+  },
+  {
+    "name": "Disability Benefits Questionnaire",
+    "code": "DBBENQNRE",
+    "deactiveDate": "2011-10-05T07:23:15-05:00"
+  },
+  {
+    "name": "Disability Benefits Questionnaire - Private",
+    "code": "DBQP"
+  },
+  {
+    "name": "Disability Benefits Questionnaire - VA",
+    "code": "DBQV"
+  },
+  {
+    "name": "FDC Excluded - Additional Evidence",
+    "code": "FDCEXAE",
+    "deactiveDate": "2011-10-05T09:15:32-05:00"
+  },
+  {
+    "name": "FDC Excluded - Failed to Report for Exam",
+    "code": "FDCEXFRE",
+    "deactiveDate": "2011-10-05T09:15:32-05:00"
+  },
+  {
+    "name": "FDC Excluded - Needs Non-Fed Evidence Development",
+    "code": "FDCNED"
+  },
+  {
+    "name": "FDC Excluded - Evidence Received After FDC CEST",
+    "code": "FDCEFC"
+  },
+  {
+    "name": "FDC Excluded - Claimant Declined FDC Processing",
+    "code": "FDCCFP"
+  },
+  {
+    "name": "Indy - Express Team",
+    "code": "IET",
+    "deactiveDate": "2011-11-15T12:29:34-06:00"
+  },
+  {
+    "name": "Indy - Core Team",
+    "code": "ICT",
+    "deactiveDate": "2011-11-15T12:29:34-06:00"
+  },
+  {
+    "name": "Indy - Select Team",
+    "code": "IST",
+    "deactiveDate": "2011-11-15T12:29:34-06:00"
+  },
+  {
+    "name": "Indy - Special Ops Team",
+    "code": "ISOT",
+    "deactiveDate": "2011-11-15T12:29:34-06:00"
+  },
+  {
+    "name": "Indy - Non-Rating Team",
+    "code": "INRT",
+    "deactiveDate": "2011-11-15T12:29:34-06:00"
+  },
+  {
+    "name": "Indy - Appeals Team",
+    "code": "IAT",
+    "deactiveDate": "2011-11-15T12:29:34-06:00"
+  },
+  {
+    "name": "VONAPP Direct Connect",
+    "code": "VDC",
+    "description": "E-Benefits"
+  },
+  {
+    "name": "Brokered - Internal",
+    "code": "BRKINT"
+  },
+  {
+    "name": "Nehmer Phase II",
+    "code": "NP"
+  },
+  {
+    "name": "AMC NOD Brokering Project",
+    "code": "ANBP"
+  },
+  {
+    "name": "Development Resource Center Case",
+    "code": "DRCC",
+    "deactiveDate": "2012-11-16T18:52:58-06:00"
+  },
+  {
+    "name": "Jurisdiction Change",
+    "code": "JC",
+    "deactiveDate": "2012-11-16T18:52:58-06:00"
+  },
+  {
+    "name": "OCR - Old Claim Review",
+    "code": "OCR",
+    "deactiveDate": "2013-07-23T00:00:00-05:00"
+  },
+  {
+    "name": "ABA Election",
+    "code": "AE"
+  },
+  {
+    "name": "Upfront Verification",
+    "code": "UV"
+  },
+  {
+    "name": "Nehmer AO Peripheral Neuropathy",
+    "code": "NAPN"
+  },
+  {
+    "name": "Non-Nehmer AO Peripheral Neuropathy",
+    "code": "NNAPN"
+  },
+  {
+    "name": "Hardship-IRH",
+    "code": "HARDI",
+    "deactiveDate": "2013-12-12T00:00:00-06:00"
+  },
+  {
+    "name": "Hardship-Financial",
+    "code": "HARDF",
+    "deactiveDate": "2013-12-12T00:00:00-06:00"
+  },
+  {
+    "name": "Homeless Veteran",
+    "code": "HOMEV",
+    "deactiveDate": "2013-12-12T00:00:00-06:00"
+  },
+  {
+    "name": "Homeless",
+    "code": "HOME",
+    "deactiveDate": "2013-12-12T00:00:00-06:00"
+  },
+  {
+    "name": "Hardship",
+    "code": "HARD",
+    "deactiveDate": "2013-12-12T00:00:00-06:00"
+  },
+  {
+    "name": "NLA Pilot",
+    "code": "NLAP",
+    "deactiveDate": "2014-02-24T00:00:00-06:00"
+  },
+  {
+    "name": "RO Special Issue 5",
+    "code": "RSI5"
+  },
+  {
+    "name": "RO Special Issue 6",
+    "code": "RSI6"
+  },
+  {
+    "name": "RO Special Issue 7",
+    "code": "RSI7"
+  },
+  {
+    "name": "FDC Excluded - FDC Certification Incomplete",
+    "code": "FEFCI"
+  },
+  {
+    "name": "FDC Excluded - Additional Claim Submitted",
+    "code": "FEACS"
+  },
+  {
+    "name": "FDC Excluded - Claim Pending",
+    "code": "FECP"
+  },
+  {
+    "name": "FDC Excluded - Appeal Pending",
+    "code": "FEAP"
+  },
+  {
+    "name": "FDC Excluded - Necessary Form(s) not Submitted",
+    "code": "FENS"
+  },
+  {
+    "name": "FDC Excluded - FTR to Examination",
+    "code": "FEFTE"
+  },
+  {
+    "name": "FDC Excluded - VBA Administrative Reason",
+    "code": "FDCEXVBAAR",
+    "deactiveDate": "2014-05-12T00:00:00-05:00"
+  },
+  {
+    "name": "Unadjudicated Claim Discovered",
+    "code": "UCD",
+    "deactiveDate": "2014-08-15T15:34:36-05:00"
+  },
+  {
+    "name": "FDC Excluded - requires INDPT VRFCTN of FTI",
+    "code": "FERIVF"
+  },
+  {
+    "name": "Administrative Decision Review - Level 1",
+    "code": "ADRL1"
+  },
+  {
+    "name": "Administrative Decision Review - Level 2",
+    "code": "ADRL2"
+  },
+  {
+    "name": "Rating Decision Review - Level 1",
+    "code": "RDR1"
+  },
+  {
+    "name": "Rating Decision Review - Level 2",
+    "code": "RDR2"
+  },
+  {
+    "name": "Local Mentor Review",
+    "code": "LMR"
+  },
+  {
+    "name": "Non-ADL Notification Letter",
+    "code": "NANL"
+  },
+  {
+    "name": "EP400 Merge Project",
+    "code": "EMP"
+  }
+]

--- a/scripts/setenv.sh
+++ b/scripts/setenv.sh
@@ -150,7 +150,9 @@ export POSTGRES_DOMAIN_CC_PW=domain_cc_password
 # Credentials for RabbitMQ and shared across containers
 export RABBITMQ_USERNAME=user
 export RABBITMQ_PASSWORD=bitnami
-
+# create basic auth token for RabbitMQ and export to github environment
+RABBITMQ_BASIC_AUTH="$(echo "${RABBITMQ_USERNAME}:${RABBITMQ_PASSWORD}" | base64)"
+export RABBITMQ_BASIC_AUTH
 ###
 ### Slack notifications ###
 

--- a/svc-bip-api/build.gradle
+++ b/svc-bip-api/build.gradle
@@ -52,6 +52,7 @@ testing {
         implementation "io.jsonwebtoken:jjwt-api:${jjwt_version}"
         implementation "io.jsonwebtoken:jjwt-impl:${jjwt_version}"
         implementation "io.jsonwebtoken:jjwt-jackson:${jjwt_version}"
+        implementation 'org.apache.commons:commons-lang3:3.12.0'
       }
     }
   }

--- a/svc-bip-api/src/integrationTest/java/gov/va/vro/bip/BaseIntegrationTest.java
+++ b/svc-bip-api/src/integrationTest/java/gov/va/vro/bip/BaseIntegrationTest.java
@@ -60,6 +60,9 @@ public class BaseIntegrationTest {
   @Value("${createClaimContentionsQueue}")
   protected String createClaimContentionsQueue;
 
+  @Value("${getSpecialIssueTypesQueue}")
+  protected String getSpecialIssueTypesQueue;
+
   @BeforeEach
   public void resetMock() {
     resetMockController.resetClaim(CLAIM_ID_200);

--- a/svc-bip-api/src/integrationTest/java/gov/va/vro/bip/SpecialIssueTypesTest.java
+++ b/svc-bip-api/src/integrationTest/java/gov/va/vro/bip/SpecialIssueTypesTest.java
@@ -8,15 +8,11 @@ import gov.va.vro.bip.model.contentions.GetSpecialIssueTypesResponse;
 import gov.va.vro.bip.model.contentions.ParameterlessBipRequest;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpStatus;
-import org.springframework.web.client.RestTemplate;
 
 import java.util.Arrays;
 
 public class SpecialIssueTypesTest extends BaseIntegrationTest {
-
-  @MockBean private RestTemplate restTemplate;
 
   @Test // g :svc-bip-api:integrationTest --tests
   // gov.va.vro.bip.SpecialIssueTypesTest.testGetSpecialIssueTypes_200

--- a/svc-bip-api/src/integrationTest/java/gov/va/vro/bip/SpecialIssueTypesTest.java
+++ b/svc-bip-api/src/integrationTest/java/gov/va/vro/bip/SpecialIssueTypesTest.java
@@ -1,0 +1,37 @@
+package gov.va.vro.bip;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import gov.va.vro.bip.model.BipPayloadRequest;
+import gov.va.vro.bip.model.contentions.GetSpecialIssueTypesResponse;
+import gov.va.vro.bip.model.contentions.ParameterlessBipRequest;
+import gov.va.vro.bip.service.MetricLoggerService;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Arrays;
+
+public class SpecialIssueTypesTest extends BaseIntegrationTest {
+
+  @MockBean private RestTemplate restTemplate;
+
+  @Test // g :svc-bip-api:integrationTest --tests gov.va.vro.bip.SpecialIssueTypesTest.testGetSpecialIssueTypes_200
+  void testGetSpecialIssueTypes_200() {
+    BipPayloadRequest request = ParameterlessBipRequest.builder().build();
+    GetSpecialIssueTypesResponse response = sendAndReceive(getSpecialIssueTypesQueue, request);
+    assertBaseResponseIs2xx(response, HttpStatus.OK);
+    var codeNamePairs = response.getCodeNamePairs();
+    assertTrue(codeNamePairs.length > 0, "Special Issue Types response was empty");
+    var emptyNameCount =
+        Arrays.stream(codeNamePairs).filter(pair -> StringUtils.isEmpty(pair.getName())).count();
+    assertEquals(emptyNameCount, 0, "Special Issue Types contained entries without names");
+    var emptyCodeCount =
+        Arrays.stream(codeNamePairs).filter(pair -> StringUtils.isEmpty(pair.getCode())).count();
+    assertEquals(emptyCodeCount, 0, "Special Issue Types contained entries without codes");
+  }
+}

--- a/svc-bip-api/src/integrationTest/java/gov/va/vro/bip/SpecialIssueTypesTest.java
+++ b/svc-bip-api/src/integrationTest/java/gov/va/vro/bip/SpecialIssueTypesTest.java
@@ -6,10 +6,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import gov.va.vro.bip.model.BipPayloadRequest;
 import gov.va.vro.bip.model.contentions.GetSpecialIssueTypesResponse;
 import gov.va.vro.bip.model.contentions.ParameterlessBipRequest;
-import gov.va.vro.bip.service.MetricLoggerService;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mock;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.client.RestTemplate;
@@ -20,7 +18,8 @@ public class SpecialIssueTypesTest extends BaseIntegrationTest {
 
   @MockBean private RestTemplate restTemplate;
 
-  @Test // g :svc-bip-api:integrationTest --tests gov.va.vro.bip.SpecialIssueTypesTest.testGetSpecialIssueTypes_200
+  @Test // g :svc-bip-api:integrationTest --tests
+  // gov.va.vro.bip.SpecialIssueTypesTest.testGetSpecialIssueTypes_200
   void testGetSpecialIssueTypes_200() {
     BipPayloadRequest request = ParameterlessBipRequest.builder().build();
     GetSpecialIssueTypesResponse response = sendAndReceive(getSpecialIssueTypesQueue, request);

--- a/svc-bip-api/src/main/java/gov/va/vro/bip/config/BipApiConfig.java
+++ b/svc-bip-api/src/main/java/gov/va/vro/bip/config/BipApiConfig.java
@@ -55,10 +55,6 @@ public class BipApiConfig {
   public BipApiProps getBipApiProps() {
     return new BipApiProps();
   }
-  // @Bean
-  // public BipApiProps getBipSpecialInterestService() {
-  //   return new SpecialIssueStateService();
-  // }
 
   private KeyStore getKeyStore(String base64, String password)
       throws KeyStoreException, IOException, NoSuchAlgorithmException, CertificateException {

--- a/svc-bip-api/src/main/java/gov/va/vro/bip/config/BipApiConfig.java
+++ b/svc-bip-api/src/main/java/gov/va/vro/bip/config/BipApiConfig.java
@@ -55,6 +55,10 @@ public class BipApiConfig {
   public BipApiProps getBipApiProps() {
     return new BipApiProps();
   }
+  // @Bean
+  // public BipApiProps getBipSpecialInterestService() {
+  //   return new SpecialIssueStateService();
+  // }
 
   private KeyStore getKeyStore(String base64, String password)
       throws KeyStoreException, IOException, NoSuchAlgorithmException, CertificateException {

--- a/svc-bip-api/src/main/java/gov/va/vro/bip/config/GetSpecialIssueCodesConfig.java
+++ b/svc-bip-api/src/main/java/gov/va/vro/bip/config/GetSpecialIssueCodesConfig.java
@@ -1,0 +1,36 @@
+package gov.va.vro.bip.config;
+
+import org.springframework.amqp.core.Binding;
+import org.springframework.amqp.core.BindingBuilder;
+import org.springframework.amqp.core.DirectExchange;
+import org.springframework.amqp.core.Queue;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class GetSpecialIssueCodesConfig {
+
+  final String queue;
+  final DirectExchange bipApiExchange;
+  final RabbitMqConfigProperties props;
+
+  public GetSpecialIssueCodesConfig(
+      @Value("${getSpecialIssueTypesQueue}") final String queue,
+      final DirectExchange bipApiExchange,
+      final RabbitMqConfigProperties props) {
+    this.queue = queue;
+    this.bipApiExchange = bipApiExchange;
+    this.props = props;
+  }
+
+  @Bean
+  Queue getSpecialIssueTypesQueue() {
+    return new Queue(queue, true, false, true, props.getDeadLetterQueueArgs());
+  }
+
+  @Bean
+  Binding getSpecialIssueTypesBinding() {
+    return BindingBuilder.bind(getSpecialIssueTypesQueue()).to(bipApiExchange).with(queue);
+  }
+}

--- a/svc-bip-api/src/main/java/gov/va/vro/bip/config/GetSpecialIssueCodesConfig.java
+++ b/svc-bip-api/src/main/java/gov/va/vro/bip/config/GetSpecialIssueCodesConfig.java
@@ -26,7 +26,7 @@ public class GetSpecialIssueCodesConfig {
 
   @Bean
   Queue getSpecialIssueTypesQueue() {
-    return new Queue(queue, true, false, true, props.getDeadLetterQueueArgs());
+    return new Queue(queue, true, false, true, props.getGlobalQueueArgs());
   }
 
   @Bean

--- a/svc-bip-api/src/main/java/gov/va/vro/bip/model/contentions/GetSpecialIssueTypesResponse.java
+++ b/svc-bip-api/src/main/java/gov/va/vro/bip/model/contentions/GetSpecialIssueTypesResponse.java
@@ -1,0 +1,40 @@
+package gov.va.vro.bip.model.contentions;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import gov.va.vro.bip.model.BipPayloadResponse;
+import lombok.Getter;
+import lombok.experimental.SuperBuilder;
+import lombok.extern.jackson.Jacksonized;
+import org.apache.commons.lang3.ArrayUtils;
+
+import java.util.function.Supplier;
+
+@Getter
+@Jacksonized
+@SuperBuilder(toBuilder = true)
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public class GetSpecialIssueTypesResponse extends BipPayloadResponse
+    implements Supplier<SpecialIssueType[]> {
+
+  // contemplated using ConcurrentInitializer<SpecialIssueType[]>, but have no need for the
+  // concurrency concern given present use case
+  private final Supplier<SpecialIssueType[]> allTypesSupplier;
+
+  public GetSpecialIssueTypesResponse(Supplier<SpecialIssueType[]> allTypesSupplier) {
+    super(BipPayloadResponse.builder());
+    this.allTypesSupplier = allTypesSupplier;
+  }
+
+  public SpecialIssueType[] get() {
+    if (ArrayUtils.isEmpty(codeNamePairs)) {
+      codeNamePairs = allTypesSupplier.get();
+    }
+    return codeNamePairs;
+  }
+
+  @JsonProperty("codeNamePairs")
+  private SpecialIssueType[] codeNamePairs;
+}

--- a/svc-bip-api/src/main/java/gov/va/vro/bip/model/contentions/GetSpecialIssueTypesResponse.java
+++ b/svc-bip-api/src/main/java/gov/va/vro/bip/model/contentions/GetSpecialIssueTypesResponse.java
@@ -7,33 +7,13 @@ import gov.va.vro.bip.model.BipPayloadResponse;
 import lombok.Getter;
 import lombok.experimental.SuperBuilder;
 import lombok.extern.jackson.Jacksonized;
-import org.apache.commons.lang3.ArrayUtils;
-
-import java.util.function.Supplier;
 
 @Getter
 @Jacksonized
 @SuperBuilder(toBuilder = true)
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
-public class GetSpecialIssueTypesResponse extends BipPayloadResponse
-    implements Supplier<SpecialIssueType[]> {
-
-  // contemplated using ConcurrentInitializer<SpecialIssueType[]>, but have no need for the
-  // concurrency concern given present use case
-  private final Supplier<SpecialIssueType[]> allTypesSupplier;
-
-  public GetSpecialIssueTypesResponse(Supplier<SpecialIssueType[]> allTypesSupplier) {
-    super(BipPayloadResponse.builder());
-    this.allTypesSupplier = allTypesSupplier;
-  }
-
-  public SpecialIssueType[] get() {
-    if (ArrayUtils.isEmpty(codeNamePairs)) {
-      codeNamePairs = allTypesSupplier.get();
-    }
-    return codeNamePairs;
-  }
+public class GetSpecialIssueTypesResponse extends BipPayloadResponse {
 
   @JsonProperty("codeNamePairs")
   private SpecialIssueType[] codeNamePairs;

--- a/svc-bip-api/src/main/java/gov/va/vro/bip/model/contentions/ParameterlessBipRequest.java
+++ b/svc-bip-api/src/main/java/gov/va/vro/bip/model/contentions/ParameterlessBipRequest.java
@@ -1,0 +1,15 @@
+package gov.va.vro.bip.model.contentions;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import gov.va.vro.bip.model.BipPayloadRequest;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+@NoArgsConstructor
+public class ParameterlessBipRequest implements BipPayloadRequest {}

--- a/svc-bip-api/src/main/java/gov/va/vro/bip/model/contentions/ParameterlessBipRequest.java
+++ b/svc-bip-api/src/main/java/gov/va/vro/bip/model/contentions/ParameterlessBipRequest.java
@@ -12,4 +12,4 @@ import lombok.NoArgsConstructor;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
 @NoArgsConstructor
-public class ParameterlessBipRequest implements BipPayloadRequest {}
+public final class ParameterlessBipRequest implements BipPayloadRequest {}

--- a/svc-bip-api/src/main/java/gov/va/vro/bip/model/contentions/SpecialIssueType.java
+++ b/svc-bip-api/src/main/java/gov/va/vro/bip/model/contentions/SpecialIssueType.java
@@ -1,0 +1,31 @@
+package gov.va.vro.bip.model.contentions;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+
+import java.time.OffsetDateTime;
+
+@Getter
+@Setter
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+@RequiredArgsConstructor
+@NoArgsConstructor(force = true)
+public class SpecialIssueType {
+  @JsonProperty("name")
+  private String name;
+
+  @JsonProperty("code")
+  private final String code;
+
+  @JsonProperty("description")
+  private String description;
+
+  @JsonProperty("deactiveDate")
+  private OffsetDateTime deactiveDate;
+}

--- a/svc-bip-api/src/main/java/gov/va/vro/bip/service/BipApiProps.java
+++ b/svc-bip-api/src/main/java/gov/va/vro/bip/service/BipApiProps.java
@@ -4,6 +4,7 @@ import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ClaimsBuilder;
 import io.jsonwebtoken.Jwts;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
@@ -18,6 +19,7 @@ import java.util.Date;
 @Getter
 @Setter
 @ConfigurationProperties(prefix = "bip")
+@NoArgsConstructor
 public class BipApiProps {
 
   static final String HTTPS = "https://";
@@ -49,6 +51,11 @@ public class BipApiProps {
     }
     return baseUrl + path;
   }
+
+  public String getAvailabilityUrl() {
+    return getClaimRequestUrl(BipApiService.SPECIAL_ISSUE_TYPES);
+  }
+
   /**
    * Creates common Jwt claims.
    *

--- a/svc-bip-api/src/main/java/gov/va/vro/bip/service/BipApiService.java
+++ b/svc-bip-api/src/main/java/gov/va/vro/bip/service/BipApiService.java
@@ -142,7 +142,7 @@ public class BipApiService implements IBipApiService {
   @Override
   public GetSpecialIssueTypesResponse getSpecialIssueTypes() {
     String url = bipApiProps.getClaimRequestUrl(SPECIAL_ISSUE_TYPES);
-    return makeRequest(url, HttpMethod.PUT, null, GetSpecialIssueTypesResponse.class);
+    return makeRequest(url, HttpMethod.GET, null, GetSpecialIssueTypesResponse.class);
   }
 
   @SuppressWarnings("unchecked")

--- a/svc-bip-api/src/main/java/gov/va/vro/bip/service/BipApiService.java
+++ b/svc-bip-api/src/main/java/gov/va/vro/bip/service/BipApiService.java
@@ -146,7 +146,7 @@ public class BipApiService implements IBipApiService {
   }
 
   @SuppressWarnings("unchecked")
-  protected <T extends BipPayloadResponse> T makeRequest(
+  private <T extends BipPayloadResponse> T makeRequest(
       String url, HttpMethod method, Object requestBody, Class<T> expectedResponse) {
 
     try {

--- a/svc-bip-api/src/main/java/gov/va/vro/bip/service/BipApiService.java
+++ b/svc-bip-api/src/main/java/gov/va/vro/bip/service/BipApiService.java
@@ -8,6 +8,7 @@ import gov.va.vro.bip.model.claim.GetClaimResponse;
 import gov.va.vro.bip.model.contentions.CreateClaimContentionsRequest;
 import gov.va.vro.bip.model.contentions.CreateClaimContentionsResponse;
 import gov.va.vro.bip.model.contentions.GetClaimContentionsResponse;
+import gov.va.vro.bip.model.contentions.GetSpecialIssueTypesResponse;
 import gov.va.vro.bip.model.contentions.UpdateClaimContentionsRequest;
 import gov.va.vro.bip.model.contentions.UpdateClaimContentionsResponse;
 import gov.va.vro.bip.model.lifecycle.PutClaimLifecycleRequest;
@@ -41,21 +42,14 @@ import java.util.Objects;
 import javax.crypto.spec.SecretKeySpec;
 
 /**
- * BIP claim API service.
- *
- * @author warren @Date 10/31/22
+ * BipApiService offers an implementation of IBipApiService as an extension of the BIP Claims REST
+ * API Service
  */
 @Service
-@RequiredArgsConstructor
 @Slf4j
 @ComponentScan("gov.va.vro.metricslogging")
+@RequiredArgsConstructor
 public class BipApiService implements IBipApiService {
-  static final String CLAIM_DETAILS = "/claims/%s";
-  static final String CANCEL_CLAIM = "/claims/%s/cancel";
-  static final String TEMP_STATION_OF_JURISDICTION = "/claims/%s/temporary_station_of_jurisdiction";
-  static final String CLAIM_LIFECYCLE_STATUS = "/claims/%s/lifecycle_status";
-  static final String CONTENTION = "/claims/%s/contentions";
-  static final String SPECIAL_ISSUE_TYPES = "/contentions/special_issue_types";
 
   @Qualifier("bipCERestTemplate")
   @NonNull
@@ -67,6 +61,13 @@ public class BipApiService implements IBipApiService {
 
   final IMetricLoggerService metricLogger;
   public static final String METRICS_PREFIX = "vro_bip";
+
+  static final String CLAIM_DETAILS = "/claims/%s";
+  static final String CANCEL_CLAIM = "/claims/%s/cancel";
+  static final String TEMP_STATION_OF_JURISDICTION = "/claims/%s/temporary_station_of_jurisdiction";
+  static final String CLAIM_LIFECYCLE_STATUS = "/claims/%s/lifecycle_status";
+  static final String CONTENTION = "/claims/%s/contentions";
+  static final String SPECIAL_ISSUE_TYPES = "/contentions/special_issue_types";
 
   @Override
   public GetClaimResponse getClaimDetails(long claimId) {
@@ -138,8 +139,14 @@ public class BipApiService implements IBipApiService {
         url, HttpMethod.PUT, requestBody, PutTempStationOfJurisdictionResponse.class);
   }
 
+  @Override
+  public GetSpecialIssueTypesResponse getSpecialIssueTypes() {
+    String url = bipApiProps.getClaimRequestUrl(SPECIAL_ISSUE_TYPES);
+    return makeRequest(url, HttpMethod.PUT, null, GetSpecialIssueTypesResponse.class);
+  }
+
   @SuppressWarnings("unchecked")
-  private <T extends BipPayloadResponse> T makeRequest(
+  protected <T extends BipPayloadResponse> T makeRequest(
       String url, HttpMethod method, Object requestBody, Class<T> expectedResponse) {
 
     try {
@@ -232,8 +239,8 @@ public class BipApiService implements IBipApiService {
    * @return true if the API responds with OK status and response.
    */
   public boolean isApiFunctioning() {
-    String url = bipApiProps.getClaimRequestUrl(SPECIAL_ISSUE_TYPES);
-    log.info("Call {} to get special_issue_types", url);
+    String url = bipApiProps.getAvailabilityUrl();
+    log.info("Call {} to confirm service availability", url);
 
     HttpHeaders headers = getBipHeader();
     HttpEntity<Void> httpEntity = new HttpEntity<>(headers);

--- a/svc-bip-api/src/main/java/gov/va/vro/bip/service/IBipApiService.java
+++ b/svc-bip-api/src/main/java/gov/va/vro/bip/service/IBipApiService.java
@@ -6,6 +6,7 @@ import gov.va.vro.bip.model.claim.GetClaimResponse;
 import gov.va.vro.bip.model.contentions.CreateClaimContentionsRequest;
 import gov.va.vro.bip.model.contentions.CreateClaimContentionsResponse;
 import gov.va.vro.bip.model.contentions.GetClaimContentionsResponse;
+import gov.va.vro.bip.model.contentions.GetSpecialIssueTypesResponse;
 import gov.va.vro.bip.model.contentions.UpdateClaimContentionsRequest;
 import gov.va.vro.bip.model.contentions.UpdateClaimContentionsResponse;
 import gov.va.vro.bip.model.lifecycle.PutClaimLifecycleRequest;
@@ -83,4 +84,13 @@ public interface IBipApiService {
    */
   PutTempStationOfJurisdictionResponse putTempStationOfJurisdiction(
       PutTempStationOfJurisdictionRequest request);
+
+  /**
+   * Gets a list of all special issue types.
+   *
+   * @param request request
+   * @return response
+   * @throws BipException error occurs
+   */
+  GetSpecialIssueTypesResponse getSpecialIssueTypes();
 }

--- a/svc-bip-api/src/main/java/gov/va/vro/bip/service/RabbitMqController.java
+++ b/svc-bip-api/src/main/java/gov/va/vro/bip/service/RabbitMqController.java
@@ -8,6 +8,7 @@ import gov.va.vro.bip.model.contentions.CreateClaimContentionsRequest;
 import gov.va.vro.bip.model.contentions.CreateClaimContentionsResponse;
 import gov.va.vro.bip.model.contentions.GetClaimContentionsRequest;
 import gov.va.vro.bip.model.contentions.GetClaimContentionsResponse;
+import gov.va.vro.bip.model.contentions.GetSpecialIssueTypesResponse;
 import gov.va.vro.bip.model.contentions.UpdateClaimContentionsRequest;
 import gov.va.vro.bip.model.contentions.UpdateClaimContentionsResponse;
 import gov.va.vro.bip.model.lifecycle.PutClaimLifecycleRequest;
@@ -69,5 +70,13 @@ public class RabbitMqController {
   PutTempStationOfJurisdictionResponse putTempStationOfJurisdictionEndpoint(
       @Valid @Payload PutTempStationOfJurisdictionRequest request) {
     return service.putTempStationOfJurisdiction(request);
+  }
+
+  @RabbitListener(queues = "getSpecialIssueTypesQueue", errorHandler = "bipRequestErrorHandler")
+  GetSpecialIssueTypesResponse getSpecialIssueTypesEndpoint() {
+    var response = service.getSpecialIssueTypes();
+    // force lazy loading to occur prior to serializing the response and shipping it back to
+    response.get();
+    return response;
   }
 }

--- a/svc-bip-api/src/main/java/gov/va/vro/bip/service/RabbitMqController.java
+++ b/svc-bip-api/src/main/java/gov/va/vro/bip/service/RabbitMqController.java
@@ -74,9 +74,6 @@ public class RabbitMqController {
 
   @RabbitListener(queues = "getSpecialIssueTypesQueue", errorHandler = "bipRequestErrorHandler")
   GetSpecialIssueTypesResponse getSpecialIssueTypesEndpoint() {
-    var response = service.getSpecialIssueTypes();
-    // force lazy loading to occur prior to serializing the response and shipping it back to
-    response.get();
-    return response;
+    return service.getSpecialIssueTypes();
   }
 }

--- a/svc-bip-api/src/main/resources/application.yaml
+++ b/svc-bip-api/src/main/resources/application.yaml
@@ -39,6 +39,7 @@ getClaimContentionsQueue: getClaimContentionsQueue
 createClaimContentionsQueue: createClaimContentionsQueue
 updateClaimContentionsQueue: updateClaimContentionsQueue
 putTempStationOfJurisdictionQueue: putTempStationOfJurisdictionQueue
+getSpecialIssueTypesQueue: getSpecialIssueTypesQueue
 exchangeName: bipApiExchange
 deadLetterQueueName: vroDeadLetterQueue
 deadLetterExchangeName: vro.dlx

--- a/svc-bip-api/src/test/java/gov/va/vro/bip/service/BipApiServiceTest.java
+++ b/svc-bip-api/src/test/java/gov/va/vro/bip/service/BipApiServiceTest.java
@@ -66,33 +66,30 @@ import java.util.Objects;
 @ExtendWith(MockitoExtension.class)
 @Slf4j
 public class BipApiServiceTest {
-  private static final ObjectMapper MAPPER = new ObjectMapper();
-  private static final long GOOD_CLAIM_ID = 9666959L;
-  private static final long NOT_FOUND_CLAIM_ID = 9234567L;
-  private static final long INTERNAL_SERVER_ERROR_CLAIM_ID = 9345678L;
-  private static final String RESPONSE_500 = "bip-test-data/response_500.json";
-  private static final String CONTENTION_RESPONSE_200 =
-      "bip-test-data/contention_response_200.json";
-  private static final String CONTENTION_RESPONSE_201 =
-      "bip-test-data/contention_response_201.json";
-  private static final String CLAIM_RESPONSE_404 = "bip-test-data/claim_response_404.json";
-  private static final String CLAIM_RESPONSE_200 = "bip-test-data/claim_response_200.json";
-  private static final String CLAIM_DETAILS = "/claims/%s";
-  private static final String CLAIM_LIFECYCLE_STATUS = "/claims/%s/lifecycle_status";
-  private static final String CANCEL_CLAIM = "/claims/%s/cancel";
-  private static final String CONTENTION = "/claims/%s/contentions";
-  private static final String TEMP_STATION_OF_JURISDICTION =
-      "/claims/%s/temporary_station_of_jurisdiction";
-  private static final String HTTPS = "https://";
-  private static final String CLAIM_URL = "claims.bip.va.gov";
-  private static final String CLAIM_SECRET = "thesecretissecurenowthatitislongenough2184vnrwma";
-  private static final String CLAIM_USERID = "userid";
-  private static final String CLAIM_ISSUER = "issuer";
-  private static final String STATION_ID = "280";
-  private static final String APP_ID = "bip";
+  static final ObjectMapper MAPPER = new ObjectMapper();
+  static final long GOOD_CLAIM_ID = 9666959L;
+  static final long NOT_FOUND_CLAIM_ID = 9234567L;
+  static final long INTERNAL_SERVER_ERROR_CLAIM_ID = 9345678L;
+  static final String RESPONSE_500 = "bip-test-data/response_500.json";
+  static final String CONTENTION_RESPONSE_200 = "bip-test-data/contention_response_200.json";
+  static final String CONTENTION_RESPONSE_201 = "bip-test-data/contention_response_201.json";
+  static final String CLAIM_RESPONSE_404 = "bip-test-data/claim_response_404.json";
+  static final String CLAIM_RESPONSE_200 = "bip-test-data/claim_response_200.json";
+  static final String CLAIM_DETAILS = "/claims/%s";
+  static final String CLAIM_LIFECYCLE_STATUS = "/claims/%s/lifecycle_status";
+  static final String CANCEL_CLAIM = "/claims/%s/cancel";
+  static final String CONTENTION = "/claims/%s/contentions";
+  static final String TEMP_STATION_OF_JURISDICTION = "/claims/%s/temporary_station_of_jurisdiction";
+  static final String HTTPS = "https://";
+  static final String CLAIM_URL = "claims.bip.va.gov";
+  static final String CLAIM_SECRET = "thesecretissecurenowthatitislongenough2184vnrwma";
+  static final String CLAIM_USERID = "userid";
+  static final String CLAIM_ISSUER = "issuer";
+  static final String STATION_ID = "280";
+  static final String APP_ID = "bip";
   // TODO get sample response
-  private static final String API_RESPONSE_200 = "{\"mock response\"}";
-  private static final String SPECIAL_ISSUE_TYPES = "/contentions/special_issue_types";
+  static final String API_RESPONSE_200 = "{\"mock response\"}";
+  static final String SPECIAL_ISSUE_TYPES = "/contentions/special_issue_types";
 
   private BipApiService service;
 

--- a/svc-bip-api/src/test/java/gov/va/vro/bip/service/BipApiServiceTest.java
+++ b/svc-bip-api/src/test/java/gov/va/vro/bip/service/BipApiServiceTest.java
@@ -66,30 +66,32 @@ import java.util.Objects;
 @ExtendWith(MockitoExtension.class)
 @Slf4j
 public class BipApiServiceTest {
-  static final ObjectMapper MAPPER = new ObjectMapper();
-  static final long GOOD_CLAIM_ID = 9666959L;
-  static final long NOT_FOUND_CLAIM_ID = 9234567L;
-  static final long INTERNAL_SERVER_ERROR_CLAIM_ID = 9345678L;
-  static final String RESPONSE_500 = "bip-test-data/response_500.json";
-  static final String CONTENTION_RESPONSE_200 = "bip-test-data/contention_response_200.json";
-  static final String CONTENTION_RESPONSE_201 = "bip-test-data/contention_response_201.json";
-  static final String CLAIM_RESPONSE_404 = "bip-test-data/claim_response_404.json";
-  static final String CLAIM_RESPONSE_200 = "bip-test-data/claim_response_200.json";
-  static final String CLAIM_DETAILS = "/claims/%s";
-  static final String CLAIM_LIFECYCLE_STATUS = "/claims/%s/lifecycle_status";
-  static final String CANCEL_CLAIM = "/claims/%s/cancel";
-  static final String CONTENTION = "/claims/%s/contentions";
-  static final String TEMP_STATION_OF_JURISDICTION = "/claims/%s/temporary_station_of_jurisdiction";
-  static final String HTTPS = "https://";
-  static final String CLAIM_URL = "claims.bip.va.gov";
-  static final String CLAIM_SECRET = "thesecretissecurenowthatitislongenough2184vnrwma";
-  static final String CLAIM_USERID = "userid";
-  static final String CLAIM_ISSUER = "issuer";
-  static final String STATION_ID = "280";
-  static final String APP_ID = "bip";
-  // TODO get sample response
-  static final String API_RESPONSE_200 = "{\"mock response\"}";
-  static final String SPECIAL_ISSUE_TYPES = "/contentions/special_issue_types";
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+  private static final long GOOD_CLAIM_ID = 9666959L;
+  private static final long NOT_FOUND_CLAIM_ID = 9234567L;
+  private static final long INTERNAL_SERVER_ERROR_CLAIM_ID = 9345678L;
+  private static final String RESPONSE_500 = "bip-test-data/response_500.json";
+  private static final String CONTENTION_RESPONSE_200 =
+      "bip-test-data/contention_response_200.json";
+  private static final String CONTENTION_RESPONSE_201 =
+      "bip-test-data/contention_response_201.json";
+  private static final String CLAIM_RESPONSE_404 = "bip-test-data/claim_response_404.json";
+  private static final String CLAIM_RESPONSE_200 = "bip-test-data/claim_response_200.json";
+  private static final String CLAIM_DETAILS = "/claims/%s";
+  private static final String CLAIM_LIFECYCLE_STATUS = "/claims/%s/lifecycle_status";
+  private static final String CANCEL_CLAIM = "/claims/%s/cancel";
+  private static final String CONTENTION = "/claims/%s/contentions";
+  private static final String TEMP_STATION_OF_JURISDICTION =
+      "/claims/%s/temporary_station_of_jurisdiction";
+  private static final String HTTPS = "https://";
+  private static final String CLAIM_URL = "claims.bip.va.gov";
+  private static final String CLAIM_SECRET = "thesecretissecurenowthatitislongenough2184vnrwma";
+  private static final String CLAIM_USERID = "userid";
+  private static final String CLAIM_ISSUER = "issuer";
+  private static final String STATION_ID = "280";
+  private static final String APP_ID = "bip";
+  private static final String API_RESPONSE_200 = "{\"mock response\"}";
+  private static final String SPECIAL_ISSUE_TYPES = "/contentions/special_issue_types";
 
   private BipApiService service;
 

--- a/svc-bip-api/src/test/java/gov/va/vro/bip/service/BipApiServiceTest.java
+++ b/svc-bip-api/src/test/java/gov/va/vro/bip/service/BipApiServiceTest.java
@@ -23,6 +23,7 @@ import gov.va.vro.bip.model.contentions.CreateClaimContentionsRequest;
 import gov.va.vro.bip.model.contentions.CreateClaimContentionsResponse;
 import gov.va.vro.bip.model.contentions.ExistingContention;
 import gov.va.vro.bip.model.contentions.GetClaimContentionsResponse;
+import gov.va.vro.bip.model.contentions.GetSpecialIssueTypesResponse;
 import gov.va.vro.bip.model.contentions.UpdateClaimContentionsRequest;
 import gov.va.vro.bip.model.contentions.UpdateClaimContentionsResponse;
 import gov.va.vro.bip.model.lifecycle.PutClaimLifecycleRequest;
@@ -92,6 +93,8 @@ public class BipApiServiceTest {
   private static final String APP_ID = "bip";
   private static final String API_RESPONSE_200 = "{\"mock response\"}";
   private static final String SPECIAL_ISSUE_TYPES = "/contentions/special_issue_types";
+  private static final String SPECIAL_ISSUE_TYPES_RESPONSE_200 =
+      "bip-test-data/special_issue_types_response_200.json";
 
   private BipApiService service;
 
@@ -117,6 +120,10 @@ public class BipApiServiceTest {
   private String formatClaimUrl(String format, Long claimId) {
     String baseUrl = HTTPS + CLAIM_URL;
     return baseUrl + String.format(format, claimId);
+  }
+
+  private String formatUrl(String url) {
+    return HTTPS + CLAIM_URL + url;
   }
 
   private static String getTestData(String dataFile) throws Exception {
@@ -487,6 +494,40 @@ public class BipApiServiceTest {
       Exception ex =
           Assertions.assertThrows(
               test.ex.getClass(), () -> service.putTempStationOfJurisdiction(request));
+      assertResponseExceptionWithStatus(ex, test.status);
+      verifyMetricIsLoggedForExceptions(test);
+    }
+  }
+
+  @Nested
+  public class GetSpecialIssueTypes {
+    @Test
+    public void testGetSpecialIssueTypes_200() throws Exception {
+      mock2xxResponse(
+          HttpMethod.GET,
+          SPECIAL_ISSUE_TYPES,
+          HttpStatus.OK,
+          GetSpecialIssueTypesResponse.class,
+          SPECIAL_ISSUE_TYPES_RESPONSE_200);
+
+      GetSpecialIssueTypesResponse result = service.getSpecialIssueTypes();
+      assertResponseIsSuccess(result, HttpStatus.OK);
+      verifyMetricsAreLogged();
+    }
+
+    @ParameterizedTest(name = "testGetSpecialIssueTypes_{0}")
+    @EnumSource(
+        value = TestCase.class,
+        names = {"DOWNSTREAM_ERROR", "BIP_INTERNAL"})
+    public void testGetSpecialIssueTypes_non2xx(TestCase test) throws Exception {
+      mockExceptionResponse(
+          test.ex,
+          formatUrl(SPECIAL_ISSUE_TYPES),
+          HttpMethod.GET,
+          GetSpecialIssueTypesResponse.class);
+
+      Exception ex =
+          Assertions.assertThrows(test.ex.getClass(), () -> service.getSpecialIssueTypes());
       assertResponseExceptionWithStatus(ex, test.status);
       verifyMetricIsLoggedForExceptions(test);
     }

--- a/svc-bip-api/src/test/resources/bip-test-data/special_issue_types_response_200.json
+++ b/svc-bip-api/src/test/resources/bip-test-data/special_issue_types_response_200.json
@@ -1,0 +1,13 @@
+{
+  "codeNamePairs": [
+    {
+      "name": "Active Code",
+      "code": "AC"
+    },
+    {
+      "name": "Deactive Code",
+      "code": "AC",
+      "deactiveDate": "2000-01-01T00:00:00-00:00"
+    }
+  ]
+}


### PR DESCRIPTION
The EE team has requested that the special_issue_types endpoint be exposed via a new rabbitmq queue on the bip exchange. This PR introduces many of the necessary components towards making that endpoint available for EE consumption. Accompanying the real bip data, is a mock implementation that can be used for local development.

## What was the problem?
special_issue_types were needed.

Associated tickets or Slack threads:
- #3213

## How does this fix it?[^1]
Adds the special_issue_types endpoint to all the necessary components of the bip service.

## How to test this PR
- submit a rabbitmq request to the newly create getSpecialIssueTypesQueue


[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
