### PR TITLE
svc-bgs-api: Fixed bug causing delays in response to client. Add standard DD tags.

### DIFF
--- a/svc-bgs-api/src/Gemfile
+++ b/svc-bgs-api/src/Gemfile
@@ -9,6 +9,7 @@ gem 'activesupport', '~> 6.0'
 gem 'bgs_ext', git: 'https://github.com/department-of-veterans-affairs/bgs-ext.git', require: 'bgs'
 gem 'datadog_api_client', '>=2.23.0'
 gem 'rexml', '~> 3.3', '>= 3.3.6'
+gem 'async', '>= 2.17.0'
 
 group :development, :test do
   gem 'rspec'

--- a/svc-bgs-api/src/Gemfile.lock
+++ b/svc-bgs-api/src/Gemfile.lock
@@ -23,6 +23,10 @@ GEM
       gyoku (>= 0.4.0)
       nokogiri
     amq-protocol (2.3.2)
+    async (2.17.0)
+      console (~> 1.26)
+      fiber-annotation
+      io-event (~> 1.6, >= 1.6.5)
     base64 (0.2.0)
     bigdecimal (3.1.8)
     builder (3.3.0)
@@ -31,6 +35,10 @@ GEM
       sorted_set (~> 1, >= 1.0.2)
     cgi (0.3.6)
     concurrent-ruby (1.3.3)
+    console (1.27.0)
+      fiber-annotation
+      fiber-local (~> 1.1)
+      json
     csv (3.3.0)
     datadog_api_client (2.23.0)
       httparty (~> 0.20, >= 0.20.0)
@@ -38,6 +46,10 @@ GEM
       zeitwerk (~> 2.6, >= 2.6.0)
     date (3.3.4)
     diff-lcs (1.5.1)
+    fiber-annotation (0.2.0)
+    fiber-local (1.1.0)
+      fiber-storage
+    fiber-storage (1.0.0)
     gyoku (1.4.0)
       builder (>= 2.1.2)
       rexml (~> 3.0)
@@ -53,6 +65,8 @@ GEM
       rack (< 3)
     i18n (1.14.5)
       concurrent-ruby (~> 1.0)
+    io-event (1.6.5)
+    json (2.7.2)
     mail (2.8.1)
       mini_mime (>= 0.1.1)
       net-imap
@@ -128,6 +142,7 @@ PLATFORMS
 
 DEPENDENCIES
   activesupport (~> 6.0)
+  async (>= 2.17.0)
   bgs_ext!
   bunny (>= 2.13.0)
   cgi (~> 0.3.6)

--- a/svc-bgs-api/src/integrationTest/add_note_tests.rb
+++ b/svc-bgs-api/src/integrationTest/add_note_tests.rb
@@ -7,16 +7,20 @@ require_relative '../config/constants'
 
 # Constants used by integration tests
 ADD_NOTE_REPLY_QUEUE = "svc_bgs_api.add_note_response"
-ADD_NOTE_PAYLOAD = "{\\\"veteranNote\\\":\\\"test\\\",\\\"veteranParticipantId\\\":111}"
 CORRELATION_ID = "1234"
 
 
-def test_successful_add_note(ch)
+def test_successful_add_note_via_veteran(ch)
+    puts "test_successful_add_note_via_veteran"
     x = ch.direct(REQUESTS_EXCHANGE, EXCHANGE_PROPERTIES)
     r = ch.queue(ADD_NOTE_REPLY_QUEUE, { durable: true, auto_delete: true }).bind(x, :routing_key => ADD_NOTE_REPLY_QUEUE)
 
     q = ch.queue(ADD_NOTE_QUEUE, ADD_NOTE_QUEUE_PROPERTIES)
-    q.publish(ADD_NOTE_PAYLOAD, :reply_to => ADD_NOTE_REPLY_QUEUE, :delivery_mode => 1, :correlation_id => CORRELATION_ID, :payload_encoding => "string")
+    q.publish("{\"veteranNote\":\"test\",\"veteranParticipantId\":111}",
+              :reply_to => ADD_NOTE_REPLY_QUEUE,
+              :delivery_mode => 1,
+              :correlation_id => CORRELATION_ID,
+              :payload_encoding => "string")
 
     delivery_info, properties, payload = r.pop
     while properties == nil
@@ -26,10 +30,27 @@ def test_successful_add_note(ch)
     # Validate response from the add-note message processing
     response_correlation_id = properties.correlation_id
 
