### PR TITLE
update springframework:spring-web to 6.1.12

### DIFF
--- a/gradle-plugins/src/main/groovy/shared.java.vro-dep-constraints.gradle
+++ b/gradle-plugins/src/main/groovy/shared.java.vro-dep-constraints.gradle
@@ -9,10 +9,10 @@ plugins {
 
 ext {
     mapstruct_version="1.4.2.Final"
-    spring_framework_version="6.1.+"
+    spring_framework_version="6.1.12"
     snakeyaml_version="2.2"
     jackson_databind_version="2.16"
-    spring_core_version="6.1.+"
+    spring_core_version="6.1.12"
 }
 
 afterEvaluate {
@@ -30,7 +30,7 @@ dependencies {
         // for starter-bom
         implementation "org.springframework.boot:spring-boot-dependencies:${spring_boot_version}"
         implementation "org.springframework:spring-webmvc:${spring_framework_version}"
-        implementation 'org.springframework:spring-web:6.1.+'
+        implementation 'org.springframework:spring-web:6.1.12'
         implementation "org.springframework:spring-beans:${spring_framework_version}"
         implementation "org.springframework:spring-core:${spring_core_version}"
         implementation "io.github.classgraph:classgraph:4.8.149"

--- a/gradle-plugins/src/main/groovy/shared.java.vro-dep-constraints.gradle
+++ b/gradle-plugins/src/main/groovy/shared.java.vro-dep-constraints.gradle
@@ -9,10 +9,10 @@ plugins {
 
 ext {
     mapstruct_version="1.4.2.Final"
-    spring_framework_version="6.1.10"
+    spring_framework_version="6.1.+"
     snakeyaml_version="2.2"
     jackson_databind_version="2.16"
-    spring_core_version="6.1.10"
+    spring_core_version="6.1.+"
 }
 
 afterEvaluate {
@@ -30,7 +30,7 @@ dependencies {
         // for starter-bom
         implementation "org.springframework.boot:spring-boot-dependencies:${spring_boot_version}"
         implementation "org.springframework:spring-webmvc:${spring_framework_version}"
-        implementation 'org.springframework:spring-web:6.1.6'
+        implementation 'org.springframework:spring-web:6.1.+'
         implementation "org.springframework:spring-beans:${spring_framework_version}"
         implementation "org.springframework:spring-core:${spring_core_version}"
         implementation "io.github.classgraph:classgraph:4.8.149"


### PR DESCRIPTION
<!-- Ensure the PR title reflects the feature or bug name -->

## What was the problem?
Snyk detected vulnerabilities in the versions of `spring-web` we're using. This is blocking SecRel signatures. 

More details in https://github.com/department-of-veterans-affairs/abd-vro-internal/security/code-scanning. As noted from those alerts, the remediation path: 
> Upgrade org.springframework:spring-web to version 5.3.38, 6.0.23, 6.1.12 or higher.

## How does this fix it?
Sets `spring-web` to 6.1.12.


## How to test this PR
Verify SecRel passes.  Achieved in https://github.com/department-of-veterans-affairs/abd-vro-internal/actions/runs/10410646547 (conducted on [76583e6](https://github.com/department-of-veterans-affairs/abd-vro-internal/commit/76583e613ae4a2484dfa8bf1ba4febd221bfba90)). 


## other approaches
Relax the version constraint to use the latest patch version, eg
`spring_core_version="6.1.+"` and ` implementation 'org.springframework:spring-web:6.1.+'`  (visible in [f8501d3](https://github.com/department-of-veterans-affairs/abd-vro/pull/3313/commits/f8501d379e9f3ebe22684a1795e205b8651b16b8))

I chose not to use that approach because:
1) that notation doesn't seem a common convention in our gradle files 
2) personal bias for explicit pins 
