### PR TITLE
Move DLQ to creation via policy

### DIFF
--- a/domain-ee/ee-ep-merge-app/end_to_end/conftest.py
+++ b/domain-ee/ee-ep-merge-app/end_to_end/conftest.py
@@ -11,7 +11,6 @@ from src.python_src.config import BIP_EXCHANGE
 from src.python_src.schema.merge_job import JobState
 from src.python_src.schema.response import GeneralResponse
 from src.python_src.service.job_store import JOB_STORE
-from src.python_src.config import EXCHANGES, ClientName
 
 
 @pytest.fixture(scope='session')
@@ -21,10 +20,9 @@ def lifecycle_endpoint():
         app_id='EP_MERGE',
         config={},
         exchange_properties=ExchangeProperties(name=BIP_EXCHANGE, passive_declare=False),
-        request_queue_properties=QueueProperties(name='putClaimLifecycleStatusQueue', passive_declare=False,
-                                                 arguments={'x-dead-letter-exchange': EXCHANGES[ClientName.BIP_DEAD_LETTER]}),
+        request_queue_properties=QueueProperties(name='putClaimLifecycleStatusQueue', passive_declare=False),
         request_routing_key='putClaimLifecycleStatusQueue',
-        reply_queue_properties=QueueProperties(name='putClaimLifecycleStatusResponseQueue', auto_delete=False, passive_declare=False),
+        reply_queue_properties=QueueProperties(name='putClaimLifecycleStatusResponseQueue', passive_declare=False),
         reply_routing_key='putClaimLifecycleStatusResponseQueue',
         request_message_ttl=0,
         response_max_latency=3,

--- a/domain-ee/ee-ep-merge-app/integration/conftest.py
+++ b/domain-ee/ee-ep-merge-app/integration/conftest.py
@@ -50,15 +50,11 @@ def cancel_claim_endpoint():
 
 @pytest.fixture(autouse=True, scope='session')
 def add_claim_note_endpoint():
-    return create_mq_endpoint_no_dlq(ClientName.BGS_ADD_CLAIM_NOTE)
+    return create_mq_endpoint(ClientName.BGS_ADD_CLAIM_NOTE)
 
-
-def create_mq_endpoint_no_dlq(name):
-    return MqEndpoint(name, EXCHANGES[name], QUEUES[name], REPLY_QUEUES[name])
 
 def create_mq_endpoint(name):
-    arguments = {'x-dead-letter-exchange': EXCHANGES[ClientName.BIP_DEAD_LETTER]}
-    return MqEndpoint(name, EXCHANGES[name], QUEUES[name], REPLY_QUEUES[name], arguments)
+    return MqEndpoint(name, EXCHANGES[name], QUEUES[name], REPLY_QUEUES[name])
 
 
 @pytest_asyncio.fixture(autouse=True, scope='session')

--- a/domain-ee/ee-ep-merge-app/integration/mq_endpoint.py
+++ b/domain-ee/ee-ep-merge-app/integration/mq_endpoint.py
@@ -11,13 +11,13 @@ class MqEndpointConsumerException(Exception):
 
 
 class MqEndpoint:
-    def __init__(self, name, exchange, req_queue, response_queue, arguments = {}):
+    def __init__(self, name, exchange, req_queue, response_queue):
         self.name = name
         self.index = 0
         self.auto_response_files = []
 
         exchange_props = ExchangeProperties(name=exchange, auto_delete=True, passive_declare=False)
-        queue_props = QueueProperties(name=req_queue, auto_delete=True, passive_declare=False, arguments=arguments)
+        queue_props = QueueProperties(name=req_queue, auto_delete=True, passive_declare=False)
         self.consumer = async_consumer.AsyncConsumer(
             exchange_properties=exchange_props, queue_properties=queue_props, routing_key=req_queue, reply_callback=self._on_message
         )

--- a/domain-ee/ee-ep-merge-app/src/python_src/config.py
+++ b/domain-ee/ee-ep-merge-app/src/python_src/config.py
@@ -19,12 +19,10 @@ class ClientName(str, Enum):
     UPDATE_CLAIM_CONTENTIONS = 'updateClaimContentionsClient'
     CANCEL_CLAIM = 'cancelClaimClient'
     BGS_ADD_CLAIM_NOTE = 'addClaimNoteClient'