-    puts "Checking correlation_id..."
-    puts "correlation_id: #{response_correlation_id}"
+    raise "Unexpected correlation_id: Expected #{CORRELATION_ID}. Found #{response_correlation_id} " if response_correlation_id != CORRELATION_ID
+end
 
-    if response_correlation_id != CORRELATION_ID then
-        raise "Unexpected correlation_id: Expected #{CORRELATION_ID}. Found #{response_correlation_id} "
+def test_successful_add_note_via_claim(ch)
+    puts "test_successful_add_note_via_claim"
+    x = ch.direct(REQUESTS_EXCHANGE, EXCHANGE_PROPERTIES)
+    r = ch.queue(ADD_NOTE_REPLY_QUEUE, { durable: true, auto_delete: true }).bind(x, :routing_key => ADD_NOTE_REPLY_QUEUE)
+
+    q = ch.queue(ADD_NOTE_QUEUE, ADD_NOTE_QUEUE_PROPERTIES)
+    q.publish("{\"vbms_claim_id\":1234,\"claim_notes\":[\"testNote\"]}",
+              :reply_to => ADD_NOTE_REPLY_QUEUE,
+              :delivery_mode => 1,
+              :correlation_id => CORRELATION_ID,
+              :payload_encoding => "string")
+    delivery_info, properties, payload = r.pop
+    while properties == nil
+        delivery_info, properties, payload = r.pop
     end
+
+    # Validate response from the add-note message processing
+    response_correlation_id = properties.correlation_id
+
+    raise "Unexpected correlation_id: Expected #{CORRELATION_ID}. Found #{response_correlation_id} " if response_correlation_id != CORRELATION_ID
 end

--- a/svc-bgs-api/src/integrationTest/run_integration_tests.rb
+++ b/svc-bgs-api/src/integrationTest/run_integration_tests.rb
@@ -5,6 +5,9 @@ require_relative 'before_integration_test'
 require_relative 'add_note_tests'
 
 ch = before_integration_test()
-test_successful_add_note(ch)
 
-puts "svc-bgs-api integration tests completed"
+puts "Running svc-bgs-api integration tests"
+test_successful_add_note_via_veteran(ch)
+test_successful_add_note_via_claim(ch)
+
+puts "All tests passed"

--- a/svc-bgs-api/src/lib/bgs_client.rb
+++ b/svc-bgs-api/src/lib/bgs_client.rb
@@ -37,11 +37,10 @@ BGS::DevelopmentNotesService.class_eval do
 end
 
 class BgsClient
-  attr_reader :bgs, :metrics
+  attr_reader :bgs
 
   def initialize
     @bgs = BGS::Services.new(external_uid: nil, external_key: nil)
-    @metrics = MetricLogger.new
   end
 
   def handle_request(req)
@@ -77,26 +76,11 @@ class BgsClient
     note_hashes = notes.map do |note|
       { claim_id:, txt: note, user_id: vro_participant_id }
     end
-    start_time = Time.now
-    metric_custom_tags = ['bgsNoteType:claim']
-    @metrics.submit_count_with_default_value(METRIC[:REQUEST_START], metric_custom_tags)
-    response = bgs.notes.create_notes(note_hashes)
-    @metrics.submit_request_duration(start_time, Time.now, metric_custom_tags)
-    @metrics.submit_count_with_default_value(METRIC[:RESPONSE_COMPLETE], metric_custom_tags)
-
-    response
+    bgs.notes.create_notes(note_hashes)
   end
 
   def create_veteran_note(note:, claim_id: nil, participant_id: nil)
     participant_id ||= bgs.benefit_claims.find_bnft_claim(claim_id:)[:bnft_claim_dto][:ptcpnt_vet_id]
-
-    start_time = Time.now
-    metric_custom_tags = ['bgsNoteType:veteran']
-    @metrics.submit_count_with_default_value(METRIC[:REQUEST_START], metric_custom_tags)
-    response = bgs.notes.create_note(participant_id:, txt: note, user_id: vro_participant_id)
-    @metrics.submit_request_duration(start_time, Time.now, metric_custom_tags)
-    @metrics.submit_count_with_default_value(METRIC[:RESPONSE_COMPLETE], metric_custom_tags)
-
-    response
+    bgs.notes.create_note(participant_id:, txt: note, user_id: vro_participant_id)
   end
 end

