### PR TITLE
Add max-length to global queue policy. Renamed Policy.

### DIFF
--- a/rabbitmq/src/main/resources/definitions.json
+++ b/rabbitmq/src/main/resources/definitions.json
@@ -23,11 +23,12 @@
   "policies": [
     {
       "vhost": "/",
-      "name": "DLX",
+      "name": "VRO-GLOBAL-QUEUES",
       "pattern": ".*",
       "apply-to": "queues",
       "definition": {
-        "dead-letter-exchange": "vro.dlx"
+        "dead-letter-exchange": "vro.dlx",
+        "max-length": 1000
       },
       "priority": 0
     }


### PR DESCRIPTION
<!-- Ensure the PR title reflects the feature or bug name -->

## What was the problem?
<!-- brief description of how things worked before this PR -->
There is no max queue size for any of the queues in RabbitMQ, thus risking an overflow event if any of the services are down for an extended period of time.

Associated tickets or Slack threads:
- #3327

## How does this fix it?[^1]
<!-- description of how things will work after this PR -->
Sets the max-length via policy on rabbitmq launch. Any resource (queue/exchange) may only have a single policy definition, so the max-length and dead letter exchange properties are set by the same global queue policy. See info on [combining policies](https://www.rabbitmq.com/docs/parameters#combining-policy-definitions). 

## How to test this PR
- In docker: 
  - Run svc-bip-api and rabbitmq services
  - Verify the queues created have the policy setting the max-length property and the dead letter queue via the rest api or rabbitmq admin console

[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
