### PR TITLE
Set DLQ Max length

### DIFF
--- a/shared/lib-rabbitmq-connector/src/main/java/gov/va/vro/camel/MessageQueueConfiguration.java
+++ b/shared/lib-rabbitmq-connector/src/main/java/gov/va/vro/camel/MessageQueueConfiguration.java
@@ -33,6 +33,7 @@ public class MessageQueueConfiguration {
   private final String SAVE_TO_DB_PREFIX = "saveToDB-";
   private final String QUEUE_MESSAGES_DLQ = "vroDeadLetterQueue";
   private final String DLX_EXCHANGE_MESSAGES = "vro.dlx";
+  private final Long DEAD_LETTER_MAX_LENGTH = 1000L;
   private final Map<String, Object> DLQ_ARGS =
       Map.of("x-dead-letter-exchange", DLX_EXCHANGE_MESSAGES);
 
@@ -171,7 +172,7 @@ public class MessageQueueConfiguration {
 
   @Bean
   Queue deadLetterQueue() {
-    return QueueBuilder.durable(QUEUE_MESSAGES_DLQ).build();
+    return QueueBuilder.durable(QUEUE_MESSAGES_DLQ).maxLength(DEAD_LETTER_MAX_LENGTH).build();
   }
 
   @Bean

--- a/svc-bip-api/src/main/java/gov/va/vro/bip/config/RabbitMqConfig.java
+++ b/svc-bip-api/src/main/java/gov/va/vro/bip/config/RabbitMqConfig.java
@@ -85,7 +85,9 @@ public class RabbitMqConfig implements RabbitListenerConfigurer {
   @Bean
   Queue deadLetterQueue() {
     log.info("Creating dead letter queue with name={}", props.getDeadLetterQueueName());
-    return QueueBuilder.durable(props.getDeadLetterQueueName()).build();
+    return QueueBuilder.durable(props.getDeadLetterQueueName())
+        .maxLength(props.getDeadLetterMaxQueueLength())
+        .build();
   }
 
   @Bean

--- a/svc-bip-api/src/main/java/gov/va/vro/bip/config/RabbitMqConfigProperties.java
+++ b/svc-bip-api/src/main/java/gov/va/vro/bip/config/RabbitMqConfigProperties.java
@@ -35,6 +35,9 @@ public class RabbitMqConfigProperties {
   @Value("${deadLetterExchangeName:vro.dlx}")
   private String deadLetterExchangeName;
 
+  @Value("${deadLetterMaxQueueLength:1000}")
+  private Long deadLetterMaxQueueLength;
+
   Map<String, Object> getDeadLetterQueueArgs() {
     return Map.ofEntries(entry("x-dead-letter-exchange", deadLetterExchangeName));
   }

--- a/svc-bip-api/src/main/resources/application.yaml
+++ b/svc-bip-api/src/main/resources/application.yaml
@@ -42,6 +42,7 @@ putTempStationOfJurisdictionQueue: putTempStationOfJurisdictionQueue
 exchangeName: bipApiExchange
 deadLetterQueueName: vroDeadLetterQueue
 deadLetterExchangeName: vro.dlx
+deadLetterMaxQueueLength: 1000
 
 # Actuator for health check, liveness, and readiness
 management:


### PR DESCRIPTION
## What was the problem?
We don't know how many messages will get placed on the dead letter queue. Setting a limit will prevent RabbitMQ from running out of resources in the event that there are too many messages to store. 

Associated tickets or Slack threads:
- https://app.zenhub.com/workspaces/vro-team-6557e67173391c000e1409f3/issues/gh/department-of-veterans-affairs/abd-vro/3238
- Discussed this solution in a Slack huddle

## How does this fix it?[^1]
Sets the max length argument on the dead letter queue