--- a/svc-bgs-api/src/lib/metric_logger.rb
+++ b/svc-bgs-api/src/lib/metric_logger.rb
@@ -1,20 +1,26 @@
 require 'datadog_api_client'
 require 'logger'
 require 'time'
+require 'async'
 
 require_relative '../config/setup'
 
 APP_PREFIX = 'vro_bgs'
 
-ENV_TAG = 'environment:' + ENVIRONMENT
-SERVICE_TAG = 'service:vro-svc-bgs-api'
-STANDARD_TAGS = [ENV_TAG, SERVICE_TAG]
+STANDARD_TAGS = [
+  'env:' + ENVIRONMENT,
+  'team:va-abd-rrd',
+  'itportfolio:benefits-delivery',
+  'service:vro-svc-bgs-api',
+  'dependency:bgs'
+]
 
 METRIC = {
   REQUEST_START: :REQUEST_START,
   REQUEST_DURATION: :REQUEST_DURATION,
   RESPONSE_COMPLETE: :RESPONSE_COMPLETE,
-  RESPONSE_ERROR: :RESPONSE_ERROR
+  RESPONSE_ERROR: :RESPONSE_ERROR,
+  ERROR_DURATION: :ERROR_DURATION
 }
 
 class MetricLogger
@@ -31,7 +37,7 @@ class MetricLogger
       api_instance = DatadogAPIClient::V1::AuthenticationAPI.new
       api_instance.validate
     rescue Exception => e
-      $logger.warn("Failed Datadog authentication check: #{e.message}")
+      $logger.warn("event=failedDatadogAuthentication error=#{e.message}")
     end
   end
 
@@ -49,19 +55,19 @@ class MetricLogger
     tags
   end
 
-  def get_metric_payload(_metric, _value, _custom_tags)
+  def get_metric_payload(metric, value, timestamp, custom_tags)
     DatadogAPIClient::V2::MetricPayload.new({
       series: [
         DatadogAPIClient::V2::MetricSeries.new({
-             metric: get_full_metric_name(_metric),
+             metric: metric,
              type: DatadogAPIClient::V2::MetricIntakeType::COUNT,
              points: [
                DatadogAPIClient::V2::MetricPoint.new({
-                   timestamp: Time.now.to_i,
-                   value: _value
+                   timestamp: timestamp.to_i,
+                   value: value
                  })
              ],
-             tags: generate_tags(_custom_tags)
+             tags: generate_tags(custom_tags)
            })
       ]
     })
@@ -71,42 +77,46 @@ class MetricLogger
     "#{APP_PREFIX}.#{metric.to_s.downcase}"
   end
 
-  def submit_count(metric, value, custom_tags)
-    payload = get_metric_payload(metric, value, custom_tags)
+  def submit_count(metric, value, timestamp, custom_tags)
+    metric_name = get_full_metric_name(metric)
+    payload = get_metric_payload(metric_name, value, timestamp, custom_tags)
 
-    begin
-      @metrics_api.submit_metrics(payload)
-      $logger.info("submitted #{payload.series.first.metric}")
-    rescue Exception => e
-      $logger.warn("Error logging metric: #{metric} (count). Error: #{e.class}, Message: #{e.message}")
+    Async do |task|
+      task.async do
+        begin
+          @metrics_api.submit_metrics(payload)
+          $logger.debug("event=countMetricSubmitted metric=#{metric_name} type=COUNT")
+        rescue Exception => e
+          $logger.warn("event=countMetricFailed metric=#{metric_name} type=COUNT error=#{e.class} message='#{e.message}'")
+        end
+      end
     end
 
     nil
   end
 
-  def submit_count_with_default_value(metric, custom_tags = nil)
-    submit_count(metric, 1, custom_tags)
-  end
+  def submit_request_duration(metric, start_time, end_time, custom_tags)
+    metric_name = get_full_metric_name(metric)
 
-  def submit_request_duration(start_time, end_time, custom_tags = nil)
-    metric_full_name = get_full_metric_name(METRIC[:REQUEST_DURATION])
-
+    duration = end_time - start_time
     payload = generate_distribution_metric(
-      metric_full_name,
-      end_time - start_time,
+      metric_name,
+      duration,
       custom_tags
     )
 
