### PR TITLE
svc-bgs-api: Make datadog calls happen after response is sent to client.

### DIFF
--- a/.github/workflows/svc-bgs-api-integration-test.yml
+++ b/.github/workflows/svc-bgs-api-integration-test.yml
@@ -41,6 +41,8 @@ jobs:
           export -p | sed 's/declare -x //'
 
           ./gradlew :dockerComposeUp
+          ./gradlew -p mocks docker
+          ./gradlew -p mocks :dockerComposeUp
 
       - name: 'Wait for containers to start'
         run: sleep 60s
@@ -68,6 +70,20 @@ jobs:
         run: |
           ./gradlew :svc-bgs-api:bundleInstall
           ./gradlew :svc-bgs-api:integrationTest
+
+      - name: "Collect docker logs"
+        if: always()
+        uses: jwalton/gh-docker-logs@v2
+        with:
+          dest: './svc-bgs-api-container-logs'
+
+      - name: "Upload artifact"
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: svc-bgs-api-container-logs
+          path: ./svc-bgs-api-container-logs/**
+          retention-days: 14
 
       - name: 'Clean shutdown of all containers'
         if: always()

--- a/svc-bgs-api/src/integrationTest/add_note_tests.rb
+++ b/svc-bgs-api/src/integrationTest/add_note_tests.rb
@@ -11,7 +11,6 @@ CORRELATION_ID = "1234"
 
 
 def test_successful_add_note_via_veteran(ch)
-    puts "test_successful_add_note_via_veteran"
     x = ch.direct(REQUESTS_EXCHANGE, EXCHANGE_PROPERTIES)
     r = ch.queue(ADD_NOTE_REPLY_QUEUE, { durable: true, auto_delete: true }).bind(x, :routing_key => ADD_NOTE_REPLY_QUEUE)
 
@@ -32,12 +31,11 @@ def test_successful_add_note_via_veteran(ch)
     raise "Unexpected correlation_id: Expected #{CORRELATION_ID}. Found #{response_correlation_id} " if response_correlation_id != CORRELATION_ID
 
     payload = JSON.parse(payload)
-    raise "Unexpected response: Expected statusCode 200. Found #{payload['statusCode']}" if payload['statusCode'] != 200
+    raise "Unexpected response: Expected statusCode 200. Response #{payload}" if payload['statusCode'] != 200
 
 end
 
 def test_successful_add_note_via_claim(ch)
-    puts "test_successful_add_note_via_claim"
     x = ch.direct(REQUESTS_EXCHANGE, EXCHANGE_PROPERTIES)
     r = ch.queue(ADD_NOTE_REPLY_QUEUE, { durable: true, auto_delete: true }).bind(x, :routing_key => ADD_NOTE_REPLY_QUEUE)
 
@@ -57,5 +55,5 @@ def test_successful_add_note_via_claim(ch)
     raise "Unexpected correlation_id: Expected #{CORRELATION_ID}. Found #{response_correlation_id} " if response_correlation_id != CORRELATION_ID
 
     payload = JSON.parse(payload)
-    raise "Unexpected response: Expected statusCode 200. Found #{payload['statusCode']}" if payload['statusCode'] != 200
+    raise "Unexpected response: Expected statusCode 200. Response #{payload}" if payload['statusCode'] != 200
 end

--- a/svc-bgs-api/src/integrationTest/add_note_tests.rb
+++ b/svc-bgs-api/src/integrationTest/add_note_tests.rb
@@ -29,8 +29,11 @@ def test_successful_add_note_via_veteran(ch)
 
     # Validate response from the add-note message processing
     response_correlation_id = properties.correlation_id
-
     raise "Unexpected correlation_id: Expected #{CORRELATION_ID}. Found #{response_correlation_id} " if response_correlation_id != CORRELATION_ID
+
+    payload = JSON.parse(payload)
+    raise "Unexpected response: Expected statusCode 200. Found #{payload['statusCode']}" if payload['statusCode'] != 200
+
 end
 
 def test_successful_add_note_via_claim(ch)
@@ -39,7 +42,7 @@ def test_successful_add_note_via_claim(ch)
     r = ch.queue(ADD_NOTE_REPLY_QUEUE, { durable: true, auto_delete: true }).bind(x, :routing_key => ADD_NOTE_REPLY_QUEUE)
 
     q = ch.queue(ADD_NOTE_QUEUE, ADD_NOTE_QUEUE_PROPERTIES)
-    q.publish("{\"vbms_claim_id\":1234,\"claim_notes\":[\"testNote\"]}",
+    q.publish("{\"vbmsClaimId\":1234,\"claimNotes\":[\"testNote\"]}",
               :reply_to => ADD_NOTE_REPLY_QUEUE,
               :delivery_mode => 1,
               :correlation_id => CORRELATION_ID,
@@ -51,6 +54,8 @@ def test_successful_add_note_via_claim(ch)
 
     # Validate response from the add-note message processing
     response_correlation_id = properties.correlation_id
-
     raise "Unexpected correlation_id: Expected #{CORRELATION_ID}. Found #{response_correlation_id} " if response_correlation_id != CORRELATION_ID
+
+    payload = JSON.parse(payload)
+    raise "Unexpected response: Expected statusCode 200. Found #{payload['statusCode']}" if payload['statusCode'] != 200
 end

--- a/svc-bgs-api/src/integrationTest/run_integration_tests.rb
+++ b/svc-bgs-api/src/integrationTest/run_integration_tests.rb
@@ -6,8 +6,20 @@ require_relative 'add_note_tests'
 
 ch = before_integration_test()
 
-puts "Running svc-bgs-api integration tests"
-test_successful_add_note_via_veteran(ch)
-test_successful_add_note_via_claim(ch)
+puts "Running svc-bgs-api integration tests:"
 
-puts "All tests passed"
+begin
+  test_successful_add_note_via_veteran(ch)
+  puts "\ttest_successful_add_note_via_veteran PASSED"
+rescue => e
+  puts "\ttest_successful_add_note_via_veteran FAILED: #{e}"
+  raise e
+end
+
+begin
+  test_successful_add_note_via_claim(ch)
+  puts "\ttest_successful_add_note_via_claim PASSED"
+rescue => e
+  puts "\ttest_successful_add_note_via_claim FAILED: #{e}"
+  raise e
+end


### PR DESCRIPTION
## What was the problem?
<!-- brief description of how things worked before this PR -->
Datadog API requests are sent synchronously during the processing of a message from the queue to add claim notes. This can cause delays if there are issues with the connection to datadog. This also artificially inflates the duration metric for processing add note requests. 



Associated tickets or Slack threads:
- This is a follow-on to #3541 
- #3536 

## How does this fix it?[^1]
<!-- description of how things will work after this PR -->
Makes the calls async by using ruby gem `async` with a do block adding the calls to a task list to be run concurrently. This will ensure that the datadog calls do not affect the responses sent to the client. 

Previous PR #3541 did not solve this, as the publishing was still being affected by the datadog calls. This PR moves those async calls to the ensure block where the response is published to the client. 

## How to test this PR
* Run rspec: `bundle exec rspec` from `svc-bgs-api/src` directory
* Run integration tests:
  1. Run platform with bgs
  2. Run `bundle exec ruby integrationTest/run_integration_test.rb` from `svc-bgs-api/src` directory

[^1]: [Pull-Requests guidelines](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Pull-Requests). If PR is significant, update [Current Software State](https://github.com/department-of-veterans-affairs/abd-vro/wiki/Current-Software-State) wiki page.
[^secrel]: To check if a PR will succeed in the SecRel workflow, [test PRs in the SecRel pipeline](https://github.com/department-of-veterans-affairs/abd-vro-internal/wiki/Secure-Release-process#to-test-prs-in-the-secrel-pipeline).
