### PR TITLE
Set DL queue declaration to false on BIP startup.

### DIFF
--- a/svc-bip-api/src/main/java/gov/va/vro/bip/config/RabbitMqConfig.java
+++ b/svc-bip-api/src/main/java/gov/va/vro/bip/config/RabbitMqConfig.java
@@ -84,9 +84,7 @@ public class RabbitMqConfig implements RabbitListenerConfigurer {
 
   @Bean
   Queue deadLetterQueue() {
-    log.info(
-        "Creating dead letter queue with name={}",
-        props.getDeadLetterQueueName());
+    log.info("Creating dead letter queue with name={}", props.getDeadLetterQueueName());
     return QueueBuilder.durable(props.getDeadLetterQueueName()).build();
   }
 

--- a/svc-bip-api/src/main/java/gov/va/vro/bip/config/RabbitMqConfig.java
+++ b/svc-bip-api/src/main/java/gov/va/vro/bip/config/RabbitMqConfig.java
@@ -85,10 +85,9 @@ public class RabbitMqConfig implements RabbitListenerConfigurer {
   @Bean
   Queue deadLetterQueue() {
     log.info(
-        "Creating dead letter queue with name={} and properties={}",
-        props.getDeadLetterQueueName(),
-        props.getDeadLetterQueueArgs());
-    return QueueBuilder.durable(props.getDeadLetterQueueName()).autoDelete().build();
+        "Creating dead letter queue with name={}",
+        props.getDeadLetterQueueName());
+    return QueueBuilder.durable(props.getDeadLetterQueueName()).build();
   }
 
   @Bean


### PR DESCRIPTION
<!-- Ensure the PR title reflects the feature or bug name -->

## What was the problem?
<!-- brief description of how things worked before this PR -->
Inconsistent queue declaration crashes bip service. 

Observed in the app logs:
> ```2024-08-14T22:00:09.275Z ERROR 1 --- [20.223.225:5672] o.s.a.r.c.CachingConnectionFactory       : Shutdown Signal: channel error; protocol method: #method<channel.close>(reply-code=406, reply-text=PRECONDITION_FAILED - inequivalent arg 'auto_delete' for queue 'vroDeadLetterQueue' in vhost '/': received 'true' but current is 'false', class-id=50, method-id=10)```

Associated tickets or Slack threads:
- Follows #3238

## How does this fix it?[^1]
<!-- description of how things will work after this PR -->
Removes autodelete from queue declaration.

## How to test this PR
Unit, Integration, and End 2 End tests.

[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
