### PR TITLE
Remove duplicate claim from jwt.

### DIFF
--- a/svc-bip-api/src/main/java/gov/va/vro/bip/model/BipMessage.java
+++ b/svc-bip-api/src/main/java/gov/va/vro/bip/model/BipMessage.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.ToString;
 import lombok.extern.jackson.Jacksonized;
 
 @Getter
@@ -12,6 +13,7 @@ import lombok.extern.jackson.Jacksonized;
 @Builder
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
+@ToString
 public class BipMessage {
   @JsonProperty("key")
   private final String key;

--- a/svc-bip-api/src/main/java/gov/va/vro/bip/service/BipApiProps.java
+++ b/svc-bip-api/src/main/java/gov/va/vro/bip/service/BipApiProps.java
@@ -8,7 +8,6 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
-import java.util.Calendar;
 import java.util.Date;
 import java.util.Objects;
 
@@ -63,14 +62,17 @@ public class BipApiProps {
    * @return Claims
    */
   public Claims toCommonJwtClaims(final String externalUserId, final String externalKey) {
-    Calendar cal = Calendar.getInstance();
-    cal.add(Calendar.MINUTE, 30);
-    Date expired = cal.getTime();
+    long currentTimeMillis = System.currentTimeMillis();
+
     ClaimsBuilder claimsBuilder =
         Jwts.claims()
             .add("applicationID", applicationId)
             .add("stationID", stationId)
-            .add("userID", claimClientId);
+            .add("userID", claimClientId)
+            .issuer(claimIssuer)
+            .subject("Claim")
+            .issuedAt(new Date(currentTimeMillis))
+            .expiration(new Date(currentTimeMillis + 3600000));
 
     if (Objects.nonNull(externalUserId)) {
       claimsBuilder.add("externalUserId", externalUserId);
@@ -78,9 +80,6 @@ public class BipApiProps {
     if (Objects.nonNull(externalKey)) {
       claimsBuilder.add("externalKey", externalKey);
     }
-
-    Date now = cal.getTime();
-    claimsBuilder.add("iat", now.getTime()).add("expires", expired.getTime());
 
     return claimsBuilder.build();
   }

--- a/svc-bip-api/src/main/java/gov/va/vro/bip/service/BipApiService.java
+++ b/svc-bip-api/src/main/java/gov/va/vro/bip/service/BipApiService.java
@@ -1,6 +1,7 @@
 package gov.va.vro.bip.service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import gov.va.vro.bip.model.BipMessage;
 import gov.va.vro.bip.model.BipPayloadResponse;
 import gov.va.vro.bip.model.cancel.CancelClaimRequest;
 import gov.va.vro.bip.model.cancel.CancelClaimResponse;
@@ -38,8 +39,9 @@ import org.springframework.web.client.RestTemplate;
 
 import java.nio.charset.StandardCharsets;
 import java.security.Key;
-import java.util.Date;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import javax.crypto.spec.SecretKeySpec;
@@ -198,7 +200,8 @@ public class BipApiService implements IBipApiService {
     try {
 
       HttpEntity<Object> httpEntity = new HttpEntity<>(requestBody, headers);
-      log.info("event=requestSent url={} method={}", url, method);
+      log.info(
+          "event=requestSent url={} method={} auth={}", url, method, headers.get("Authorization"));
       metricLogger.submitCount(
           METRICS_PREFIX,
           IMetricLoggerService.METRIC.REQUEST_START,
@@ -249,12 +252,25 @@ public class BipApiService implements IBipApiService {
               .statusMessage(HttpStatus.valueOf(bipResponse.getStatusCode().value()).name())
               .build();
     } catch (HttpStatusCodeException e) {
+
+      String errors;
+      try {
+        T response = mapper.readValue(e.getResponseBodyAsString(), expectedResponse);
+        List<BipMessage> messages =
+            new ArrayList<>(
+                response.getMessages() != null ? response.getMessages() : new ArrayList<>());
+        errors = messages.toString();
+      } catch (Exception ex) {
+        errors = ex.getMessage();
+      }
+
       log.info(
-          "event=responseReceived url={} method={} status={} statusMessage={}",
+          "event=responseReceived url={} method={} status={} statusMessage={} errors={}",
           url,
           method,
           e.getStatusCode(),
-          ((HttpStatus) e.getStatusCode()).name());
+          ((HttpStatus) e.getStatusCode()).name(),
+          errors);
       throw e;
     } catch (Exception e) {
       log.error(
@@ -308,25 +324,16 @@ public class BipApiService implements IBipApiService {
     bipHttpHeaders.setContentType(MediaType.APPLICATION_JSON);
 
     Claims claims = bipApiProps.toCommonJwtClaims(externalUserId, externalKey);
-    String issuer = bipApiProps.getClaimIssuer();
     String secret = bipApiProps.getClaimSecret();
 
     // Define the signing key
     byte[] signSecretBytes = secret.getBytes(StandardCharsets.UTF_8);
     Key signingKey = new SecretKeySpec(signSecretBytes, "HmacSHA256");
 
-    // Set the expiration as an example (e.g., 1 hour from now)
-    long currentTimeMillis = System.currentTimeMillis();
-    Date expiryDate = new Date(currentTimeMillis + 3600000);
-
     // Build the JWT
     String jwt =
         Jwts.builder()
             .claims(claims)
-            .issuer(issuer)
-            .subject("Claim")
-            .issuedAt(new Date(currentTimeMillis))
-            .expiration(expiryDate)
             .signWith(signingKey)
             .header()
             .add("alg", "HS256")


### PR DESCRIPTION
Still having issues with request to bip. Their team recommended removing the duplicate expiration field from the JWT Claims. 

[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