-    begin
-      opts = {
-        content_encoding: DatadogAPIClient::V1::DistributionPointsContentEncoding::DEFLATE
-      }
-      @distribution_metrics_api.submit_distribution_points(payload, opts)
-      $logger.info("submitted #{payload.series.first.metric}")
-    rescue Exception => e
-      $logger.warn(
-        "exception submitting request duration  #{e.message}"
-      )
+    Async do |task|
+      task.async do
+        begin
+          opts = {
+            content_encoding: DatadogAPIClient::V1::DistributionPointsContentEncoding::DEFLATE
+          }
+          @distribution_metrics_api.submit_distribution_points(payload, opts)
+          $logger.debug("event=durationMetricSubmitted metric=#{metric_name} type=DISTRIBUTION duration=#{duration}")
+        rescue Exception => e
+          $logger.warn("event=durationMetricFailed metric=#{metric_name} type=DISTRIBUTION duration=#{duration} error=#{e.class} message='#{e.message}'")
+        end
+      end
     end
 
     nil
@@ -129,5 +139,17 @@ class MetricLogger
        })
       ]
     })
+  end
+
+  def submit_error(start_time, end_time, custom_tags)
+    submit_count(METRIC[:REQUEST_START], 1, start_time, custom_tags)
+    submit_count(METRIC[:RESPONSE_ERROR], 1, end_time, custom_tags)
+    submit_request_duration(METRIC[:ERROR_DURATION], start_time, end_time, custom_tags)
+  end
+
+  def submit_all_metrics(start_time, end_time, custom_tags)
+    submit_count(METRIC[:REQUEST_START], 1, start_time, custom_tags)
+    submit_count(METRIC[:RESPONSE_COMPLETE], 1, end_time, custom_tags)
+    submit_request_duration(METRIC[:REQUEST_DURATION], start_time, end_time, custom_tags)
   end
 end

--- a/svc-bgs-api/src/spec/bgs_client_spec.rb
+++ b/svc-bgs-api/src/spec/bgs_client_spec.rb
@@ -2,14 +2,9 @@ require "bgs_client"
 
 describe BgsClient do
   let(:client) { BgsClient.new }
-  let(:metrics) { double("metrics") }
   let(:notes_service) { double("notes_service") }
 
   before do
-    allow(MetricLogger).to receive(:new).and_return(metrics)
-    allow(metrics).to receive(:submit_count_with_default_value).and_return(202)
-    allow(metrics).to receive(:submit_request_duration).and_return(202)
-
     allow(BGS::Services).to receive(:new).and_return(double("bgs_services", notes: notes_service))
     allow(client).to receive(:vro_participant_id).and_return("12345")
   end

--- a/svc-bgs-api/src/spec/metric_logger_spec.rb
+++ b/svc-bgs-api/src/spec/metric_logger_spec.rb
@@ -5,6 +5,7 @@ describe MetricLogger do
   let(:api_instance) { double("api_instance") }
   let(:metrics) { double("metrics") }
   let(:distributions) { double("distributions") }
+  let(:expected_tags) { STANDARD_TAGS }
 
   before do
     allow(DatadogAPIClient::V1::AuthenticationAPI).to receive(:new).and_return(api_instance)
@@ -15,13 +16,14 @@ describe MetricLogger do
 
   it 'generates standard tags when no custom tags are specified' do
     tags = client.generate_tags
-    expect(tags).to eq(['environment:local', 'service:vro-svc-bgs-api'])
+    expect(tags).to include(*expected_tags)
   end
 
   it 'adds custom tags to the standard tags' do
     custom_tags = ['color:green', 'animal:frog']
     tags = client.generate_tags(custom_tags)
-    expect(tags).to match_array(['color:green', 'animal:frog', 'environment:local', 'service:vro-svc-bgs-api'])
+    expect(tags).to include(*['color:green', 'animal:frog'])
+    expect(tags).to include(*expected_tags)
   end
 
   it 'generates the full metric name with app prefix and lowercase' do
@@ -37,29 +39,31 @@ describe MetricLogger do
   it 'generates a metric intake payload' do
     # value of MetricIntakeType.COUNT is 1
     # ref: https://github.com/DataDog/datadog-api-client-ruby/blob/4b3bf85/lib/datadog_api_client/v2/models/metric_intake_type.rb#L24
-    timestamp_before_getting_payload = Time.now.to_i
-    payload = client.get_metric_payload('cats', 42, ['sunny:true', 'humid:false'])
+    time = Time.now
+    payload = client.get_metric_payload('cats', 42, time, ['sunny:true', 'humid:false'])
     expect(payload.series.length).to eq(1)
     expect(payload.series[0].type).to eq(1)
