### PR TITLE
Automate enablement of prometheus plugin for Rabbitmq pod

### DIFF
--- a/helm/platform/charts/rabbitmq/templates/deployment.yaml
+++ b/helm/platform/charts/rabbitmq/templates/deployment.yaml
@@ -17,7 +17,7 @@ spec:
       {{- include "vro.imagePullSecrets" . | nindent 6 }}
       containers:
         - name: rabbitmq{{ include "vro.containerSuffix" . }}
-          image: ghcr.io/department-of-veterans-affairs/abd-vro-internal/vro-rabbitmq:{{ .Values.imageTag }}
+          image: {{ include "vro.imageRegistryPath" . }}vro-rabbitmq:{{ .Values.imageTag }}
           env:
             - name: RABBITMQ_USERNAME
               {{- include "vro.valueFromSecret.rabbitmqUser" . | nindent 14 }}
@@ -38,5 +38,9 @@ spec:
           # This volume is available for RabbitMQ messages to be persisted
           volumeMounts:
             {{- include "vro.volumeMounts.tracking" . | nindent 12 }}
+          lifecycle:
+            postStart:
+              exec:
+                command: ["/bin/sh", "-c", "rabbitmq-plugins enable rabbitmq_prometheus"]
       volumes:
         {{- include "vro.volumes.tracking" . | nindent 8 }}


### PR DESCRIPTION
Updated rabbitmq deployment.yaml file to enable prometheus plugin to help us see data on datadog. The issue was when the pod was created/restarted this plugin wasn't enabled and had to be done manually. This solution has been tested in dev pod and the plugin is enabled during restart/creation of the rabbitmq pod. 

Ticket: https://github.com/department-of-veterans-affairs/abd-vro/issues/3144

###How to Test?
1. Delete the pod (**ONLY in Dev**) OR restart the rabbitmq deployment
2. kubectl exec -it Rabbitmq-Pod-Name -- rabbitmq-plugins list

