### PR TITLE
fix syntax error in helm deployment.yaml

### DIFF
--- a/helm/domain-xample/templates/deployment.yaml
+++ b/helm/domain-xample/templates/deployment.yaml
@@ -28,7 +28,7 @@ spec:
             {{- include "vro.commonEnvVars" . | nindent 12 }}
             {{- include "vro.dbClient.envVars" . | nindent 12 }}
             {{- include "vro.mqClient.envVars" . | nindent 12 }}
-            {{ - include "vro.datadog.envVars" . | nindent 12 }}
+            {{- include "vro.datadog.envVars" . | nindent 12 }}
           resources:
             requests:
               cpu: 150m

--- a/helm/svc-bie-kafka/templates/deployment.yaml
+++ b/helm/svc-bie-kafka/templates/deployment.yaml
@@ -27,7 +27,7 @@ spec:
           env:
             {{- include "vro.commonEnvVars" . | nindent 12 }}
             {{- include "vro.mqClient.envVars" . | nindent 12 }}
-            {{ - include "vro.datadog.envVars" . | nindent 12 }}
+            {{- include "vro.datadog.envVars" . | nindent 12 }}
             {{- range $envVar := .Values.biekafka.envVars }}
             - name: {{ $envVar.name }}
               value: {{ default $envVar.value $envVar.default }}


### PR DESCRIPTION
## What was the problem?
The helm chart deployments for `svc-bie-kafka` and `xample-workflows` contain a syntax error, causing deployments to fail. The bug was introduced in https://github.com/department-of-veterans-affairs/abd-vro/pull/3267. 

## How does this fix it? 

Fixes the syntax error.

Tested by running `helm lint --values values.yaml --values ../_shared/values.yaml` for both cases.