### PR TITLE
update datadog metric prefixes to be app-specific

### DIFF
--- a/domain-xample/xample-workflows/src/main/java/gov/va/vro/routes/xample/BieXampleRoutes.java
+++ b/domain-xample/xample-workflows/src/main/java/gov/va/vro/routes/xample/BieXampleRoutes.java
@@ -15,6 +15,8 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 @ComponentScan("gov.va.vro.metricslogging")
 public class BieXampleRoutes {
+
+  private static final String METRICS_PREFIX = "vro_xample_workflows";
   private final DbHelper dbHelper;
   private final ObjectMapper objectMapper;
   private final IMetricLoggerService metricLogger;
@@ -33,15 +35,17 @@ public class BieXampleRoutes {
   public void handleMessage(BieMessagePayload payload) {
     try {
       metricLogger.submitCount(
-          IMetricLoggerService.METRIC.REQUEST_START, metricTagsSaveContentionEvent);
+          METRICS_PREFIX, IMetricLoggerService.METRIC.REQUEST_START, metricTagsSaveContentionEvent);
       long transactionStartTime = System.nanoTime();
 
       dbHelper.saveContentionEvent(payload);
 
       metricLogger.submitRequestDuration(
-          transactionStartTime, System.nanoTime(), metricTagsSaveContentionEvent);
+          METRICS_PREFIX, transactionStartTime, System.nanoTime(), metricTagsSaveContentionEvent);
       metricLogger.submitCount(
-          IMetricLoggerService.METRIC.RESPONSE_COMPLETE, metricTagsSaveContentionEvent);
+          METRICS_PREFIX,
+          IMetricLoggerService.METRIC.RESPONSE_COMPLETE,
+          metricTagsSaveContentionEvent);
 
       log.info("Saved Contention Event to DB");
       payload.setStatus(200);
@@ -61,7 +65,9 @@ public class BieXampleRoutes {
       log.error("FailedMessageEventBody: " + jsonBody);
 
       metricLogger.submitCount(
-          IMetricLoggerService.METRIC.RESPONSE_ERROR, metricTagsSaveContentionEvent);
+          METRICS_PREFIX,
+          IMetricLoggerService.METRIC.RESPONSE_ERROR,
+          metricTagsSaveContentionEvent);
     } catch (JsonProcessingException jsonException) {
       log.error("Error converting failed message to JSON", jsonException);
     } catch (Exception exception) {

--- a/domain-xample/xample-workflows/src/test/java/gov/va/vro/routes/xample/BieXampleRoutesTest.java
+++ b/domain-xample/xample-workflows/src/test/java/gov/va/vro/routes/xample/BieXampleRoutesTest.java
@@ -47,12 +47,21 @@ class BieXampleRoutesTest {
 
     // Verify metrics logging
     verify(metricLoggerService, times(1))
-        .submitCount(IMetricLoggerService.METRIC.REQUEST_START, metricTagsSaveContentionEvent);
+        .submitCount(
+            "vro_xample_workflows",
+            IMetricLoggerService.METRIC.REQUEST_START,
+            metricTagsSaveContentionEvent);
     verify(metricLoggerService, times(1))
         .submitRequestDuration(
-            ArgumentMatchers.anyLong(), ArgumentMatchers.anyLong(), ArgumentMatchers.any());
+            ArgumentMatchers.anyString(),
+            ArgumentMatchers.anyLong(),
+            ArgumentMatchers.anyLong(),
+            ArgumentMatchers.any());
     verify(metricLoggerService, times(1))
-        .submitCount(IMetricLoggerService.METRIC.RESPONSE_COMPLETE, metricTagsSaveContentionEvent);
+        .submitCount(
+            "vro_xample_workflows",
+            IMetricLoggerService.METRIC.RESPONSE_COMPLETE,
+            metricTagsSaveContentionEvent);
   }
 
   @Test
