### PR TITLE
3528 add monitoring tags

### DIFF
--- a/shared/lib-metrics/src/main/java/gov/va/vro/metricslogging/IMetricLoggerService.java
+++ b/shared/lib-metrics/src/main/java/gov/va/vro/metricslogging/IMetricLoggerService.java
@@ -10,26 +10,17 @@ public interface IMetricLoggerService {
 
   ArrayList<String> getTagsForSubmission(String[] customTags);
 
-  MetricsPayload createMetricsPayload(
-      @NotNull String metricPrefix, @NotNull METRIC metric, double value, String[] tags);
+  MetricsPayload createMetricsPayload(@NotNull METRIC metric, double value, String[] tags);
 
-  void submitCount(@NotNull String metricPrefix, @NotNull METRIC metric, String[] tags);
+  void submitCount(@NotNull METRIC metric, String[] tags);
 
-  void submitCount(
-      @NotNull String metricPrefix, @NotNull METRIC metric, double value, String[] tags);
+  void submitCount(@NotNull METRIC metric, double value, String[] tags);
 
   DistributionPointsPayload createDistributionPointsPayload(
-      @NotNull String metricPrefix,
-      @NotNull METRIC metric,
-      double timestamp,
-      double value,
-      String[] tags);
+      @NotNull METRIC metric, double timestamp, double value, String[] tags);
 
   void submitRequestDuration(
-      @NotNull String metricPrefix,
-      long requestStartNanoseconds,
-      long requestEndNanoseconds,
-      String[] tags);
+      long requestStartNanoseconds, long requestEndNanoseconds, String[] tags);
 
   enum METRIC {
     REQUEST_START,

--- a/shared/lib-metrics/src/main/java/gov/va/vro/metricslogging/MetricLoggerService.java
+++ b/shared/lib-metrics/src/main/java/gov/va/vro/metricslogging/MetricLoggerService.java
@@ -5,6 +5,7 @@ import com.datadog.api.client.v1.model.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Service;
 
@@ -18,6 +19,21 @@ import java.util.*;
 public class MetricLoggerService implements IMetricLoggerService {
 
   private final MetricsApi metricsApi;
+
+  @Value("${vro.env}")
+  public final String env;
+
+  @Value("${vro.it-portfolio:benefits-delivery}")
+  public final String itPortfolio;
+
+  @Value("${vro.team:va-abd-rrd}")
+  public final String team;
+
+  @Value("${vro.app.name}")
+  public final String service;
+
+  @Value("${vro.app.dependency:")
+  public final String dependency;
 
   public static double getTimestamp() {
     return Long.valueOf(OffsetDateTime.now().toInstant().getEpochSecond()).doubleValue();
@@ -43,6 +59,15 @@ public class MetricLoggerService implements IMetricLoggerService {
     if (customTags != null) {
       tags.addAll(Arrays.asList(customTags));
     }
+
+    tags.add("env:" + env);
+    tags.add("itportfolio:" + itPortfolio);
+    tags.add("team:" + team);
+    tags.add("service:" + service);
+    if (dependency != null && !dependency.isEmpty()) {
+      tags.add("dependency:" + dependency);
+    }
+
     return tags;
   }
 

--- a/shared/lib-metrics/src/main/java/gov/va/vro/metricslogging/MetricLoggerService.java
+++ b/shared/lib-metrics/src/main/java/gov/va/vro/metricslogging/MetricLoggerService.java
@@ -5,6 +5,7 @@ import com.datadog.api.client.v1.model.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Service;
@@ -29,11 +30,14 @@ public class MetricLoggerService implements IMetricLoggerService {
   @Value("${vro.team:va-abd-rrd}")
   public final String team;
 
-  @Value("${vro.app.name}")
+  @Value("${vro.app.service}")
   public final String service;
 
-  @Value("${vro.app.dependency:")
-  public final String dependency;
+  @Value("${vro.app.dependencies:}")
+  public final Set<String> dependencies;
+
+  @Value("${vro.metric.prefix}")
+  public final String metricPrefix;
 
   public static double getTimestamp() {
     return Long.valueOf(OffsetDateTime.now().toInstant().getEpochSecond()).doubleValue();
@@ -55,7 +59,7 @@ public class MetricLoggerService implements IMetricLoggerService {
     // tags that will accompany the submitted data point(s).
     // a "key:value" format, while not required, can be convenient with querying metrics in the
     // datadog dashboard
-    ArrayList<String> tags = new ArrayList<>();
+    Set<String> tags = new HashSet<>();
     if (customTags != null) {
       tags.addAll(Arrays.asList(customTags));
     }
@@ -64,16 +68,19 @@ public class MetricLoggerService implements IMetricLoggerService {
     tags.add("itportfolio:" + itPortfolio);
     tags.add("team:" + team);
     tags.add("service:" + service);
-    if (dependency != null && !dependency.isEmpty()) {
-      tags.add("dependency:" + dependency);
+    if (dependencies != null && !dependencies.isEmpty()) {
+      for (String dep : dependencies) {
+        if (StringUtils.isNotEmpty(dep)) {
+          tags.add("dependency:" + dep);
+        }
+      }
     }
 
-    return tags;
+    return new ArrayList<>(tags);
   }
 
   @Override
-  public MetricsPayload createMetricsPayload(
-      @NotNull String metricPrefix, @NotNull METRIC metric, double value, String[] tags) {
+  public MetricsPayload createMetricsPayload(@NotNull METRIC metric, double value, String[] tags) {
     //  create the payload for a count metric
     Series dataPointSeries = new Series();
     dataPointSeries.setMetric(getFullMetricString(metricPrefix, metric));
@@ -85,14 +92,13 @@ public class MetricLoggerService implements IMetricLoggerService {
   }
 
   @Override
-  public void submitCount(@NotNull String metricPrefix, @NotNull METRIC metric, String[] tags) {
-    submitCount(metricPrefix, metric, 1.0, tags);
+  public void submitCount(@NotNull METRIC metric, String[] tags) {
+    submitCount(metric, 1.0, tags);
   }
 
   @Override
-  public void submitCount(
-      @NotNull String metricPrefix, @NotNull METRIC metric, double value, String[] tags) {
-    MetricsPayload payload = createMetricsPayload(metricPrefix, metric, value, tags);
+  public void submitCount(@NotNull METRIC metric, double value, String[] tags) {
+    MetricsPayload payload = createMetricsPayload(metric, value, tags);
 
     try {
       metricsApi
@@ -102,7 +108,7 @@ public class MetricLoggerService implements IMetricLoggerService {
                 if (ex != null) {
                   log.warn(String.format("exception submitting %s: %s", metric, ex.getMessage()));
                 } else {
-                  log.info(String.format("submitted %s: %s", metric, payloadAccepted.getStatus()));
+                  log.debug(String.format("submitted %s: %s", metric, payloadAccepted.getStatus()));
                 }
               });
     } catch (Exception e) {
@@ -112,11 +118,7 @@ public class MetricLoggerService implements IMetricLoggerService {
 
   @Override
   public DistributionPointsPayload createDistributionPointsPayload(
-      @NotNull String metricPrefix,
-      @NotNull METRIC metric,
-      double timestamp,
-      double value,
-      String[] tags) {
+      @NotNull METRIC metric, double timestamp, double value, String[] tags) {
     //  create the payload for a distribution metric
 
     DistributionPointsSeries dataPointSeries = new DistributionPointsSeries();
@@ -134,14 +136,10 @@ public class MetricLoggerService implements IMetricLoggerService {
 
   @Override
   public void submitRequestDuration(
-      @NotNull String metricPrefix,
-      long requestStartNanoseconds,
-      long requestEndNanoseconds,
-      String[] tags) {
+      long requestStartNanoseconds, long requestEndNanoseconds, String[] tags) {
 
     DistributionPointsPayload payload =
         createDistributionPointsPayload(
-            metricPrefix,
             METRIC.REQUEST_DURATION,
             getTimestamp(),
             getElapsedTimeInMilliseconds(requestStartNanoseconds, requestEndNanoseconds),
@@ -157,7 +155,7 @@ public class MetricLoggerService implements IMetricLoggerService {
                       String.format(
                           "exception submitting %s: %s", METRIC.REQUEST_DURATION, ex.getMessage()));
                 } else {
-                  log.info(
+                  log.debug(
                       String.format(
                           "submitted %s: %s",
                           METRIC.REQUEST_DURATION, payloadAccepted.getStatus()));

--- a/shared/lib-metrics/src/main/java/gov/va/vro/metricslogging/NoopMetricLoggerService.java
+++ b/shared/lib-metrics/src/main/java/gov/va/vro/metricslogging/NoopMetricLoggerService.java
@@ -2,7 +2,6 @@ package gov.va.vro.metricslogging;
 
 import com.datadog.api.client.v1.model.DistributionPointsPayload;
 import com.datadog.api.client.v1.model.MetricsPayload;
-import jakarta.validation.constraints.NotNull;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Service;
 
@@ -18,28 +17,23 @@ public class NoopMetricLoggerService implements IMetricLoggerService {
   }
 
   @Override
-  public MetricsPayload createMetricsPayload(
-      @NotNull String metricPrefix, METRIC metric, double value, String[] tags) {
+  public MetricsPayload createMetricsPayload(METRIC metric, double value, String[] tags) {
     return new MetricsPayload();
   }
 
   @Override
-  public void submitCount(@NotNull String metricPrefix, METRIC metric, String[] tags) {}
+  public void submitCount(METRIC metric, String[] tags) {}
 
   @Override
-  public void submitCount(
-      @NotNull String metricPrefix, METRIC metric, double value, String[] tags) {}
+  public void submitCount(METRIC metric, double value, String[] tags) {}
 
   @Override
   public DistributionPointsPayload createDistributionPointsPayload(
-      @NotNull String metricPrefix, METRIC metric, double timestamp, double value, String[] tags) {
+      METRIC metric, double timestamp, double value, String[] tags) {
     return new DistributionPointsPayload();
   }
 
   @Override
   public void submitRequestDuration(
-      @NotNull String metricPrefix,
-      long requestStartNanoseconds,
-      long requestEndNanoseconds,
-      String[] tags) {}
+      long requestStartNanoseconds, long requestEndNanoseconds, String[] tags) {}
 }

--- a/shared/lib-metrics/src/test/java/gov/va/vro/metricslogging/MetricLoggerServiceTest.java
+++ b/shared/lib-metrics/src/test/java/gov/va/vro/metricslogging/MetricLoggerServiceTest.java
@@ -17,13 +17,13 @@ import java.util.Objects;
 
 public class MetricLoggerServiceTest {
 
-  private MetricLoggerService mls = new MetricLoggerService(new MetricsApi());
+  private MetricLoggerService mls = new MetricLoggerService(new MetricsApi(), "", "", "", "", "");
   private static final String METRICS_PREFIX = "vro_short_app_name";
 
   @Test
   void testConstructors() {
     try {
-      new MetricLoggerService(new MetricsApi());
+      new MetricLoggerService(new MetricsApi(), "", "", "", "", "");
     } catch (Exception e) {
       fail("Constructor failed", e);
     }
@@ -63,13 +63,13 @@ public class MetricLoggerServiceTest {
         mls.getTagsForSubmission(new String[] {"source:integration-test", "version:2.1"});
     assertTrue(tags.contains("source:integration-test"));
     assertTrue(tags.contains("version:2.1"));
-    assertEquals(tags.size(), 2);
+    assertEquals(tags.size(), 6);
   }
 
   @Test
   void getTagsForSubmissionNoCustomTags() {
     List<String> tags = mls.getTagsForSubmission(null);
-    assertEquals(0, tags.size());
+    assertEquals(4, tags.size());
   }
 
   @Test
@@ -128,7 +128,7 @@ public class MetricLoggerServiceTest {
   @Test
   void testSubmitCountCallsApiWithPayload() {
     MetricsApi metricsApi = mock(MetricsApi.class);
-    MetricLoggerService mls = new MetricLoggerService(metricsApi);
+    MetricLoggerService mls = new MetricLoggerService(metricsApi, "", "", "", "", "");
     mls.submitCount(METRICS_PREFIX, IMetricLoggerService.METRIC.RESPONSE_COMPLETE, null);
     mls.submitCount(METRICS_PREFIX, IMetricLoggerService.METRIC.RESPONSE_COMPLETE, 3.0, null);
     try {
@@ -141,7 +141,7 @@ public class MetricLoggerServiceTest {
   @Test
   void testSubmitRequestDurationCallsApiWithPayload() {
     MetricsApi metricsApi = mock(MetricsApi.class);
-    MetricLoggerService mls = new MetricLoggerService(metricsApi);
+    MetricLoggerService mls = new MetricLoggerService(metricsApi, "", "", "", "", "");
     mls.submitRequestDuration("app_name_placeholder", 100, 200, null);
     try {
       verify(metricsApi, times(1))

--- a/shared/lib-metrics/src/test/java/gov/va/vro/metricslogging/MetricLoggerServiceTest.java
+++ b/shared/lib-metrics/src/test/java/gov/va/vro/metricslogging/MetricLoggerServiceTest.java
@@ -12,18 +12,29 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
 
 import java.time.OffsetDateTime;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 
 public class MetricLoggerServiceTest {
 
-  private MetricLoggerService mls = new MetricLoggerService(new MetricsApi(), "", "", "", "", "");
+  private MetricLoggerService mls =
+      new MetricLoggerService(
+          new MetricsApi(),
+          "env",
+          "benefits-delivery",
+          "va-abd-rrd",
+          "the-service",
+          Set.of("dep_1", "dep_2"),
+          METRICS_PREFIX);
   private static final String METRICS_PREFIX = "vro_short_app_name";
 
   @Test
   void testConstructors() {
     try {
-      new MetricLoggerService(new MetricsApi(), "", "", "", "", "");
+      new MetricLoggerService(
+          new MetricsApi(), "", "", "", "", Collections.emptySet(), METRICS_PREFIX);
     } catch (Exception e) {
       fail("Constructor failed", e);
     }
@@ -63,23 +74,46 @@ public class MetricLoggerServiceTest {
         mls.getTagsForSubmission(new String[] {"source:integration-test", "version:2.1"});
     assertTrue(tags.contains("source:integration-test"));
     assertTrue(tags.contains("version:2.1"));
-    assertEquals(tags.size(), 6);
+
+    // two tags above; 4 required tags + 2 dependency tags
+    assertEquals(tags.size(), 8);
+
+    List<String> requiredTags = List.of("env:", "team:", "itportfolio:", "service:", "dependency:");
+    for (String requiredTag : requiredTags) {
+      if (tags.stream().noneMatch(t -> t.startsWith(requiredTag))) {
+        fail("Required tag " + requiredTag + " not found in tags: " + tags);
+      }
+    }
   }
 
   @Test
   void getTagsForSubmissionNoCustomTags() {
     List<String> tags = mls.getTagsForSubmission(null);
-    assertEquals(4, tags.size());
+
+    // 4 required tags + 2 dependency tags
+    assertEquals(tags.size(), 6);
+
+    // check that all required tags are present
+    List<String> requiredTags = List.of("env:", "team:", "itportfolio:", "service:", "dependency:");
+    for (String requiredTag : requiredTags) {
+      if (tags.stream().noneMatch(t -> t.startsWith(requiredTag))) {
+        fail("Required tag " + requiredTag + " not found in tags: " + tags);
+      }
+    }
+
+    // check that no extra tags were added since we passed null above
+    for (String tag : tags) {
+      if (requiredTags.stream().noneMatch(t -> t.startsWith(tag.substring(0, t.indexOf(":"))))) {
+        fail("Unexpected tag: " + tag);
+      }
+    }
   }
 
   @Test
   void testCreateMetricsPayload() {
     MetricsPayload mp =
         mls.createMetricsPayload(
-            METRICS_PREFIX,
-            MetricLoggerService.METRIC.RESPONSE_COMPLETE,
-            14.0,
-            new String[] {"zone:purple"});
+            MetricLoggerService.METRIC.RESPONSE_COMPLETE, 14.0, new String[] {"zone:purple"});
     Assertions.assertEquals("count", mp.getSeries().get(0).getType());
     Assertions.assertEquals(1, mp.getSeries().size());
     Assertions.assertEquals(
@@ -108,7 +142,6 @@ public class MetricLoggerServiceTest {
 
     DistributionPointsPayload dpl =
         mls.createDistributionPointsPayload(
-            METRICS_PREFIX,
             MetricLoggerService.METRIC.REQUEST_DURATION,
             timestamp,
             1523,
@@ -128,9 +161,10 @@ public class MetricLoggerServiceTest {
   @Test
   void testSubmitCountCallsApiWithPayload() {
     MetricsApi metricsApi = mock(MetricsApi.class);
-    MetricLoggerService mls = new MetricLoggerService(metricsApi, "", "", "", "", "");
-    mls.submitCount(METRICS_PREFIX, IMetricLoggerService.METRIC.RESPONSE_COMPLETE, null);
-    mls.submitCount(METRICS_PREFIX, IMetricLoggerService.METRIC.RESPONSE_COMPLETE, 3.0, null);
+    MetricLoggerService mls =
+        new MetricLoggerService(metricsApi, "", "", "", "", Collections.emptySet(), METRICS_PREFIX);
+    mls.submitCount(IMetricLoggerService.METRIC.RESPONSE_COMPLETE, null);
+    mls.submitCount(IMetricLoggerService.METRIC.RESPONSE_COMPLETE, 3.0, null);
     try {
       verify(metricsApi, times(2)).submitMetricsAsync(ArgumentMatchers.any(MetricsPayload.class));
     } catch (Exception e) {
@@ -141,8 +175,9 @@ public class MetricLoggerServiceTest {
   @Test
   void testSubmitRequestDurationCallsApiWithPayload() {
     MetricsApi metricsApi = mock(MetricsApi.class);
-    MetricLoggerService mls = new MetricLoggerService(metricsApi, "", "", "", "", "");
-    mls.submitRequestDuration("app_name_placeholder", 100, 200, null);
+    MetricLoggerService mls =
+        new MetricLoggerService(metricsApi, "", "", "", "", Collections.emptySet(), METRICS_PREFIX);
+    mls.submitRequestDuration(100, 200, null);
     try {
       verify(metricsApi, times(1))
           .submitDistributionPointsAsync(ArgumentMatchers.any(DistributionPointsPayload.class));

--- a/svc-bie-kafka/src/main/resources/application.yaml
+++ b/svc-bie-kafka/src/main/resources/application.yaml
@@ -73,5 +73,7 @@ management:
 vro:
   env: ${ENV}
   app:
-    name: vro-svc-bie-kafka
-    dependency: bie
+    service: vro-svc-bie-kafka
+    dependencies: bie
+  metrics:
+    prefix: vro_bie_kafka

--- a/svc-bie-kafka/src/main/resources/application.yaml
+++ b/svc-bie-kafka/src/main/resources/application.yaml
@@ -69,3 +69,9 @@ management:
       group:
         liveness.include: livenessState
         readiness.include: readinessState
+
+vro:
+  env: ${ENV}
+  app:
+    name: vro-svc-bie-kafka
+    dependency: bie

--- a/svc-bip-api/src/main/java/gov/va/vro/bip/service/BipApiService.java
+++ b/svc-bip-api/src/main/java/gov/va/vro/bip/service/BipApiService.java
@@ -65,7 +65,6 @@ public class BipApiService implements IBipApiService {
   final ObjectMapper mapper;
 
   final IMetricLoggerService metricLogger;
-  public static final String METRICS_PREFIX = "vro_bip";
 
   static final String CLAIM_DETAILS = "/claims/%s";
   static final String CANCEL_CLAIM = "/claims/%s/cancel";
@@ -203,7 +202,6 @@ public class BipApiService implements IBipApiService {
       log.info(
           "event=requestSent url={} method={} auth={}", url, method, headers.get("Authorization"));
       metricLogger.submitCount(
-          METRICS_PREFIX,
           IMetricLoggerService.METRIC.REQUEST_START,
           new String[] {
             String.format("expectedResponse:%s", expectedResponse.getSimpleName()),
@@ -221,7 +219,6 @@ public class BipApiService implements IBipApiService {
           method,
           bipResponse.getStatusCode().value());
       metricLogger.submitRequestDuration(
-          METRICS_PREFIX,
           requestStartTime,
           System.nanoTime(),
           new String[] {
@@ -238,7 +235,6 @@ public class BipApiService implements IBipApiService {
       }
 
       metricLogger.submitCount(
-          METRICS_PREFIX,
           IMetricLoggerService.METRIC.RESPONSE_COMPLETE,
           new String[] {
             String.format("expectedResponse:%s", expectedResponse.getSimpleName()),
@@ -281,7 +277,6 @@ public class BipApiService implements IBipApiService {
           e.getMessage());
 
       metricLogger.submitCount(
-          METRICS_PREFIX,
           IMetricLoggerService.METRIC.RESPONSE_ERROR,
           new String[] {
             String.format("expectedResponse:%s", expectedResponse.getSimpleName()),

--- a/svc-bip-api/src/main/java/gov/va/vro/bip/service/BipRequestErrorHandler.java
+++ b/svc-bip-api/src/main/java/gov/va/vro/bip/service/BipRequestErrorHandler.java
@@ -67,7 +67,6 @@ public class BipRequestErrorHandler implements RabbitListenerErrorHandler {
       }
 
       metricLoggerService.submitCount(
-          BipApiService.METRICS_PREFIX,
           MetricLoggerService.METRIC.LISTENER_ERROR,
           new String[] {
             "event:statusCodeException",
@@ -98,7 +97,6 @@ public class BipRequestErrorHandler implements RabbitListenerErrorHandler {
                   .build());
 
       metricLoggerService.submitCount(
-          BipApiService.METRICS_PREFIX,
           MetricLoggerService.METRIC.LISTENER_ERROR,
           new String[] {
             "event:unexpectedError",

--- a/svc-bip-api/src/main/java/gov/va/vro/bip/service/InvalidPayloadRejectingFatalExceptionStrategy.java
+++ b/svc-bip-api/src/main/java/gov/va/vro/bip/service/InvalidPayloadRejectingFatalExceptionStrategy.java
@@ -32,7 +32,6 @@ public class InvalidPayloadRejectingFatalExceptionStrategy implements FatalExcep
           ((ListenerExecutionFailedException) t).getFailedMessage());
 
       metricLoggerService.submitCount(
-          BipApiService.METRICS_PREFIX,
           MetricLoggerService.METRIC.MESSAGE_CONVERSION_ERROR,
           new String[] {
             "event:fatalMessageConversionError",

--- a/svc-bip-api/src/main/resources/application.yaml
+++ b/svc-bip-api/src/main/resources/application.yaml
@@ -63,5 +63,7 @@ truststore_password: ${BIP_PASSWORD}
 vro:
   env: ${ENV}
   app:
-    name: vro-svc-bip-api
-    dependency: bip
+    service: vro-svc-bip-api
+    dependencies: bip-claims-api
+  metrics:
+    prefix: vro_bip

--- a/svc-bip-api/src/main/resources/application.yaml
+++ b/svc-bip-api/src/main/resources/application.yaml
@@ -59,3 +59,9 @@ management:
 truststore: ${BIP_TRUSTSTORE}
 keystore: ${BIP_KEYSTORE}
 truststore_password: ${BIP_PASSWORD}
+
+vro:
+  env: ${ENV}
+  app:
+    name: vro-svc-bip-api
+    dependency: bip

--- a/svc-bip-api/src/test/java/gov/va/vro/bip/config/RabbitMqApiConfigTest.java
+++ b/svc-bip-api/src/test/java/gov/va/vro/bip/config/RabbitMqApiConfigTest.java
@@ -16,7 +16,8 @@ import java.util.HashMap;
 
 class RabbitMqApiConfigTest {
 
-  private final MetricLoggerService metricLoggerService = new MetricLoggerService(new MetricsApi());
+  private final MetricLoggerService metricLoggerService =
+      new MetricLoggerService(new MetricsApi(), "", "", "", "", "");
 
   @Test
   @SuppressWarnings({"unchecked", "rawtypes"})

--- a/svc-bip-api/src/test/java/gov/va/vro/bip/config/RabbitMqApiConfigTest.java
+++ b/svc-bip-api/src/test/java/gov/va/vro/bip/config/RabbitMqApiConfigTest.java
@@ -12,12 +12,14 @@ import org.springframework.amqp.rabbit.listener.api.RabbitListenerErrorHandler;
 import org.springframework.amqp.rabbit.support.ListenerExecutionFailedException;
 import org.springframework.messaging.support.GenericMessage;
 
+import java.util.Collections;
 import java.util.HashMap;
 
 class RabbitMqApiConfigTest {
 
   private final MetricLoggerService metricLoggerService =
-      new MetricLoggerService(new MetricsApi(), "", "", "", "", "");
+      new MetricLoggerService(
+          new MetricsApi(), "", "", "", "", Collections.emptySet(), "metric_prefix");
 
   @Test
   @SuppressWarnings({"unchecked", "rawtypes"})

--- a/svc-bip-api/src/test/java/gov/va/vro/bip/service/BipApiServiceTest.java
+++ b/svc-bip-api/src/test/java/gov/va/vro/bip/service/BipApiServiceTest.java
@@ -597,7 +597,6 @@ public class BipApiServiceTest {
     assertResponseIsSuccess(result, HttpStatus.OK);
     verify(metricLoggerService, times(1))
         .submitCount(
-            "vro_bip",
             IMetricLoggerService.METRIC.REQUEST_START,
             new String[] {
               "expectedResponse:PutTempStationOfJurisdictionResponse",
@@ -606,13 +605,9 @@ public class BipApiServiceTest {
             });
     verify(metricLoggerService, times(1))
         .submitRequestDuration(
-            ArgumentMatchers.anyString(),
-            ArgumentMatchers.anyLong(),
-            ArgumentMatchers.anyLong(),
-            ArgumentMatchers.any());
+            ArgumentMatchers.anyLong(), ArgumentMatchers.anyLong(), ArgumentMatchers.any());
     verify(metricLoggerService, times(1))
         .submitCount(
-            "vro_bip",
             IMetricLoggerService.METRIC.RESPONSE_COMPLETE,
             new String[] {
               "expectedResponse:PutTempStationOfJurisdictionResponse",
@@ -630,13 +625,9 @@ public class BipApiServiceTest {
 
   private void verifyMetricsAreLogged() {
     verify(metricLoggerService, times(2))
-        .submitCount(
-            ArgumentMatchers.anyString(),
-            ArgumentMatchers.any(),
-            ArgumentMatchers.any(String[].class));
+        .submitCount(ArgumentMatchers.any(), ArgumentMatchers.any(String[].class));
     verify(metricLoggerService, times(1))
         .submitRequestDuration(
-            ArgumentMatchers.anyString(),
             ArgumentMatchers.anyLong(),
             ArgumentMatchers.anyLong(),
             ArgumentMatchers.any(String[].class));
@@ -644,10 +635,7 @@ public class BipApiServiceTest {
 
   private void verifyMetricIsLoggedForExceptions(TestCase testCase) {
     verify(metricLoggerService, times(testCase == TestCase.BIP_INTERNAL ? 2 : 1))
-        .submitCount(
-            ArgumentMatchers.anyString(),
-            ArgumentMatchers.any(),
-            ArgumentMatchers.any(String[].class));
+        .submitCount(ArgumentMatchers.any(), ArgumentMatchers.any(String[].class));
   }
 
   private void assertResponseExceptionWithStatus(Exception ex, HttpStatus expected)

--- a/svc-bip-api/src/test/java/gov/va/vro/bip/service/BipRequestErrorHandlerTest.java
+++ b/svc-bip-api/src/test/java/gov/va/vro/bip/service/BipRequestErrorHandlerTest.java
@@ -29,7 +29,8 @@ import java.util.Objects;
 class BipRequestErrorHandlerTest {
   private static final String CLAIM_RESPONSE_404 = "bip-test-data/claim_response_404.json";
 
-  private final MetricLoggerService metricLoggerService = new MetricLoggerService(new MetricsApi());
+  private final MetricLoggerService metricLoggerService =
+      new MetricLoggerService(new MetricsApi(), "", "", "", "", "");
 
   enum HttpStatusCodeTestCase {
     NOT_FOUND(new HttpClientErrorException(HttpStatus.NOT_FOUND)),

--- a/svc-bip-api/src/test/java/gov/va/vro/bip/service/BipRequestErrorHandlerTest.java
+++ b/svc-bip-api/src/test/java/gov/va/vro/bip/service/BipRequestErrorHandlerTest.java
@@ -24,13 +24,14 @@ import org.springframework.web.client.HttpStatusCodeException;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Collections;
 import java.util.Objects;
 
 class BipRequestErrorHandlerTest {
   private static final String CLAIM_RESPONSE_404 = "bip-test-data/claim_response_404.json";
 
   private final MetricLoggerService metricLoggerService =
-      new MetricLoggerService(new MetricsApi(), "", "", "", "", "");
+      new MetricLoggerService(new MetricsApi(), "", "", "", "", Collections.emptySet(), "vro_bip");
 
   enum HttpStatusCodeTestCase {
     NOT_FOUND(new HttpClientErrorException(HttpStatus.NOT_FOUND)),


### PR DESCRIPTION
<!-- Ensure the PR title reflects the feature or bug name -->

## What was the problem?
Monitoring tags are required by the VA but not present on metrics.

Associated tickets or Slack threads:
- #3528 

## How does this fix it?[^1]
`MetricLoggerService` now includes all required tags with values populated by properties defined in `application.yaml`.
