### PR TITLE
EP Merge: Add externalUserId and externalKey to requests to BIP endpoints

### DIFF
--- a/domain-ee/ee-ep-merge-app/src/python_src/service/ep_merge_machine.py
+++ b/domain-ee/ee-ep-merge-app/src/python_src/service/ep_merge_machine.py
@@ -32,6 +32,8 @@ from statemachine import State, StateMachine
 from util.contentions_util import ContentionsUtil
 from util.metric_logger import CountMetric, DistributionMetric, distribution, increment
 
+EP_MERGE_BIP_EXTERNAL_KEY = 'vetsApi526ClaimID-PostSubmitEpMerge'
+
 ERROR_STATES_TO_LOG_METRICS = [
     JobState.CANCEL_EP400_CLAIM,
     JobState.CANCEL_CLAIM_FAILED_REVERT_TEMP_STATION_OF_JURISDICTION,
@@ -495,6 +497,10 @@ class EpMergeMachine(StateMachine):  # type: ignore[misc]
     ) -> GeneralResponse:
         attempts = 0
         while True:
+            if hoppy_client.name is not ClientName.BGS_ADD_CLAIM_NOTE.value:
+                request_body['externalUserId'] = self.job.ep400_claim_id
+                request_body['externalKey'] = EP_MERGE_BIP_EXTERNAL_KEY
+
             response = await hoppy_client.make_request(request_id, request_body)
             model = response_type.model_validate(response)
             if model.status_code not in expected_statuses:


### PR DESCRIPTION
<!-- Ensure the PR title reflects the feature or bug name -->

## What was the problem?
<!-- brief description of how things worked before this PR -->
`svc-bip-api` has been updated to properly include the keys `externalUserId` and `externalKey` in the JWT claims, and this PR populates that information in the request to `svc-bip-api`.

Associated tickets or Slack threads:
- #3448 
- Follows #3462

## How does this fix it?[^1]
<!-- description of how things will work after this PR -->
It was decided to set the `externalUserId` to the EP400 claim ID and the `externalKey` to `vetsApi526ClaimID-PostSubmitEpMerge`. These key-value pairs are sent in the requests to the `svc-bip-api` so that it can use them when creating the JWT to authorize downstream BIP Claims API requests. 

## How to test this PR
- pull code
- Unit Test:
  - from /domain-ee/ee-ep-merge-app run `pytest`
- Integration Tests:
  - run [base platform](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Docker-Compose#platform-base)
  - from /domain-ee/ee-ep-merge-app run `pytest ./integration`
- End to End tests:
  - run this [CI](https://github.com/department-of-veterans-affairs/abd-vro/actions/workflows/ee-ep-merge-end-to-end.yml) action to verify successful integration test
  - run end to end tests locally:
    - `export BIP_CLAIM_URL=mock-bip-claims-api:20300`
    - run bgs and bip services and mocks:
      - `COMPOSE_PROFILES=“all” ./gradlew dockerComposeUp`
      - `COMPOSE_PROFILES="bip,bgs" ./gradlew -p mocks :dockerComposeUp`
    - `./gradlew :domain-ee:ee-ep-merge-app:endToEndTest`

[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
