### PR TITLE
Upgrade Secrel to V6

### DIFF
--- a/.github/workflows/publish-3rd-party-image.yml
+++ b/.github/workflows/publish-3rd-party-image.yml
@@ -64,7 +64,7 @@ jobs:
   secrel:
     name: SecRel Pipeline
     needs: publish-image
-    uses: department-of-veterans-affairs/lighthouse-tornado-secrel-pipeline/.github/workflows/pipeline.yml@v4
+    uses: department-of-veterans-affairs/lighthouse-tornado-secrel-pipeline/.github/workflows/pipeline.yml@v6
     with:
       config-file: .github/secrel/config.yml
       images: ${{ needs.publish-image.outputs.published-images }}

--- a/.github/workflows/secrel.yml
+++ b/.github/workflows/secrel.yml
@@ -230,7 +230,7 @@ jobs:
     needs: [secrel-inputs, gate-check]
     if: ${{always() && needs.gate-check.outputs.run-secrel == 'true'}}
     secrets: inherit
-    uses: department-of-veterans-affairs/lighthouse-tornado-secrel-pipeline/.github/workflows/pipeline.yml@v5
+    uses: department-of-veterans-affairs/lighthouse-tornado-secrel-pipeline/.github/workflows/pipeline.yml@v6
     with:
       config-file: .github/secrel/config.yml
       images: ${{ needs.secrel-inputs.outputs.vro-images }}


### PR DESCRIPTION
## What was the problem?
Secrel V5 is being decommissioned October 9th, so we need to upgrade to V6 by EOD today to prevent disruption. 

Associated tickets or Slack threads:
- #3577 

