### PR TITLE
3521 - revert 2.1 modification; add repair to docker runs

### DIFF
--- a/db-init/Dockerfile
+++ b/db-init/Dockerfile
@@ -15,6 +15,6 @@ COPY flyway.conf /flyway/conf
 
 RUN adduser --no-create-home --disabled-password tron
 USER tron
-CMD ["migrate", "-X" ]
+CMD ["repair", "migrate", "-X" ]
 
 HEALTHCHECK NONE

--- a/db-init/docker-entrypoint.sh
+++ b/db-init/docker-entrypoint.sh
@@ -7,4 +7,4 @@ until pg_isready -d $POSTGRES_DB -h $POSTGRES_URL -p 5432 -U $POSTGRES_FLYWAY_US
 done
 
 # Perform flyway migrations
-migrate -X
+repair && migrate -X

--- a/db-init/src/main/resources/database/migrations/V1.7.1_resolve_migration.sql
+++ b/db-init/src/main/resources/database/migrations/V1.7.1_resolve_migration.sql
@@ -1,0 +1,2 @@
+-- dummy migration to satisfy problematic 1.7 removal/2.1 conflict
+SELECT 1;

--- a/db-init/src/main/resources/database/migrations/V2.1__BIE_Contention_Event_Add_ActorUserId.sql
+++ b/db-init/src/main/resources/database/migrations/V2.1__BIE_Contention_Event_Add_ActorUserId.sql
@@ -1,2 +1,2 @@
 ALTER TABLE "bie_contention_event"
-ADD COLUMN IF NOT EXISTS "actor_user_id" VARCHAR(255) DEFAULT NULL;
+ADD COLUMN "actor_user_id" VARCHAR(255) DEFAULT NULL;


### PR DESCRIPTION
## What was the problem?
flyway repair needs to be run to resolve 1.7 migration issues.

Associated tickets or Slack threads:
- #3521



[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