-    BIP_DEAD_LETTER = 'vroDeadLetterQueue'
 
 
 BIP_EXCHANGE = 'bipApiExchange'
 BGS_EXCHANGE = 'bgs-api'
-DLQ_EXCHANGE = 'vro.dlx'
 
 EXCHANGES = {
     ClientName.GET_CLAIM: os.environ.get('BIP_API_EXCHANGE') or BIP_EXCHANGE,
@@ -34,7 +32,6 @@ EXCHANGES = {
     ClientName.UPDATE_CLAIM_CONTENTIONS: os.environ.get('BIP_API_EXCHANGE') or BIP_EXCHANGE,
     ClientName.CANCEL_CLAIM: os.environ.get('BIP_API_EXCHANGE') or BIP_EXCHANGE,
     ClientName.BGS_ADD_CLAIM_NOTE: os.environ.get('BGS_API_EXCHANGE') or BGS_EXCHANGE,
-    ClientName.BIP_DEAD_LETTER: os.environ.get('BIP_API_DLQ_EXCHANGE') or DLQ_EXCHANGE,
 }
 
 QUEUES = {

--- a/domain-ee/ee-ep-merge-app/src/python_src/service/hoppy_service.py
+++ b/domain-ee/ee-ep-merge-app/src/python_src/service/hoppy_service.py
@@ -3,7 +3,6 @@ import asyncio
 from config import EXCHANGES, QUEUES, REPLY_QUEUES, ClientName, config
 from hoppy.async_hoppy_client import AsyncHoppyClient, RetryableAsyncHoppyClient
 from hoppy.hoppy_properties import ExchangeProperties, QueueProperties
-from typing import Dict
 
 
 class HoppyService:
@@ -22,12 +21,8 @@ class HoppyService:
         exchange = EXCHANGES[name]
         req_queue = QUEUES[name]
         reply_queue = REPLY_QUEUES[name]
-        arguments: Dict[str, str] = {}
-        if name != ClientName.BGS_ADD_CLAIM_NOTE:
-            arguments = {'x-dead-letter-exchange': EXCHANGES[ClientName.BIP_DEAD_LETTER]}
-
         exchange_props = ExchangeProperties(name=exchange, passive_declare=False)
-        request_queue_props = QueueProperties(name=req_queue, passive_declare=False, arguments=arguments)
+        request_queue_props = QueueProperties(name=req_queue, passive_declare=False)
         reply_queue_props = QueueProperties(name=reply_queue, passive_declare=False)
         client = RetryableAsyncHoppyClient(
             name=name.value,

--- a/rabbitmq/Dockerfile
+++ b/rabbitmq/Dockerfile
@@ -2,6 +2,7 @@
 FROM bitnami/rabbitmq:3.12
 
 COPY rabbitmq.conf /tmp/rabbitmq.conf
+COPY definitions.json /tmp/definitions.json
 
 USER root
 

--- a/rabbitmq/Dockerfile
+++ b/rabbitmq/Dockerfile
@@ -9,6 +9,9 @@ USER root
 RUN chown 1001 /tmp/rabbitmq.conf  \
     && chmod g+w /tmp/rabbitmq.conf
 
+RUN chown 1001 /tmp/definitions.json  \
+    && chmod g+w /tmp/definitions.json
+
 USER 1001
 
 ## Copy the entrypoint script

--- a/rabbitmq/src/main/resources/definitions.json
+++ b/rabbitmq/src/main/resources/definitions.json
@@ -4,6 +4,22 @@
       "name": "/"
     }
   ],
+  "users": [
+    {
+      "name": "${RABBITMQ_USER_VALUE}",
+      "password": "${RABBITMQ_PASSWORD}",
+      "tags": "administrator"
+    }
+  ],
+  "permissions": [
+    {
+      "user": "${RABBITMQ_USER_VALUE}",
+      "vhost": "/",
+      "configure": ".*",
+      "write": ".*",
+      "read": ".*"
+    }
+  ],
   "policies": [
     {
       "vhost": "/",

--- a/rabbitmq/src/main/resources/definitions.json
+++ b/rabbitmq/src/main/resources/definitions.json
@@ -1,0 +1,19 @@
+{
+  "vhosts": [
+    {
+      "name": "/"
+    }
+  ],
+  "policies": [
+    {
+      "vhost": "/",
+      "name": "DLX",
+      "pattern": ".*",
+      "apply-to": "queues",
+      "definition": {
+        "dead-letter-exchange": "vro.dlx"
+      },
+      "priority": 0
+    }
+  ]
+}

--- a/rabbitmq/src/main/resources/entrypoint.sh
+++ b/rabbitmq/src/main/resources/entrypoint.sh
@@ -20,5 +20,6 @@ sed -i "s/^default_pass .*/default_pass = ${RABBITMQ_PASSWORD}/" $CONFIG_FILE
 
 
 cp /tmp/rabbitmq.conf /etc/rabbitmq/rabbitmq.conf
+cp /tmp/definitions.json /etc/rabbitmq/definitions.json
 
 exec /opt/bitnami/scripts/rabbitmq/entrypoint.sh /opt/bitnami/scripts/rabbitmq/run.sh

--- a/rabbitmq/src/main/resources/entrypoint.sh
+++ b/rabbitmq/src/main/resources/entrypoint.sh
@@ -13,10 +13,16 @@ fi
 
 # Define the path to your configuration file
 CONFIG_FILE="/tmp/rabbitmq.conf"
+DEFINITIONS_FILE="/tmp/definitions.json"
 
 # Replace lines in the config file
 sed -i "s/^default_user .*/default_user = $RABBITMQ_USER_VALUE/" $CONFIG_FILE
 sed -i "s/^default_pass .*/default_pass = ${RABBITMQ_PASSWORD}/" $CONFIG_FILE
+
+# Replace values in the definitions file with the values from the environment variables
+sed -i -e "s/\${RABBITMQ_USER_VALUE}/$RABBITMQ_USER_VALUE/g" \
+    -e "s/\${RABBITMQ_PASSWORD}/${RABBITMQ_PASSWORD}/g" \
+    $DEFINITIONS_FILE
 
 
 cp /tmp/rabbitmq.conf /etc/rabbitmq/rabbitmq.conf

--- a/rabbitmq/src/main/resources/rabbitmq.conf
+++ b/rabbitmq/src/main/resources/rabbitmq.conf
@@ -18,9 +18,12 @@ listeners.tcp.default = 5672
 ## Management
 management.tcp.ip = 0.0.0.0
 management.tcp.port = 15672
-management.load_definitions = /etc/rabbitmq/definitions.json
+
 loopback_users.user = false
 
 ## Resource limits
 # Set a free disk space limit relative to total available RAM
 disk_free_limit.absolute = 1GB
+
+## Advanced Configuration
+load_definitions = /etc/rabbitmq/definitions.json

--- a/rabbitmq/src/main/resources/rabbitmq.conf
+++ b/rabbitmq/src/main/resources/rabbitmq.conf
@@ -18,6 +18,7 @@ listeners.tcp.default = 5672
 ## Management
 management.tcp.ip = 0.0.0.0
 management.tcp.port = 15672
+management.load_definitions = /etc/rabbitmq/definitions.json
 loopback_users.user = false
 
 ## Resource limits

--- a/svc-bip-api/src/main/java/gov/va/vro/bip/config/CancelClaimConfig.java
+++ b/svc-bip-api/src/main/java/gov/va/vro/bip/config/CancelClaimConfig.java
@@ -26,7 +26,7 @@ public class CancelClaimConfig {
 
   @Bean
   Queue cancelClaimQueue() {
-    return new Queue(cancelClaimQueue, true, false, true, props.getDeadLetterQueueArgs());
+    return new Queue(cancelClaimQueue, true, false, true, props.getGlobalQueueArgs());
   }
 
   @Bean

--- a/svc-bip-api/src/main/java/gov/va/vro/bip/config/CreateClaimContentionsConfig.java
+++ b/svc-bip-api/src/main/java/gov/va/vro/bip/config/CreateClaimContentionsConfig.java
@@ -26,8 +26,7 @@ public class CreateClaimContentionsConfig {
 
   @Bean
   Queue createClaimContentionsQueue() {
-    return new Queue(
-        createClaimContentionsQueue, true, false, true, props.getDeadLetterQueueArgs());
+    return new Queue(createClaimContentionsQueue, true, false, true, props.getGlobalQueueArgs());
   }
 
   @Bean

--- a/svc-bip-api/src/main/java/gov/va/vro/bip/config/GetClaimContentionsConfig.java
+++ b/svc-bip-api/src/main/java/gov/va/vro/bip/config/GetClaimContentionsConfig.java
@@ -26,7 +26,7 @@ public class GetClaimContentionsConfig {
 
   @Bean
   Queue getClaimContentionsQueue() {
-    return new Queue(getClaimContentionsQueue, true, false, true, props.getDeadLetterQueueArgs());
+    return new Queue(getClaimContentionsQueue, true, false, true, props.getGlobalQueueArgs());
   }
 
   @Bean

--- a/svc-bip-api/src/main/java/gov/va/vro/bip/config/GetClaimDetailsConfig.java
+++ b/svc-bip-api/src/main/java/gov/va/vro/bip/config/GetClaimDetailsConfig.java
@@ -9,13 +9,13 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
-public class ConfigForGetClaimDetails {
+public class GetClaimDetailsConfig {
 
   final String getClaimDetailsQueue;
   final DirectExchange bipApiExchange;
   final RabbitMqConfigProperties props;
 
-  public ConfigForGetClaimDetails(
+  public GetClaimDetailsConfig(
       @Value("${getClaimDetailsQueue}") final String getClaimDetailsQueue,
       final DirectExchange bipApiExchange,
       final RabbitMqConfigProperties props) {
@@ -26,7 +26,7 @@ public class ConfigForGetClaimDetails {
 
   @Bean
   Queue getClaimDetailsQueue() {
-    return new Queue(getClaimDetailsQueue, true, false, true, props.getDeadLetterQueueArgs());
+    return new Queue(getClaimDetailsQueue, true, false, true, props.getGlobalQueueArgs());
   }
 
   @Bean

--- a/svc-bip-api/src/main/java/gov/va/vro/bip/config/PutTempStationOfJurisdictionConfig.java
+++ b/svc-bip-api/src/main/java/gov/va/vro/bip/config/PutTempStationOfJurisdictionConfig.java
@@ -27,7 +27,7 @@ public class PutTempStationOfJurisdictionConfig {
   @Bean
   Queue putTempStationOfJurisdictionQueue() {
     return new Queue(
-        putTempStationOfJurisdictionQueue, true, false, true, props.getDeadLetterQueueArgs());
+        putTempStationOfJurisdictionQueue, true, false, true, props.getGlobalQueueArgs());
   }
 
   @Bean

--- a/svc-bip-api/src/main/java/gov/va/vro/bip/config/RabbitMqConfig.java
+++ b/svc-bip-api/src/main/java/gov/va/vro/bip/config/RabbitMqConfig.java
@@ -4,14 +4,18 @@ import gov.va.vro.bip.service.InvalidPayloadRejectingFatalExceptionStrategy;
 import gov.va.vro.metricslogging.IMetricLoggerService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.amqp.core.*;
+import org.springframework.amqp.core.Binding;
+import org.springframework.amqp.core.BindingBuilder;
+import org.springframework.amqp.core.DirectExchange;
+import org.springframework.amqp.core.FanoutExchange;
+import org.springframework.amqp.core.Queue;
+import org.springframework.amqp.core.QueueBuilder;
 import org.springframework.amqp.rabbit.annotation.RabbitListenerConfigurer;
 import org.springframework.amqp.rabbit.config.SimpleRabbitListenerContainerFactory;
 import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 import org.springframework.amqp.rabbit.listener.ConditionalRejectingErrorHandler;
 import org.springframework.amqp.rabbit.listener.RabbitListenerEndpointRegistrar;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
@@ -28,9 +32,6 @@ public class RabbitMqConfig implements RabbitListenerConfigurer {
   private final RabbitMqConfigProperties props;
   private final JacksonConfig jacksonConfig;
   private final IMetricLoggerService metricLoggerService;
-
-  @Value("${exchangeName}")
-  String exchangeName;
 
   public SimpleRabbitListenerContainerFactory rabbitListenerContainerFactory() {
     SimpleRabbitListenerContainerFactory factory = new SimpleRabbitListenerContainerFactory();
@@ -73,7 +74,7 @@ public class RabbitMqConfig implements RabbitListenerConfigurer {
 
   @Bean
   DirectExchange bipApiExchange() {
-    return new DirectExchange(exchangeName, true, true);
+    return new DirectExchange(props.getExchangeName(), true, true);
   }
 
   @Bean

--- a/svc-bip-api/src/main/java/gov/va/vro/bip/config/RabbitMqConfigProperties.java
+++ b/svc-bip-api/src/main/java/gov/va/vro/bip/config/RabbitMqConfigProperties.java
@@ -1,7 +1,5 @@
 package gov.va.vro.bip.config;
 
-import static java.util.Map.entry;
-
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -9,6 +7,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 
+import java.util.Collections;
 import java.util.Map;
 
 @Data
@@ -29,13 +28,16 @@ public class RabbitMqConfigProperties {
   @Value("${spring.rabbitmq.password:bitnami}")
   private String password;
 
+  @Value("${exchangeName}")
+  String exchangeName;
+
   @Value("${deadLetterQueueName:vroDeadLetterQueue}")
   private String deadLetterQueueName;
 
   @Value("${deadLetterExchangeName:vro.dlx}")
   private String deadLetterExchangeName;
 
-  Map<String, Object> getDeadLetterQueueArgs() {
-    return Map.ofEntries(entry("x-dead-letter-exchange", deadLetterExchangeName));
+  Map<String, Object> getGlobalQueueArgs() {
+    return Collections.emptyMap();
   }
 }

--- a/svc-bip-api/src/main/java/gov/va/vro/bip/config/UpdateClaimContentionsConfig.java
+++ b/svc-bip-api/src/main/java/gov/va/vro/bip/config/UpdateClaimContentionsConfig.java
@@ -26,8 +26,7 @@ public class UpdateClaimContentionsConfig {
 
   @Bean
   Queue updateClaimContentionsQueue() {
-    return new Queue(
-        updateClaimContentionsQueue, true, false, true, props.getDeadLetterQueueArgs());
+    return new Queue(updateClaimContentionsQueue, true, false, true, props.getGlobalQueueArgs());
   }
 
   @Bean

--- a/svc-bip-api/src/main/java/gov/va/vro/bip/config/UpdateClaimStatusConfig.java
+++ b/svc-bip-api/src/main/java/gov/va/vro/bip/config/UpdateClaimStatusConfig.java
@@ -26,8 +26,7 @@ public class UpdateClaimStatusConfig {
 
   @Bean
   Queue putClaimLifecycleStatusQueue() {
-    return new Queue(
-        putClaimLifecycleStatusQueue, true, false, true, props.getDeadLetterQueueArgs());
+    return new Queue(putClaimLifecycleStatusQueue, true, false, true, props.getGlobalQueueArgs());
   }
 
   @Bean


### PR DESCRIPTION
<!-- Ensure the PR title reflects the feature or bug name -->

## What was the problem?
<!-- brief description of how things worked before this PR -->
Dead Letter configuration is recommended through RabbitMQ policies to avoid difficulties with deployment.

Associated tickets or Slack threads:
- #2758 
- [Slack Thread](https://dsva.slack.com/archives/C04QLHM9LR0/p1724083218694299)

## How does this fix it?[^1]
<!-- description of how things will work after this PR -->
Removes previous implementation from EP Merge and `svc-bip-api` declaring DL via optional queue declarations. Adds RabbitMQ startup policies declaring DL policy. 

## How to test this PR
- All unit/integration/end2end tests pass
- Deploy RabbitMQ, `svc-bip-api` and EP Merge
  - View in RabbitMQ console that the queues have the policy DLX applied. 


[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
