### PR TITLE
Modified the jwt applicationId claim to have correct value. 

### DIFF
--- a/.github/workflows/svc-bgs-api-integration-test.yml
+++ b/.github/workflows/svc-bgs-api-integration-test.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Setup Ruby'
-        uses: ruby/setup-ruby@v1.165.1
+        uses: ruby/setup-ruby@v1.196.0
         with:
           ruby-version: '3.3.0'
       - name: 'Checkout source code'

--- a/svc-bip-api/src/main/java/gov/va/vro/bip/service/BipApiService.java
+++ b/svc-bip-api/src/main/java/gov/va/vro/bip/service/BipApiService.java
@@ -199,8 +199,7 @@ public class BipApiService implements IBipApiService {
     try {
 
       HttpEntity<Object> httpEntity = new HttpEntity<>(requestBody, headers);
-      log.info(
-          "event=requestSent url={} method={} auth={}", url, method, headers.get("Authorization"));
+      log.info("event=requestSent url={} method={}", url, method);
       metricLogger.submitCount(
           IMetricLoggerService.METRIC.REQUEST_START,
           new String[] {

--- a/svc-bip-api/src/main/resources/application.yaml
+++ b/svc-bip-api/src/main/resources/application.yaml
@@ -14,7 +14,7 @@ bip:
   claimSecret: ${BIP_CLAIM_SECRET:7zEJ+xepTPakl7KfX58bVR+t0zQGpsElg9bDdKmoVJM=}
   evidenceClientId: ${BIP_EVIDENCE_USERID:VRO_USER}
   evidenceSecret: ${BIP_EVIDENCE_SECRET:daSecret}
-  applicationId: ${BIP_APPLICATION_ID:VRO}
+  applicationId: ${BIP_APPLICATION_ID:virtual_regional_office}
   stationId: ${BIP_STATION_ID:456}
   env: local
 


### PR DESCRIPTION
<!-- Ensure the PR title reflects the feature or bug name -->

## What was the problem?
<!-- brief description of how things worked before this PR -->
We are still not formatting our JWT with the correct values for certain claims. I confirmed with Nathan Jolly the correct values to use in the template below: 
```
{
    "iss": "(Send your issuer value here)",
    "iat": 1727361917,
    "exp": 1727365517,
    "applicationID": "(Send your issuer value here)",
    "stationID": "(Station Id for your user)",
    "userID": "(Id of system account)",
    "externalUserId": "(Id that can be used to identify the initiating user, must be less than 50 characters)",
    "externalKey": "(Key that can be used to identify the initiating user, must be less than 50 characters)",
}
```

Associated tickets or Slack threads:
- https://github.com/department-of-veterans-affairs/abd-vro/issues/3583

## How does this fix it?[^1]
<!-- description of how things will work after this PR -->
uses the correct value for the JWT `iss` claim. 