@@ -77,7 +86,10 @@ class BieXampleRoutesTest {
 
     // Verify metrics logging
     verify(metricLoggerService, times(1))
-        .submitCount(IMetricLoggerService.METRIC.RESPONSE_ERROR, metricTagsSaveContentionEvent);
+        .submitCount(
+            "vro_xample_workflows",
+            IMetricLoggerService.METRIC.RESPONSE_ERROR,
+            metricTagsSaveContentionEvent);
   }
 
   private BieMessagePayload createSamplePayload() {

--- a/shared/lib-metrics/src/main/java/gov/va/vro/metricslogging/IMetricLoggerService.java
+++ b/shared/lib-metrics/src/main/java/gov/va/vro/metricslogging/IMetricLoggerService.java
@@ -10,17 +10,26 @@ public interface IMetricLoggerService {
 
   ArrayList<String> getTagsForSubmission(String[] customTags);
 
-  MetricsPayload createMetricsPayload(@NotNull METRIC metric, double value, String[] tags);
+  MetricsPayload createMetricsPayload(
+      @NotNull String metricPrefix, @NotNull METRIC metric, double value, String[] tags);
 
-  void submitCount(@NotNull METRIC metric, String[] tags);
+  void submitCount(@NotNull String metricPrefix, @NotNull METRIC metric, String[] tags);
 
-  void submitCount(@NotNull METRIC metric, double value, String[] tags);
+  void submitCount(
+      @NotNull String metricPrefix, @NotNull METRIC metric, double value, String[] tags);
 
   DistributionPointsPayload createDistributionPointsPayload(
-      @NotNull METRIC metric, double timestamp, double value, String[] tags);
+      @NotNull String metricPrefix,
+      @NotNull METRIC metric,
+      double timestamp,
+      double value,
+      String[] tags);
 
   void submitRequestDuration(
-      long requestStartNanoseconds, long requestEndNanoseconds, String[] tags);
+      @NotNull String metricPrefix,
+      long requestStartNanoseconds,
+      long requestEndNanoseconds,
+      String[] tags);
 
   enum METRIC {
     REQUEST_START,

--- a/shared/lib-metrics/src/main/java/gov/va/vro/metricslogging/MetricLoggerService.java
+++ b/shared/lib-metrics/src/main/java/gov/va/vro/metricslogging/MetricLoggerService.java
@@ -17,8 +17,6 @@ import java.util.*;
 @Conditional(NonLocalEnvironmentCondition.class)
 public class MetricLoggerService implements IMetricLoggerService {
 
-  private static final String SERVICE_TAG = "service:vro-svc-bip-api";
-
   private final MetricsApi metricsApi;
 
   public static double getTimestamp() {
@@ -42,7 +40,6 @@ public class MetricLoggerService implements IMetricLoggerService {
     // a "key:value" format, while not required, can be convenient with querying metrics in the
     // datadog dashboard
     ArrayList<String> tags = new ArrayList<>();
-    tags.add(SERVICE_TAG);
     if (customTags != null) {
       tags.addAll(Arrays.asList(customTags));
     }

--- a/shared/lib-metrics/src/main/java/gov/va/vro/metricslogging/NoopMetricLoggerService.java
+++ b/shared/lib-metrics/src/main/java/gov/va/vro/metricslogging/NoopMetricLoggerService.java
@@ -2,6 +2,7 @@ package gov.va.vro.metricslogging;
 
 import com.datadog.api.client.v1.model.DistributionPointsPayload;
 import com.datadog.api.client.v1.model.MetricsPayload;
+import jakarta.validation.constraints.NotNull;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Service;
 
@@ -17,23 +18,28 @@ public class NoopMetricLoggerService implements IMetricLoggerService {
   }
 
   @Override
-  public MetricsPayload createMetricsPayload(METRIC metric, double value, String[] tags) {
+  public MetricsPayload createMetricsPayload(
+      @NotNull String metricPrefix, METRIC metric, double value, String[] tags) {
     return new MetricsPayload();
   }
 
   @Override
-  public void submitCount(METRIC metric, String[] tags) {}
+  public void submitCount(@NotNull String metricPrefix, METRIC metric, String[] tags) {}
 
   @Override
-  public void submitCount(METRIC metric, double value, String[] tags) {}
+  public void submitCount(
+      @NotNull String metricPrefix, METRIC metric, double value, String[] tags) {}
 
   @Override
   public DistributionPointsPayload createDistributionPointsPayload(
-      METRIC metric, double timestamp, double value, String[] tags) {
+      @NotNull String metricPrefix, METRIC metric, double timestamp, double value, String[] tags) {
     return new DistributionPointsPayload();
   }
 
   @Override
   public void submitRequestDuration(
-      long requestStartNanoseconds, long requestEndNanoseconds, String[] tags) {}
+      @NotNull String metricPrefix,
+      long requestStartNanoseconds,
+      long requestEndNanoseconds,
+      String[] tags) {}
 }

--- a/svc-bip-api/src/main/java/gov/va/vro/bip/service/BipApiService.java
+++ b/svc-bip-api/src/main/java/gov/va/vro/bip/service/BipApiService.java
@@ -66,6 +66,7 @@ public class BipApiService implements IBipApiService {
   final ObjectMapper mapper;
 
   final IMetricLoggerService metricLogger;
+  public static final String METRICS_PREFIX = "vro_bip";
 
   @Override
   public GetClaimResponse getClaimDetails(long claimId) {
@@ -146,6 +147,7 @@ public class BipApiService implements IBipApiService {
       HttpEntity<Object> httpEntity = new HttpEntity<>(requestBody, getBipHeader());
       log.info("event=requestSent url={} method={}", url, method);
       metricLogger.submitCount(
+          METRICS_PREFIX,
           IMetricLoggerService.METRIC.REQUEST_START,
           new String[] {
             String.format("expectedResponse:%s", expectedResponse.getSimpleName()),
@@ -163,6 +165,7 @@ public class BipApiService implements IBipApiService {
           method,
           bipResponse.getStatusCode().value());
       metricLogger.submitRequestDuration(
+          METRICS_PREFIX,
           requestStartTime,
           System.nanoTime(),
           new String[] {
@@ -179,6 +182,7 @@ public class BipApiService implements IBipApiService {
       }
 
       metricLogger.submitCount(
+          METRICS_PREFIX,
           IMetricLoggerService.METRIC.RESPONSE_COMPLETE,
           new String[] {
             String.format("expectedResponse:%s", expectedResponse.getSimpleName()),
@@ -208,6 +212,7 @@ public class BipApiService implements IBipApiService {
           e.getMessage());
 
       metricLogger.submitCount(
+          METRICS_PREFIX,
           IMetricLoggerService.METRIC.RESPONSE_ERROR,
           new String[] {
             String.format("expectedResponse:%s", expectedResponse.getSimpleName()),

--- a/svc-bip-api/src/main/java/gov/va/vro/bip/service/BipRequestErrorHandler.java
+++ b/svc-bip-api/src/main/java/gov/va/vro/bip/service/BipRequestErrorHandler.java
@@ -67,6 +67,7 @@ public class BipRequestErrorHandler implements RabbitListenerErrorHandler {
       }
 
       metricLoggerService.submitCount(
+          BipApiService.METRICS_PREFIX,
           MetricLoggerService.METRIC.LISTENER_ERROR,
           new String[] {
             "event:statusCodeException",
@@ -97,6 +98,7 @@ public class BipRequestErrorHandler implements RabbitListenerErrorHandler {
                   .build());
 
       metricLoggerService.submitCount(
+          BipApiService.METRICS_PREFIX,
           MetricLoggerService.METRIC.LISTENER_ERROR,
           new String[] {
             "event:unexpectedError",

--- a/svc-bip-api/src/main/java/gov/va/vro/bip/service/InvalidPayloadRejectingFatalExceptionStrategy.java
+++ b/svc-bip-api/src/main/java/gov/va/vro/bip/service/InvalidPayloadRejectingFatalExceptionStrategy.java
@@ -32,6 +32,7 @@ public class InvalidPayloadRejectingFatalExceptionStrategy implements FatalExcep
           ((ListenerExecutionFailedException) t).getFailedMessage());
 
       metricLoggerService.submitCount(
+          BipApiService.METRICS_PREFIX,
           MetricLoggerService.METRIC.MESSAGE_CONVERSION_ERROR,
           new String[] {
             "event:fatalMessageConversionError",


### PR DESCRIPTION
## What was the problem?
Datadog metrics emitted by `xample-workflows` and `svc-bie-kafka` are being attributed to `svc-bip-api`.

`svc-bip-api` has been emitting metrics under the `vro_bip` metric prefix (eg `vro_bip.REQUEST_STARTED`).
In applying the metrics code to other apps (#3267), the metric prefix was hardcoded to `vro_bip` (🙀 ).

This PR updates the metrics interface so that the desired metric prefix is specified, with `svc-bie-kafka` using metric prefix `vro_bie_kafka` and `xample-workflows` using metric prefix `vro_xample_workflows`. 