-    expect(payload.series[0].metric).to eq('vro_bgs.cats')
-    expect(payload.series[0].tags).to match_array(['sunny:true', 'humid:false', 'environment:local',
-                                                   'service:vro-svc-bgs-api'])
+    expect(payload.series[0].metric).to eq('cats')
+    expect(payload.series[0].tags).to include(*['sunny:true', 'humid:false'])
+    expect(payload.series[0].tags).to include(*expected_tags)
     expect(payload.series[0].points.length).to eq(1)
-    expect(payload.series[0].points[0].timestamp).to be_between(timestamp_before_getting_payload, Time.now.to_i)
     expect(payload.series[0].points[0].value).to eq(42)
+    expect(payload.series[0].points[0].timestamp).to eq(time.to_i)
   end
 
   it 'generates a metric intake payload when no custom tags are defined' do
-    timestamp_before_getting_payload = Time.now.to_i
-    payload = client.get_metric_payload('dogs', 51, nil)
+    time = Time.now
+
+    payload = client.get_metric_payload('dogs', 51, time, nil)
 
     expect(payload.series.length).to eq(1)
     expect(payload.series[0].type).to eq(1)
-    expect(payload.series[0].metric).to eq('vro_bgs.dogs')
-    expect(payload.series[0].tags).to match_array(['environment:local', 'service:vro-svc-bgs-api'])
+    expect(payload.series[0].metric).to eq('dogs')
+    expect(payload.series[0].tags).to include(*expected_tags)
+    expect(payload.series[0].tags.count).to eq(expected_tags.count)
     expect(payload.series[0].points.length).to eq(1)
-    expect(payload.series[0].points[0].timestamp).to be_between(timestamp_before_getting_payload, Time.now.to_i)
     expect(payload.series[0].points[0].value).to eq(51)
+    expect(payload.series[0].points[0].timestamp).to eq(time.to_i)
   end
 
   it 'generates a distribution metric payload' do
@@ -68,8 +72,8 @@ describe MetricLogger do
 
     expect(payload.series.length).to eq(1)
     expect(payload.series[0].metric).to eq('vro_bgs.request_duration')
-    expect(payload.series[0].tags).to match_array(['dog.adoptions.ventura', 'environment:local',
-                                                   'service:vro-svc-bgs-api'])
+    expect(payload.series[0].tags).to include('dog.adoptions.ventura')
+    expect(payload.series[0].tags).to include(*expected_tags)
     expect(payload.series[0].points.length).to eq(1)
     expect(payload.series[0].points[0][0]).to be_between(timestamp_before_getting_payload, Time.now.to_i)
     expect(payload.series[0].points[0][1][0]).to eq(424)
@@ -81,7 +85,8 @@ describe MetricLogger do
 
     expect(payload.series.length).to eq(1)
     expect(payload.series[0].metric).to eq('vro_bgs.request_duration')
-    expect(payload.series[0].tags).to match_array(['environment:local', 'service:vro-svc-bgs-api'])
+    expect(payload.series[0].tags).to include(*expected_tags)
+    expect(payload.series[0].tags.count).to eq(expected_tags.count)
     expect(payload.series[0].points.length).to eq(1)
     expect(payload.series[0].points[0][0]).to be_between(timestamp_before_getting_payload, Time.now.to_i)
     expect(payload.series[0].points[0][1][0]).to eq(424)


### PR DESCRIPTION
## What was the problem?
<!-- brief description of how things worked before this PR -->
Datadog API requests are sent synchronously during the processing of a message from the queue to add claim notes. This can cause delays if there are issues with the connection to datadog. This also artificially inflates the duration metric for processing add note requests. 

Additionally, `svc-bgs-api` does not currently meet VA tagging standards as defined [here](https://depo-platform-documentation.scrollhelp.site/developer-docs/monitor-tagging-standards).

Associated tickets or Slack threads:
- #3536 
- #3529

## How does this fix it?[^1]
<!-- description of how things will work after this PR -->
Makes the calls async by using ruby gem `async` with a do block adding the calls to a task list to be run concurrently. This will ensure that the datadog calls do not affect the responses sent to the client. 

## How to test this PR
* Run rspec: `bundle exec rspec` from `svc-bgs-api/src` directory
* Run integration tests:
  1. Run platform with bgs
  2. Run `bundle exec ruby integrationTest/run_integration_test.rb` from `svc-bgs-api/src` directory

[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
